### PR TITLE
fix: correct gosec G107 nolint placement and gocritic deferInLoop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,21 +5,21 @@ repos:
       - id: go-build
         name: go build
         language: system
-        entry: bash -c 'PKG_CONFIG_PATH=./pkg-config go build ./...'
+        entry: bash -c 'PKG_CONFIG_PATH="$(pwd)/pkg-config" go build ./...'
         types: [go]
         pass_filenames: false
 
       - id: go-vet
         name: go vet
         language: system
-        entry: bash -c 'PKG_CONFIG_PATH=./pkg-config go vet ./...'
+        entry: bash -c 'PKG_CONFIG_PATH="$(pwd)/pkg-config" go vet ./...'
         types: [go]
         pass_filenames: false
 
       - id: go-test
         name: go test
         language: system
-        entry: bash -c 'PKG_CONFIG_PATH=./pkg-config go test ./...'
+        entry: bash -c 'PKG_CONFIG_PATH="$(pwd)/pkg-config" go test ./...'
         types: [go]
         pass_filenames: false
 

--- a/internal/lyrics/lrclib.go
+++ b/internal/lyrics/lrclib.go
@@ -53,7 +53,7 @@ func (c *Client) Fetch(ctx context.Context, artist, title, album string, duratio
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil) //nolint:gosec // G107: URL is constructed from a parsed constant base with safe query params
 	if err != nil {
 		return nil, err
 	}

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -142,7 +142,7 @@ func extractDeb(debPath, destDir string) error {
 				return fmt.Errorf("create temp: %w", err)
 			}
 			tmpPath := tmp.Name()
-			defer os.Remove(tmpPath) //nolint:errcheck
+			defer os.Remove(tmpPath) //nolint:errcheck,gocritic // deferInLoop: function always returns before next iteration
 
 			if _, err := io.CopyN(tmp, f, size); err != nil {
 				_ = tmp.Close()

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -84,7 +84,7 @@ func (a *AppleProvider) IsAuthenticated() bool {
 }
 
 func (a *AppleProvider) newRequest(ctx context.Context, method, endpoint string) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, method, a.baseURL+endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, method, a.baseURL+endpoint, nil) //nolint:gosec // G107: URL is constructed from config, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (a *AppleProvider) newRequest(ctx context.Context, method, endpoint string)
 // unlike the standard API it returns extendedAssetUrls in search responses,
 // which lets us reliably detect purchase-only / region-locked tracks.
 func (a *AppleProvider) newCatalogRequest(ctx context.Context, method, endpoint string) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, method, a.catalogBaseURL+endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, method, a.catalogBaseURL+endpoint, nil) //nolint:gosec // G107: URL is constructed from config, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +603,7 @@ func (a *AppleProvider) CreatePlaylist(ctx context.Context, name string, trackID
 		return provider.Playlist{}, fmt.Errorf("CreatePlaylist: marshal: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/me/library/playlists", bytes.NewReader(raw))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/me/library/playlists", bytes.NewReader(raw)) //nolint:gosec // G107: URL is constructed from config, not user input
 	if err != nil {
 		return provider.Playlist{}, err
 	}
@@ -639,7 +639,7 @@ func (a *AppleProvider) LoveSong(ctx context.Context, catalogID string, loved bo
 	// Add to library first (idempotent — safe to call even if already in library).
 	if loved {
 		libURL := fmt.Sprintf("%s/me/library?ids[songs]=%s", a.baseURL, url.QueryEscape(catalogID))
-		addReq, err := http.NewRequestWithContext(ctx, http.MethodPost, libURL, http.NoBody)
+		addReq, err := http.NewRequestWithContext(ctx, http.MethodPost, libURL, http.NoBody) //nolint:gosec // G107: URL is constructed from config, not user input
 		if err != nil {
 			return fmt.Errorf("LoveSong: add to library: %w", err)
 		}
@@ -655,7 +655,7 @@ func (a *AppleProvider) LoveSong(ctx context.Context, catalogID string, loved bo
 
 	if !loved {
 		// Remove rating (un-love).
-		delReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, ratingURL, http.NoBody)
+		delReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, ratingURL, http.NoBody) //nolint:gosec // G107: URL is constructed from config, not user input
 		if err != nil {
 			return fmt.Errorf("LoveSong: delete rating: %w", err)
 		}
@@ -672,7 +672,7 @@ func (a *AppleProvider) LoveSong(ctx context.Context, catalogID string, loved bo
 	if err != nil {
 		return fmt.Errorf("LoveSong: marshal: %w", err)
 	}
-	putReq, err := http.NewRequestWithContext(ctx, http.MethodPut, ratingURL, bytes.NewReader(raw))
+	putReq, err := http.NewRequestWithContext(ctx, http.MethodPut, ratingURL, bytes.NewReader(raw)) //nolint:gosec // G107: URL is constructed from config, not user input
 	if err != nil {
 		return fmt.Errorf("LoveSong: %w", err)
 	}
@@ -700,7 +700,7 @@ func (a *AppleProvider) GetSongRating(ctx context.Context, catalogID string) (bo
 		return false, fmt.Errorf("GetSongRating: %w", err)
 	}
 	// Use the raw client so we can distinguish 404 (not rated) from real errors.
-	resp, err := a.client.Do(req) //nolint:gosec
+	resp, err := a.client.Do(req) //nolint:gosec // G704: URL is constructed from config, not user input
 	if err != nil {
 		return false, fmt.Errorf("GetSongRating: http: %w", err)
 	}


### PR DESCRIPTION
- apple.go: the original //nolint:gosec on client.Do() correctly suppresses G704 (SSRF taint analysis), but all http.NewRequestWithContext calls with variable URLs were missing a //nolint:gosec // G107 annotation. Add the missing comments to newRequest, newCatalogRequest, CreatePlaylist, and LoveSong.
- lrclib.go: add missing //nolint:gosec // G107 to the http.NewRequestWithContext call in Fetch.
- browser.go: extend //nolint:errcheck to also cover gocritic on the defer inside a for-loop (deferInLoop); the function always returns before a second iteration so the defer is safe.