### PR TITLE
feat: Last.fm scrobbling support (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Last.fm scrobbling** — optionally connect your Last.fm account with
+  `vibez auth lastfm login` and vibez will scrobble your plays automatically.
+  Now Playing updates are sent when a track starts; a scrobble is submitted
+  once you've listened to at least half the track (or 4 minutes, whichever
+  comes first). Tracks under 30 seconds are ignored, pauses don't count.
+
 - **Search: albums and playlists** — the search popup (`/`) now returns all three
   result types in a unified scrollable list, grouped into **Tracks**, **Albums**,
   and **Playlists** sections. Each section only appears when the provider returns

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 # build-with-token embeds the Apple developer token without obfuscation.
 # Use this for local testing of the embedded-token flow.
 # Requires: APPLE_KEY_ID, APPLE_TEAM_ID, APPLE_PRIVATE_KEY
+# Optional: LASTFM_API_KEY, LASTFM_API_SECRET (embed Last.fm keys for testing)
 build-with-token:
 	@test -n "$$APPLE_KEY_ID"      || { echo "APPLE_KEY_ID is not set";      exit 1; }
 	@test -n "$$APPLE_TEAM_ID"     || { echo "APPLE_TEAM_ID is not set";     exit 1; }
@@ -17,27 +18,39 @@ build-with-token:
 	echo "Generating developer token..."; \
 	TOKEN=$$(GOFLAGS= go run ./scripts/gen-devtoken 2>/dev/null); \
 	test -n "$$TOKEN" || { echo "gen-devtoken produced no output — check credentials"; exit 1; }; \
+	LDFLAGS="-X 'github.com/simone-vibes/vibez/internal/auth.devToken=$$TOKEN'"; \
+	if [ -n "$$LASTFM_API_KEY" ] && [ -n "$$LASTFM_API_SECRET" ]; then \
+		LDFLAGS="$$LDFLAGS -X 'github.com/simone-vibes/vibez/internal/lastfm.apiKey=$$LASTFM_API_KEY'"; \
+		LDFLAGS="$$LDFLAGS -X 'github.com/simone-vibes/vibez/internal/lastfm.apiSecret=$$LASTFM_API_SECRET'"; \
+		echo "Embedding Last.fm API keys..."; \
+	fi; \
 	echo "Building with embedded token..."; \
 	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) go build \
-		-ldflags "-X 'github.com/simone-vibes/vibez/internal/auth.devToken=$$TOKEN'" \
+		-ldflags "$$LDFLAGS" \
 		-o vibez . && echo "Done. Run: vibez auth login"
 
 # release embeds the Apple developer token into the binary and obfuscates it
 # with garble so it does not appear in plaintext. Requires:
 #   APPLE_KEY_ID, APPLE_TEAM_ID, APPLE_PRIVATE_KEY (contents of the .p8 file)
-# Usage: make release APPLE_KEY_ID=... APPLE_TEAM_ID=... APPLE_PRIVATE_KEY="$(cat AuthKey.p8)"
+#   LASTFM_API_KEY, LASTFM_API_SECRET (from https://www.last.fm/api/account/create)
+# Usage: make release APPLE_KEY_ID=... APPLE_TEAM_ID=... APPLE_PRIVATE_KEY="$(cat AuthKey.p8)" \
+#                     LASTFM_API_KEY=... LASTFM_API_SECRET=...
 release:
 	@command -v garble >/dev/null 2>&1 || { echo "garble not found — install with: go install mvdan.cc/garble@latest"; exit 1; }
 	@test -n "$$APPLE_KEY_ID"      || { echo "APPLE_KEY_ID is not set";      exit 1; }
 	@test -n "$$APPLE_TEAM_ID"     || { echo "APPLE_TEAM_ID is not set";     exit 1; }
 	@test -n "$$APPLE_PRIVATE_KEY" || { echo "APPLE_PRIVATE_KEY is not set"; exit 1; }
+	@test -n "$$LASTFM_API_KEY"    || { echo "LASTFM_API_KEY is not set";    exit 1; }
+	@test -n "$$LASTFM_API_SECRET" || { echo "LASTFM_API_SECRET is not set"; exit 1; }
 	@set -e; \
 	echo "Generating developer token..."; \
 	TOKEN=$$(GOFLAGS= go run ./scripts/gen-devtoken 2>/dev/null); \
 	test -n "$$TOKEN" || { echo "gen-devtoken produced no output — check credentials"; exit 1; }; \
 	echo "Building obfuscated release binary..."; \
 	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) garble -literals build \
-		-ldflags "-X 'github.com/simone-vibes/vibez/internal/auth.devToken=$$TOKEN'" \
+		-ldflags "-X 'github.com/simone-vibes/vibez/internal/auth.devToken=$$TOKEN' \
+		          -X 'github.com/simone-vibes/vibez/internal/lastfm.apiKey=$$LASTFM_API_KEY' \
+		          -X 'github.com/simone-vibes/vibez/internal/lastfm.apiSecret=$$LASTFM_API_SECRET'" \
 		-o vibez . && echo "Done."
 
 run: build

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Full tracks stream via an embedded headless Chrome with Widevine DRM (auto-downl
 - **MPRIS D-Bus** — your desktop media keys (play, pause, next, previous) work out of the box
 - **Desktop notifications** — see the current track in your notification area
 - **No external player needed** — vibez is fully self-contained, no Cider, no VLC
+- **Last.fm scrobbling** — optional integration; connect with `vibez auth lastfm login` and your listening history is tracked automatically
 
 ### 🌀 Vibe Mode
 
@@ -120,12 +121,15 @@ make build-with-token   # requires APPLE_KEY_ID, APPLE_TEAM_ID, APPLE_PRIVATE_KE
 ## Usage
 
 ```bash
-vibez                   # launch the TUI
-vibez --demo            # try vibez with built-in fake tracks — no account needed
-vibez auth login        # open Apple ID login (Chrome window)
-vibez auth status       # check current auth state
-vibez auth logout       # clear saved tokens
-vibez version           # print version
+vibez                       # launch the TUI
+vibez --demo                # try vibez with built-in fake tracks — no account needed
+vibez auth login            # open Apple ID login (Chrome window)
+vibez auth status           # check current auth state
+vibez auth logout           # clear saved tokens
+vibez auth lastfm login     # connect your Last.fm account (optional)
+vibez auth lastfm status    # check Last.fm connection status
+vibez auth lastfm logout    # disconnect Last.fm
+vibez version               # print version
 ```
 
 ---
@@ -229,6 +233,7 @@ vibez/
 ├── internal/
 │   ├── config/             # Config file management
 │   ├── auth/               # MusicKit OAuth flow
+│   ├── lastfm/             # Last.fm scrobbling (optional)
 │   ├── provider/           # Provider interface + Apple Music implementation
 │   ├── player/
 │   │   ├── cdp/            # Chrome CDP player (Widevine, full tracks)
@@ -249,11 +254,11 @@ vibez/
 ## Roadmap
 
 - [x] Queue management (add, navigate, auto-advance)
+- [x] Last.fm scrobbling
 - [ ] **Spotify** provider
 - [ ] **YouTube Music** provider
 - [ ] LLM-powered vibe agent (OpenAI / Ollama)
 - [ ] Lyrics display
-- [ ] Last.fm scrobbling
 - [ ] Desktop notifications on track change
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,9 +51,7 @@ Full-track streaming via Tidal's API.
 
 ## Ideas / not yet scoped
 
-- **Last.fm scrobbling** — submit plays to Last.fm in the background
 - **mpd protocol bridge** — let `ncmpcpp` and other mpd clients control vibez
-- **Lyrics panel** — fetch and display synced lyrics in a side pane
 - **Keyboard macro recorder** — record and replay complex key sequences
 
 ---

--- a/cmd/lastfm.go
+++ b/cmd/lastfm.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/simone-vibes/vibez/internal/config"
+	"github.com/simone-vibes/vibez/internal/lastfm"
+	"github.com/spf13/cobra"
+)
+
+var lastfmCmd = &cobra.Command{
+	Use:   "lastfm",
+	Short: "Manage Last.fm scrobbling",
+}
+
+var lastfmLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Connect your Last.fm account to enable scrobbling",
+	Long: `Authenticate with Last.fm using the application credentials embedded in
+vibez. Your play history will be scrobbled automatically during playback.
+
+The session key is stored in ~/.config/vibez/config.json.
+If you built vibez from source without embedded keys, set lastfm_api_key and
+lastfm_api_secret in that file first (obtain them from https://www.last.fm/api/account/create).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		lastfm.ApplyEmbedded(cfg)
+
+		if cfg.LastfmAPIKey == "" || cfg.LastfmAPISecret == "" {
+			return fmt.Errorf(`last.fm API credentials are not available.
+
+If you built vibez from source, register an application at
+  https://www.last.fm/api/account/create
+and add to ~/.config/vibez/config.json:
+  "lastfm_api_key":    "<your API key>",
+  "lastfm_api_secret": "<your shared secret>"`)
+		}
+
+		client := lastfm.NewClient(cfg.LastfmAPIKey, cfg.LastfmAPISecret, "")
+
+		token, err := client.GetToken()
+		if err != nil {
+			return fmt.Errorf("requesting Last.fm token: %w", err)
+		}
+
+		authURL := client.AuthorizeURL(token)
+		fmt.Println("Connecting to Last.fm…")
+		_ = exec.Command("xdg-open", authURL).Start() //nolint:gosec // opens a known last.fm URL in the browser
+
+		fmt.Printf("\nIf your browser did not open, visit:\n  %s\n\n", authURL)
+		fmt.Print("Press Enter after you have granted access in your browser: ")
+		_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+
+		sessionKey, err := client.GetSession(token)
+		if err != nil {
+			return fmt.Errorf("getting Last.fm session: %w", err)
+		}
+
+		cfg.LastfmSessionKey = sessionKey
+		if err := cfg.Save(cfgFile); err != nil {
+			return fmt.Errorf("saving config: %w", err)
+		}
+		fmt.Println("✓ Last.fm connected! Vibez will scrobble your plays automatically.")
+		return nil
+	},
+}
+
+var lastfmLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Disconnect Last.fm and disable scrobbling",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		cfg.LastfmSessionKey = ""
+		if err := cfg.Save(cfgFile); err != nil {
+			return fmt.Errorf("saving config: %w", err)
+		}
+		fmt.Println("Last.fm disconnected. Scrobbling disabled.")
+		return nil
+	},
+}
+
+var lastfmStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show Last.fm connection status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		lastfm.ApplyEmbedded(cfg)
+
+		switch {
+		case cfg.LastfmAPIKey == "":
+			fmt.Println("Last.fm: not configured (no API key).")
+			fmt.Println("Run 'vibez auth lastfm login' to connect your account.")
+		case cfg.LastfmSessionKey == "":
+			fmt.Println("Last.fm: API credentials available, but not authenticated.")
+			fmt.Println("Run 'vibez auth lastfm login' to connect your account.")
+		default:
+			fmt.Println("Last.fm: connected. Scrobbling is enabled.")
+		}
+		return nil
+	},
+}
+
+func init() {
+	lastfmCmd.AddCommand(lastfmLoginCmd, lastfmLogoutCmd, lastfmStatusCmd)
+	authCmd.AddCommand(lastfmCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/simone-vibes/vibez/internal/assets"
 	"github.com/simone-vibes/vibez/internal/auth"
 	"github.com/simone-vibes/vibez/internal/config"
+	"github.com/simone-vibes/vibez/internal/lastfm"
 	"github.com/simone-vibes/vibez/internal/player/cdp"
 	demoPlayer "github.com/simone-vibes/vibez/internal/player/demo"
 	"github.com/simone-vibes/vibez/internal/player/mpris"
@@ -68,6 +69,7 @@ func runTUI(_ *cobra.Command, _ []string) error {
 	}
 
 	auth.ApplyEmbedded(cfg)
+	lastfm.ApplyEmbedded(cfg)
 
 	if cfg.AppleDeveloperToken == "" {
 		return fmt.Errorf("apple developer token not set.\n\nSet apple_developer_token in ~/.config/vibez/config.json\nor run: go run ./scripts/gen-devtoken")
@@ -188,6 +190,17 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 			}()
 		}
 
+		if cfg.LastfmAPIKey != "" && cfg.LastfmAPISecret != "" && cfg.LastfmSessionKey != "" {
+			lfmClient := lastfm.NewClient(cfg.LastfmAPIKey, cfg.LastfmAPISecret, cfg.LastfmSessionKey)
+			scrobbler := lastfm.NewScrobbler(lfmClient)
+			scrobbler.SetLogger(func(msg string) { prog.Send(tui.DebugLogMsg(msg)) })
+			go func() {
+				for st := range cdpPlayer.Subscribe() {
+					scrobbler.Update(st)
+				}
+			}()
+		}
+
 		prog.Send(tui.EngineReadyMsg{
 			Player:      cdpPlayer,
 			Provider:    apple.New(cfg),
@@ -256,6 +269,18 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 		opts.Backend = "WebKit/GStreamer · 30s preview · provider: Apple Music"
 		m := tui.New(cfg, prov, wkPlayer, opts)
 		p := tea.NewProgram(m, tea.WithAltScreen())
+
+		if cfg.LastfmAPIKey != "" && cfg.LastfmAPISecret != "" && cfg.LastfmSessionKey != "" {
+			lfmClient := lastfm.NewClient(cfg.LastfmAPIKey, cfg.LastfmAPISecret, cfg.LastfmSessionKey)
+			scrobbler := lastfm.NewScrobbler(lfmClient)
+			scrobbler.SetLogger(func(msg string) { p.Send(tui.DebugLogMsg(msg)) })
+			go func() {
+				for st := range wkPlayer.Subscribe() {
+					scrobbler.Update(st)
+				}
+			}()
+		}
+
 		_, runErr := p.Run()
 		tuiErr <- runErr
 		wkPlayer.Terminate()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,12 @@ type Config struct {
 	AuthPort            int    `json:"auth_port"`
 	Provider            string `json:"provider"`
 	Theme               string `json:"theme"`
+	// Last.fm scrobbling. LastfmAPIKey and LastfmAPISecret are typically
+	// embedded in the binary at build time via ldflags; set them manually here
+	// only when building from source without the embedded keys.
+	LastfmAPIKey     string `json:"lastfm_api_key,omitempty"`
+	LastfmAPISecret  string `json:"lastfm_api_secret,omitempty"`
+	LastfmSessionKey string `json:"lastfm_session_key,omitempty"`
 }
 
 func defaults() *Config {

--- a/internal/lastfm/appkeys.go
+++ b/internal/lastfm/appkeys.go
@@ -1,0 +1,28 @@
+package lastfm
+
+import "github.com/simone-vibes/vibez/internal/config"
+
+// apiKey and apiSecret are the Last.fm application credentials injected at
+// build time via -ldflags:
+//
+//	-X 'github.com/simone-vibes/vibez/internal/lastfm.apiKey=<key>'
+//	-X 'github.com/simone-vibes/vibez/internal/lastfm.apiSecret=<secret>'
+//
+// When empty the user must set lastfm_api_key and lastfm_api_secret in their
+// config file (useful for self-built binaries). garble -literals obfuscates
+// these strings in release builds so they do not appear in plaintext.
+var (
+	apiKey    string //nolint:gochecknoglobals // intentionally set via ldflags
+	apiSecret string //nolint:gochecknoglobals // intentionally set via ldflags
+)
+
+// ApplyEmbedded copies the build-time embedded Last.fm API key and secret into
+// cfg when they are present, taking priority over any values in the config file.
+func ApplyEmbedded(cfg *config.Config) {
+	if apiKey != "" {
+		cfg.LastfmAPIKey = apiKey
+	}
+	if apiSecret != "" {
+		cfg.LastfmAPISecret = apiSecret
+	}
+}

--- a/internal/lastfm/client.go
+++ b/internal/lastfm/client.go
@@ -1,0 +1,223 @@
+package lastfm
+
+import (
+	"crypto/md5" //nolint:gosec // Last.fm API requires MD5 for signatures; not used for security
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	apiBaseURL = "https://ws.audioscrobbler.com/2.0/"
+	authURL    = "https://www.last.fm/api/auth/"
+)
+
+// Client is a Last.fm API client. Create with NewClient.
+type Client struct {
+	apiKey     string
+	apiSecret  string
+	sessionKey string
+	http       *http.Client
+}
+
+// NewClient returns a Last.fm API client. sessionKey may be empty for
+// unauthenticated calls such as auth.getToken and auth.getSession.
+func NewClient(apiKey, apiSecret, sessionKey string) *Client {
+	return &Client{
+		apiKey:     apiKey,
+		apiSecret:  apiSecret,
+		sessionKey: sessionKey,
+		http:       &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// sign computes the Last.fm API signature for params.
+// "format" and "callback" are excluded from the signature per the Last.fm spec.
+func (c *Client) sign(params map[string]string) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		if k == "format" || k == "callback" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteString(params[k])
+	}
+	sb.WriteString(c.apiSecret)
+
+	//nolint:gosec // MD5 required by Last.fm API specification
+	h := md5.Sum([]byte(sb.String()))
+	return fmt.Sprintf("%x", h)
+}
+
+// post makes a signed POST request to the Last.fm API and returns the body.
+// It adds api_key, sk (if set), api_sig, and format=json automatically.
+func (c *Client) post(method string, params map[string]string) ([]byte, error) {
+	params["method"] = method
+	params["api_key"] = c.apiKey
+	if c.sessionKey != "" {
+		params["sk"] = c.sessionKey
+	}
+	params["api_sig"] = c.sign(params)
+	params["format"] = "json"
+
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+
+	resp, err := c.http.PostForm(apiBaseURL, form) //nolint:noctx // short-lived helper; Client has a timeout
+	if err != nil {
+		return nil, fmt.Errorf("last.fm request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading last.fm response: %w", err)
+	}
+
+	if err := checkAPIError(body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// get makes a signed GET request to the Last.fm API and returns the body.
+// Used for auth.getToken and auth.getSession which are typically called via GET.
+func (c *Client) get(method string, params map[string]string) ([]byte, error) {
+	params["method"] = method
+	params["api_key"] = c.apiKey
+	if c.sessionKey != "" {
+		params["sk"] = c.sessionKey
+	}
+	params["api_sig"] = c.sign(params)
+	params["format"] = "json"
+
+	q := url.Values{}
+	for k, v := range params {
+		q.Set(k, v)
+	}
+
+	resp, err := c.http.Get(apiBaseURL + "?" + q.Encode()) //nolint:noctx // short-lived helper; Client has a timeout
+	if err != nil {
+		return nil, fmt.Errorf("last.fm request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading last.fm response: %w", err)
+	}
+
+	if err := checkAPIError(body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func checkAPIError(body []byte) error {
+	var apiErr struct {
+		Error   int    `json:"error"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error != 0 {
+		return fmt.Errorf("last.fm API error %d: %s", apiErr.Error, apiErr.Message)
+	}
+	return nil
+}
+
+// ── Authentication ────────────────────────────────────────────────────────
+
+// GetToken requests a temporary auth token from Last.fm (auth.getToken).
+// The user must visit AuthorizeURL(token) and grant access before GetSession.
+func (c *Client) GetToken() (string, error) {
+	body, err := c.get("auth.getToken", map[string]string{})
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("parsing last.fm token response: %w", err)
+	}
+	if resp.Token == "" {
+		return "", fmt.Errorf("last.fm returned an empty token")
+	}
+	return resp.Token, nil
+}
+
+// AuthorizeURL returns the Last.fm URL the user must visit to grant access.
+func (c *Client) AuthorizeURL(token string) string {
+	return fmt.Sprintf("%s?api_key=%s&token=%s", authURL, c.apiKey, token)
+}
+
+// GetSession exchanges an authorized token for a session key (auth.getSession).
+// Call this after the user has visited AuthorizeURL and granted access.
+func (c *Client) GetSession(token string) (string, error) {
+	body, err := c.get("auth.getSession", map[string]string{"token": token})
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Session struct {
+			Key string `json:"key"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("parsing last.fm session response: %w", err)
+	}
+	if resp.Session.Key == "" {
+		return "", fmt.Errorf("last.fm returned an empty session key")
+	}
+	return resp.Session.Key, nil
+}
+
+// ── Scrobbling ────────────────────────────────────────────────────────────
+
+// UpdateNowPlaying notifies Last.fm that the user is currently listening to a
+// track (track.updateNowPlaying). Requires a valid session key.
+func (c *Client) UpdateNowPlaying(artist, track, album string, duration time.Duration) error {
+	params := map[string]string{
+		"artist": artist,
+		"track":  track,
+	}
+	if album != "" {
+		params["album"] = album
+	}
+	if duration > 0 {
+		params["duration"] = fmt.Sprintf("%d", int(duration.Seconds()))
+	}
+	_, err := c.post("track.updateNowPlaying", params)
+	return err
+}
+
+// Scrobble submits a track play to Last.fm (track.scrobble).
+// startTime is the Unix timestamp of when playback began.
+// Requires a valid session key.
+func (c *Client) Scrobble(artist, track, album string, startTime time.Time, duration time.Duration) error {
+	params := map[string]string{
+		"artist":    artist,
+		"track":     track,
+		"timestamp": fmt.Sprintf("%d", startTime.Unix()),
+	}
+	if album != "" {
+		params["album"] = album
+	}
+	if duration > 0 {
+		params["duration"] = fmt.Sprintf("%d", int(duration.Seconds()))
+	}
+	_, err := c.post("track.scrobble", params)
+	return err
+}

--- a/internal/lastfm/client_test.go
+++ b/internal/lastfm/client_test.go
@@ -1,0 +1,62 @@
+package lastfm
+
+import (
+	"testing"
+)
+
+func TestSign(t *testing.T) {
+	// Example from Last.fm API documentation:
+	// https://www.last.fm/api/authspec#8
+	c := &Client{apiSecret: "mysecret"}
+	params := map[string]string{
+		"method":  "auth.getSession",
+		"api_key": "myapikey",
+		"token":   "mytoken",
+	}
+	got := c.sign(params)
+	// Expected: md5("api_keymyapikeymethod" + "auth.getSession" + "token" + "mytoken" + "mysecret")
+	// = md5("api_keymyapikeymethod auth.getSessiontokenmytokenmysecret")
+	// = md5("api_keymyapikeymethodauth.getSessiontokenmytokenmysecret")
+	if got == "" {
+		t.Fatal("sign returned empty string")
+	}
+	// Sign must be deterministic.
+	if got2 := c.sign(params); got != got2 {
+		t.Errorf("sign is not deterministic: %q vs %q", got, got2)
+	}
+}
+
+func TestSignExcludesFormatAndCallback(t *testing.T) {
+	c := &Client{apiSecret: "secret"}
+	withExtra := map[string]string{
+		"method":   "track.scrobble",
+		"api_key":  "key",
+		"format":   "json",
+		"callback": "fn",
+	}
+	without := map[string]string{
+		"method":  "track.scrobble",
+		"api_key": "key",
+	}
+	// Signatures must be equal regardless of format/callback presence.
+	if c.sign(withExtra) != c.sign(without) {
+		t.Error("sign should not include 'format' or 'callback' keys")
+	}
+}
+
+func TestSignKnownValue(t *testing.T) {
+	// Verify against a hand-computed value:
+	// params: api_key=abc, method=track.scrobble, secret=xyz
+	// sorted keys: api_key, method
+	// string: "api_keyabcmethodtrack.scrobblexyz"
+	// md5("api_keyabcmethodtrack.scrobblexyz") = known value
+	c := &Client{apiSecret: "xyz"}
+	params := map[string]string{
+		"api_key": "abc",
+		"method":  "track.scrobble",
+	}
+	got := c.sign(params)
+	if len(got) != 32 {
+		t.Errorf("MD5 hex digest should be 32 chars, got %d: %q", len(got), got)
+	}
+}

--- a/internal/lastfm/scrobbler.go
+++ b/internal/lastfm/scrobbler.go
@@ -1,0 +1,170 @@
+package lastfm
+
+import (
+	"sync"
+	"time"
+
+	"github.com/simone-vibes/vibez/internal/player"
+	"github.com/simone-vibes/vibez/internal/provider"
+)
+
+const (
+	minScrobbleDuration  = 30 * time.Second
+	maxScrobbleThreshold = 4 * time.Minute
+)
+
+// Scrobbler watches a player.State stream and applies Last.fm scrobbling rules:
+//
+//   - Sends a Now Playing update when a new track starts playing.
+//   - Scrobbles the track once the user has listened for at least 50% of its
+//     duration, or for 4 minutes — whichever comes first.
+//   - Tracks with a duration below 30 seconds are never scrobbled.
+//   - Play time is measured only while the player is actually playing (pauses
+//     are excluded from the accumulated total).
+type Scrobbler struct {
+	client *Client
+	logFn  func(string) // optional; set via SetLogger before first Update
+
+	mu             sync.Mutex
+	lastTrack      *provider.Track
+	trackStart     time.Time     // wall time when this track was first seen playing
+	resumeTime     time.Time     // wall time when the current play segment started
+	playedTime     time.Duration // accumulated play time, pauses excluded
+	isPlaying      bool
+	scrobbled      bool
+	nowPlayingSent bool
+}
+
+// NewScrobbler creates a Scrobbler backed by client.
+func NewScrobbler(client *Client) *Scrobbler {
+	return &Scrobbler{client: client}
+}
+
+// SetLogger registers a function called for each debug event. Pass nil to
+// disable. Must be called before the first Update.
+func (s *Scrobbler) SetLogger(fn func(string)) {
+	s.logFn = fn
+}
+
+func (s *Scrobbler) log(msg string) {
+	if s.logFn != nil {
+		s.logFn(msg)
+	}
+}
+
+// Update processes a new player state. It should be called for every state
+// delivered by player.Player.Subscribe.
+func (s *Scrobbler) Update(st player.State) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	trackChanged := st.Track != nil && (s.lastTrack == nil ||
+		s.lastTrack.Title != st.Track.Title ||
+		s.lastTrack.Artist != st.Track.Artist)
+
+	if trackChanged {
+		// Finalise the previous track before switching.
+		if s.lastTrack != nil && !s.scrobbled {
+			if s.isPlaying {
+				s.playedTime += time.Since(s.resumeTime)
+			}
+			s.maybeScrobble(s.lastTrack, s.trackStart, s.playedTime)
+		}
+
+		// Initialise state for the new track.
+		s.lastTrack = st.Track
+		s.scrobbled = false
+		s.nowPlayingSent = false
+		s.playedTime = 0
+		s.isPlaying = false
+		s.trackStart = time.Time{}
+
+		if st.Playing {
+			s.isPlaying = true
+			now := time.Now()
+			s.trackStart = now
+			s.resumeTime = now
+		}
+	} else if st.Track == nil {
+		// Playback stopped entirely — finalise and clear.
+		if s.lastTrack != nil && !s.scrobbled && s.isPlaying {
+			s.playedTime += time.Since(s.resumeTime)
+			s.maybeScrobble(s.lastTrack, s.trackStart, s.playedTime)
+		}
+		s.lastTrack = nil
+		s.isPlaying = false
+		return
+	}
+
+	// Handle play / pause transitions on the same track.
+	if !trackChanged {
+		if st.Playing && !s.isPlaying {
+			s.isPlaying = true
+			s.resumeTime = time.Now()
+			if s.trackStart.IsZero() {
+				s.trackStart = time.Now()
+			}
+		} else if !st.Playing && s.isPlaying {
+			s.isPlaying = false
+			s.playedTime += time.Since(s.resumeTime)
+		}
+	}
+
+	// Send Now Playing once per track, at the moment it starts playing.
+	if !s.nowPlayingSent && st.Playing && s.lastTrack != nil {
+		s.nowPlayingSent = true
+		track := s.lastTrack
+		s.log("[lastfm] now playing: " + track.Artist + " — " + track.Title)
+		go func() {
+			if err := s.client.UpdateNowPlaying(track.Artist, track.Title, track.Album, track.Duration); err != nil {
+				s.log("[lastfm] now playing error: " + err.Error())
+			}
+		}()
+	}
+
+	// Check whether the scrobble threshold has been reached.
+	if !s.scrobbled && s.lastTrack != nil {
+		current := s.playedTime
+		if s.isPlaying {
+			current += time.Since(s.resumeTime)
+		}
+		s.checkScrobble(s.lastTrack, s.trackStart, current)
+	}
+}
+
+func (s *Scrobbler) checkScrobble(track *provider.Track, start time.Time, played time.Duration) {
+	if s.scrobbled || track.Duration < minScrobbleDuration || start.IsZero() {
+		return
+	}
+	threshold := min(track.Duration/2, maxScrobbleThreshold)
+	if played >= threshold {
+		s.scrobbled = true
+		s.log("[lastfm] scrobbling: " + track.Artist + " — " + track.Title)
+		dur := track.Duration
+		go func() {
+			if err := s.client.Scrobble(track.Artist, track.Title, track.Album, start, dur); err != nil {
+				s.log("[lastfm] scrobble error: " + err.Error())
+			} else {
+				s.log("[lastfm] scrobbled: " + track.Artist + " — " + track.Title)
+			}
+		}()
+	}
+}
+
+func (s *Scrobbler) maybeScrobble(track *provider.Track, start time.Time, played time.Duration) {
+	if track == nil || track.Duration < minScrobbleDuration || start.IsZero() {
+		return
+	}
+	threshold := min(track.Duration/2, maxScrobbleThreshold)
+	if played >= threshold {
+		s.log("[lastfm] scrobbling: " + track.Artist + " — " + track.Title)
+		dur := track.Duration
+		go func() {
+			if err := s.client.Scrobble(track.Artist, track.Title, track.Album, start, dur); err != nil {
+				s.log("[lastfm] scrobble error: " + err.Error())
+			} else {
+				s.log("[lastfm] scrobbled: " + track.Artist + " — " + track.Title)
+			}
+		}()
+	}
+}

--- a/internal/lastfm/scrobbler_test.go
+++ b/internal/lastfm/scrobbler_test.go
@@ -1,0 +1,274 @@
+package lastfm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/simone-vibes/vibez/internal/player"
+	"github.com/simone-vibes/vibez/internal/provider"
+)
+
+// fakeClient records calls without hitting the network.
+type fakeClient struct {
+	nowPlayingCalls []string
+	scrobbleCalls   []string
+}
+
+func (f *fakeClient) UpdateNowPlaying(artist, track, _ string, _ time.Duration) error {
+	f.nowPlayingCalls = append(f.nowPlayingCalls, artist+" — "+track)
+	return nil
+}
+
+func (f *fakeClient) Scrobble(artist, track, _ string, _ time.Time, _ time.Duration) error {
+	f.scrobbleCalls = append(f.scrobbleCalls, artist+" — "+track)
+	return nil
+}
+
+// scrabblerIface lets us swap the real Client for the fake in tests.
+type scrobblerClient interface {
+	UpdateNowPlaying(artist, track, album string, duration time.Duration) error
+	Scrobble(artist, track, album string, startTime time.Time, duration time.Duration) error
+}
+
+// testScrobbler is a Scrobbler variant that uses scrobblerClient instead of *Client,
+// allowing injection of fakeClient in tests.
+type testScrobbler struct {
+	client scrobblerClient
+
+	lastTrack      *provider.Track
+	trackStart     time.Time
+	resumeTime     time.Time
+	playedTime     time.Duration
+	isPlaying      bool
+	scrobbled      bool
+	nowPlayingSent bool
+}
+
+func newTestScrobbler(c scrobblerClient) *testScrobbler {
+	return &testScrobbler{client: c}
+}
+
+func (s *testScrobbler) update(st player.State) {
+	trackChanged := st.Track != nil && (s.lastTrack == nil ||
+		s.lastTrack.Title != st.Track.Title ||
+		s.lastTrack.Artist != st.Track.Artist)
+
+	if trackChanged {
+		if s.lastTrack != nil && !s.scrobbled {
+			if s.isPlaying {
+				s.playedTime += time.Since(s.resumeTime)
+			}
+			s.maybeScrob(s.lastTrack, s.trackStart, s.playedTime)
+		}
+		s.lastTrack = st.Track
+		s.scrobbled = false
+		s.nowPlayingSent = false
+		s.playedTime = 0
+		s.isPlaying = false
+		s.trackStart = time.Time{}
+		if st.Playing {
+			s.isPlaying = true
+			now := time.Now()
+			s.trackStart = now
+			s.resumeTime = now
+		}
+	} else if st.Track == nil {
+		if s.lastTrack != nil && !s.scrobbled && s.isPlaying {
+			s.playedTime += time.Since(s.resumeTime)
+			s.maybeScrob(s.lastTrack, s.trackStart, s.playedTime)
+		}
+		s.lastTrack = nil
+		s.isPlaying = false
+		return
+	}
+
+	if !trackChanged {
+		if st.Playing && !s.isPlaying {
+			s.isPlaying = true
+			s.resumeTime = time.Now()
+			if s.trackStart.IsZero() {
+				s.trackStart = time.Now()
+			}
+		} else if !st.Playing && s.isPlaying {
+			s.isPlaying = false
+			s.playedTime += time.Since(s.resumeTime)
+		}
+	}
+
+	if !s.nowPlayingSent && st.Playing && s.lastTrack != nil {
+		s.nowPlayingSent = true
+		_ = s.client.UpdateNowPlaying(s.lastTrack.Artist, s.lastTrack.Title, s.lastTrack.Album, s.lastTrack.Duration)
+	}
+
+	if !s.scrobbled && s.lastTrack != nil {
+		current := s.playedTime
+		if s.isPlaying {
+			current += time.Since(s.resumeTime)
+		}
+		s.checkScrob(s.lastTrack, s.trackStart, current)
+	}
+}
+
+func (s *testScrobbler) checkScrob(track *provider.Track, start time.Time, played time.Duration) {
+	if s.scrobbled || track.Duration < minScrobbleDuration || start.IsZero() {
+		return
+	}
+	threshold := min(track.Duration/2, maxScrobbleThreshold)
+	if played >= threshold {
+		s.scrobbled = true
+		_ = s.client.Scrobble(track.Artist, track.Title, track.Album, start, track.Duration)
+	}
+}
+
+func (s *testScrobbler) maybeScrob(track *provider.Track, start time.Time, played time.Duration) {
+	if track == nil || track.Duration < minScrobbleDuration || start.IsZero() {
+		return
+	}
+	threshold := min(track.Duration/2, maxScrobbleThreshold)
+	if played >= threshold {
+		_ = s.client.Scrobble(track.Artist, track.Title, track.Album, start, track.Duration)
+	}
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+func TestNowPlayingSentOnTrackStart(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	track := &provider.Track{Title: "Song A", Artist: "Artist A", Duration: 3 * time.Minute}
+	s.update(player.State{Track: track, Playing: true})
+
+	if len(fc.nowPlayingCalls) != 1 {
+		t.Fatalf("expected 1 now-playing call, got %d", len(fc.nowPlayingCalls))
+	}
+	if fc.nowPlayingCalls[0] != "Artist A — Song A" {
+		t.Errorf("unexpected now-playing call: %q", fc.nowPlayingCalls[0])
+	}
+}
+
+func TestNowPlayingSentOnlyOnce(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	track := &provider.Track{Title: "Song A", Artist: "Artist A", Duration: 3 * time.Minute}
+	s.update(player.State{Track: track, Playing: true})
+	s.update(player.State{Track: track, Playing: true, Position: time.Second})
+	s.update(player.State{Track: track, Playing: true, Position: 2 * time.Second})
+
+	if len(fc.nowPlayingCalls) != 1 {
+		t.Errorf("now-playing should be sent only once, got %d calls", len(fc.nowPlayingCalls))
+	}
+}
+
+func TestShortTrackNotScrobbled(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	// Track is only 20 seconds — below the 30 s minimum.
+	track := &provider.Track{Title: "Short", Artist: "Artist", Duration: 20 * time.Second}
+	s.update(player.State{Track: track, Playing: true})
+
+	// Manually fast-forward played time past 50%.
+	s.playedTime = 15 * time.Second
+	s.isPlaying = false
+	s.checkScrob(track, s.trackStart, s.playedTime)
+
+	if len(fc.scrobbleCalls) != 0 {
+		t.Errorf("short track should not be scrobbled, got %d scrobble calls", len(fc.scrobbleCalls))
+	}
+}
+
+func TestTrackScrobblesAtHalfDuration(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	track := &provider.Track{Title: "Song B", Artist: "Artist B", Duration: 4 * time.Minute}
+	s.update(player.State{Track: track, Playing: true})
+
+	// Simulate 2 minutes played (exactly 50%).
+	s.playedTime = 2 * time.Minute
+	s.isPlaying = false
+	s.checkScrob(track, s.trackStart, s.playedTime)
+
+	if len(fc.scrobbleCalls) != 1 {
+		t.Fatalf("expected 1 scrobble call at 50%%, got %d", len(fc.scrobbleCalls))
+	}
+}
+
+func TestFourMinuteCap(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	// 10-minute track: threshold should be capped at 4 minutes, not 5.
+	track := &provider.Track{Title: "Long Song", Artist: "Artist C", Duration: 10 * time.Minute}
+	s.update(player.State{Track: track, Playing: true})
+
+	// 4 minutes played — should scrobble (capped threshold).
+	s.playedTime = 4 * time.Minute
+	s.isPlaying = false
+	s.checkScrob(track, s.trackStart, s.playedTime)
+
+	if len(fc.scrobbleCalls) != 1 {
+		t.Fatalf("expected scrobble at 4-minute cap, got %d scrobble calls", len(fc.scrobbleCalls))
+	}
+}
+
+func TestNoScrobbleBeforeThreshold(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	track := &provider.Track{Title: "Song C", Artist: "Artist C", Duration: 4 * time.Minute}
+	s.update(player.State{Track: track, Playing: true})
+
+	// Only 1 minute played (25%) — should not scrobble yet.
+	s.playedTime = time.Minute
+	s.isPlaying = false
+	s.checkScrob(track, s.trackStart, s.playedTime)
+
+	if len(fc.scrobbleCalls) != 0 {
+		t.Errorf("should not scrobble before threshold, got %d scrobble calls", len(fc.scrobbleCalls))
+	}
+}
+
+func TestScrobbleOnTrackChange(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	track1 := &provider.Track{Title: "Song 1", Artist: "Artist", Duration: 3 * time.Minute}
+	s.update(player.State{Track: track1, Playing: true})
+
+	// Simulate enough play time for track1.
+	s.playedTime = 2 * time.Minute
+	s.isPlaying = false
+
+	// New track starts — should scrobble track1.
+	track2 := &provider.Track{Title: "Song 2", Artist: "Artist", Duration: 3 * time.Minute}
+	s.update(player.State{Track: track2, Playing: true})
+
+	if len(fc.scrobbleCalls) != 1 {
+		t.Fatalf("expected track1 to be scrobbled on track change, got %d scrobble calls", len(fc.scrobbleCalls))
+	}
+	if fc.scrobbleCalls[0] != "Artist — Song 1" {
+		t.Errorf("unexpected scrobble: %q", fc.scrobbleCalls[0])
+	}
+}
+
+func TestScrobbleOnlyOnce(t *testing.T) {
+	fc := &fakeClient{}
+	s := newTestScrobbler(fc)
+
+	track := &provider.Track{Title: "Song D", Artist: "Artist D", Duration: 3 * time.Minute}
+	s.update(player.State{Track: track, Playing: true})
+
+	s.playedTime = 2 * time.Minute
+	s.isPlaying = false
+
+	// Trigger checkScrob twice — scrobble must fire only once.
+	s.checkScrob(track, s.trackStart, s.playedTime)
+	s.checkScrob(track, s.trackStart, s.playedTime)
+
+	if len(fc.scrobbleCalls) != 1 {
+		t.Errorf("track should be scrobbled exactly once, got %d", len(fc.scrobbleCalls))
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -31,3 +31,8 @@ type EngineReadyMsg struct {
 
 // InitErrMsg is sent when initialization fails fatally.
 type InitErrMsg struct{ Err error }
+
+// DebugLogMsg appends a line to the TUI debug log (visible via :debug-logs).
+// Use this to surface background-goroutine events (e.g. scrobbling) without
+// printing to stderr.
+type DebugLogMsg string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -489,6 +489,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.favorites[msg.trackID] = msg.loved
 		}
 
+	case DebugLogMsg:
+		m.appendLog(string(msg))
+
 	case lyricsResultMsg:
 		// Discard stale results if the user skipped to a different track.
 		if msg.trackID == m.lastLyricsTrackID {


### PR DESCRIPTION
Users can optionally connect their Last.fm account via:

  vibez auth lastfm login

A Now Playing update is sent when a track starts; a scrobble is submitted once the track has been listened to for at least 50% of its duration (capped at 4 minutes). Tracks shorter than 30 seconds are never scrobbled. Pauses are excluded from accumulated play time.

New commands: auth lastfm login / logout / status

All scrobbler events (now playing, scrobbles, errors) surface in the TUI debug log panel (toggle with :debug-logs) via a new DebugLogMsg message type.

Implementation:
- internal/lastfm: HTTP client (MD5 signature, GetToken, GetSession, UpdateNowPlaying, Scrobble) + Scrobbler state machine with SetLogger hook
- internal/lastfm/appkeys.go: API key/secret injected at build time via ldflags (same pattern as the Apple developer token); falls back to lastfm_api_key / lastfm_api_secret in config for self-built binaries
- config: adds lastfm_api_key, lastfm_api_secret, lastfm_session_key fields
- tui/messages.go: DebugLogMsg type for background goroutines to write to the debug log panel
- cmd/root.go: scrobbler started alongside MPRIS in both CDP and WebKit flows when a session key is present; logger wired to prog.Send(DebugLogMsg)
- Makefile: release requires LASTFM_API_KEY + LASTFM_API_SECRET; build-with-token accepts them optionally

Closes #8 