### PR TITLE
fix(library): fix library panel not activating and rendering blank content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.9] — 2026-04-30
+
+### Fixed
+- **Library panel (`l`) not activating** — reopening the library panel after the
+  music engine was ready replaced the internal model pointer instead of updating it
+  in-place, causing the active-panel check to always fail silently. The panel state
+  is now updated in-place so the pointer identity is preserved.
+- **Library panel rendering blank** — the `WindowSizeMsg` sized the original inner
+  model before the engine was ready; when the engine started a new model was created
+  with zero dimensions. The panel now re-applies the current window dimensions after
+  the engine is ready, and also re-sizes lazily on every render (consistent with the
+  queue panel).
+- **Apple Music API 400 on track loading** — all four track-fetching endpoints sent
+  `limit=300`, which exceeds the Apple Music API maximum of 100. Corrected to
+  `limit=100` across `GetPlaylistTracks`, `GetAlbumTracks`, `GetLibraryAlbumTracks`,
+  and `GetCatalogPlaylistTracks`.
+
+### Changed
+- **Library view simplified to Playlists only** — the Albums and Tracks tabs have
+  been removed. The library panel now shows only the user's playlists, keeping the
+  interface focused and reducing unnecessary API calls.
+- **Library and drill-down errors go to debug log** — playlist load errors and
+  track-fetch errors are no longer shown as inline messages in the library panel;
+  they are written to the debug-logs view (`d` key) so the UI stays clean.
+
+---
+
 ## [0.0.8] — 2026-04-18
 
 ### Added

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -515,7 +515,7 @@ func (a *AppleProvider) GetLibraryPlaylists(ctx context.Context) ([]provider.Pla
 
 func (a *AppleProvider) GetPlaylistTracks(ctx context.Context, playlistID string) ([]provider.Track, error) {
 	var tracks []provider.Track
-	endpoint := fmt.Sprintf("/me/library/playlists/%s/tracks?limit=300", playlistID)
+	endpoint := fmt.Sprintf("/me/library/playlists/%s/tracks?limit=100", playlistID)
 
 	for endpoint != "" {
 		req, err := a.newRequest(ctx, http.MethodGet, endpoint)
@@ -540,7 +540,7 @@ func (a *AppleProvider) GetAlbumTracks(ctx context.Context, albumID string) ([]p
 		return nil, fmt.Errorf("GetAlbumTracks: %w", err)
 	}
 	var tracks []provider.Track
-	endpoint := fmt.Sprintf("/catalog/%s/albums/%s/tracks?limit=300", sf, albumID)
+	endpoint := fmt.Sprintf("/catalog/%s/albums/%s/tracks?limit=100", sf, albumID)
 	for endpoint != "" {
 		req, err := a.newRequest(ctx, http.MethodGet, endpoint)
 		if err != nil {
@@ -560,7 +560,7 @@ func (a *AppleProvider) GetAlbumTracks(ctx context.Context, albumID string) ([]p
 
 func (a *AppleProvider) GetLibraryAlbumTracks(ctx context.Context, albumID string) ([]provider.Track, error) {
 	var tracks []provider.Track
-	endpoint := fmt.Sprintf("/me/library/albums/%s/tracks?limit=300", albumID)
+	endpoint := fmt.Sprintf("/me/library/albums/%s/tracks?limit=100", albumID)
 	for endpoint != "" {
 		req, err := a.newRequest(ctx, http.MethodGet, endpoint)
 		if err != nil {
@@ -584,7 +584,7 @@ func (a *AppleProvider) GetCatalogPlaylistTracks(ctx context.Context, playlistID
 		return nil, fmt.Errorf("GetCatalogPlaylistTracks: %w", err)
 	}
 	var tracks []provider.Track
-	endpoint := fmt.Sprintf("/catalog/%s/playlists/%s/tracks?limit=300", sf, playlistID)
+	endpoint := fmt.Sprintf("/catalog/%s/playlists/%s/tracks?limit=100", sf, playlistID)
 	for endpoint != "" {
 		req, err := a.newRequest(ctx, http.MethodGet, endpoint)
 		if err != nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -735,7 +735,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.player = msg.Player
 		m.provider = msg.Provider
 		m.stateCh = msg.Player.Subscribe()
-		m.library = &libraryPanel{m: views.NewLibrary(msg.Provider)}
+		m.library.m = views.NewLibrary(msg.Provider)
+		// Re-apply the window size that was stored from the earlier WindowSizeMsg,
+		// since the new inner LibraryModel starts with zero dimensions.
+		if m.width > 0 {
+			inner := max(0, m.width-2)
+			m.library.SetSize(max(0, inner-2), m.panelHeight())
+		}
 		m.search = views.NewSearch(msg.Provider)
 		m.helperPaths = msg.HelperPaths
 		m.appendLog("[engine] backend: " + msg.Backend)
@@ -780,6 +786,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	default:
 		// Forward library background loads
 		updated, libCmd := m.library.m.Update(msg)
+		if err := updated.DrillErr(); err != nil && m.library.m.DrillErr() == nil {
+			m.appendLog("[library] playlist tracks error: " + err.Error())
+		}
+		if err := updated.LoadErr(); err != nil && m.library.m.LoadErr() == nil {
+			m.appendLog("[library] playlists load error: " + err.Error())
+		}
 		m.library.m = updated
 		cmds = append(cmds, libCmd)
 	}
@@ -2165,6 +2177,7 @@ func (m *Model) renderBoxLayout() string {
 			sb.WriteString("│ " + padRight(line, inner-2) + " │\n")
 		}
 	case libraryActive:
+		m.library.SetSize(inner-2, panelH)
 		for _, line := range toLines(m.library.View(), panelH) {
 			sb.WriteString("│ " + padRight(line, inner-2) + " │\n")
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1209,6 +1209,10 @@ func TestModel_Update_PlayerStateMsg_GenericError(t *testing.T) {
 func TestModel_Update_EngineReadyMsg(t *testing.T) {
 	mp := newMockPlayer()
 	m := newModel(nil)
+
+	// Simulate a window size arriving before the engine is ready (normal startup).
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
 	_, cmd := m.Update(EngineReadyMsg{
 		Player:      mp,
 		Provider:    &mockProvider{},
@@ -1221,6 +1225,15 @@ func TestModel_Update_EngineReadyMsg(t *testing.T) {
 	}
 	if m.provider == nil {
 		t.Error("EngineReadyMsg should set m.provider")
+	}
+	// panels[0] must still point to m.library so the 'l' key works after EngineReadyMsg.
+	if m.panels[0] != m.library {
+		t.Error("EngineReadyMsg must not replace m.library pointer; panels[0] would become stale")
+	}
+	// The new inner LibraryModel must have non-zero dimensions so items are visible.
+	if m.library.m.Width() == 0 || m.library.m.Height() == 0 {
+		t.Errorf("library inner model has zero dimensions (%dx%d) after EngineReadyMsg; window size was not re-applied",
+			m.library.m.Width(), m.library.m.Height())
 	}
 }
 

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -13,14 +13,6 @@ import (
 	"github.com/simone-vibes/vibez/internal/tui/styles"
 )
 
-type libraryTab int
-
-const (
-	tabPlaylists libraryTab = iota
-	tabAlbums
-	tabTracks
-)
-
 // libraryPane controls which level of the drill-down is visible.
 type libraryPane int
 
@@ -30,8 +22,6 @@ const (
 )
 
 type libraryLoadedMsg struct {
-	tab       libraryTab
-	tracks    []provider.Track
 	playlists []provider.Playlist
 	err       error
 }
@@ -43,20 +33,20 @@ type playlistTracksMsg struct {
 }
 
 type LibraryModel struct {
-	provider  provider.Provider
-	activeTab libraryTab
-	loading   bool
-	list      list.Model
-	spinner   spinner.Model
+	provider provider.Provider
+	loading  bool
+	loadErr  error
+	list     list.Model
+	spinner  spinner.Model
 
 	playlists []provider.Playlist
-	tracks    []provider.Track
 
 	// Drill-down into a playlist's tracks.
 	pane          libraryPane
 	drillPlaylist provider.Playlist
 	drillTracks   []provider.Track
 	drillLoading  bool
+	drillErr      error
 	drillList     list.Model
 
 	width  int
@@ -92,6 +82,11 @@ func (m *LibraryModel) Init() tea.Cmd {
 	return tea.Batch(m.spinner.Tick, m.loadPlaylists())
 }
 
+func (m *LibraryModel) Width() int      { return m.width }
+func (m *LibraryModel) Height() int     { return m.height }
+func (m *LibraryModel) DrillErr() error { return m.drillErr }
+func (m *LibraryModel) LoadErr() error  { return m.loadErr }
+
 func (m *LibraryModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
@@ -105,16 +100,7 @@ func (m *LibraryModel) loadPlaylists() tea.Cmd {
 	prov := m.provider
 	return func() tea.Msg {
 		playlists, err := prov.GetLibraryPlaylists(context.Background())
-		return libraryLoadedMsg{tab: tabPlaylists, playlists: playlists, err: err}
-	}
-}
-
-func (m *LibraryModel) loadTracks() tea.Cmd {
-	m.loading = true
-	prov := m.provider
-	return func() tea.Msg {
-		tracks, err := prov.GetLibraryTracks(context.Background())
-		return libraryLoadedMsg{tab: tabTracks, tracks: tracks, err: err}
+		return libraryLoadedMsg{playlists: playlists, err: err}
 	}
 }
 
@@ -131,19 +117,16 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case libraryLoadedMsg:
 		m.loading = false
+		m.loadErr = msg.err
 		if msg.err == nil {
-			switch msg.tab {
-			case tabPlaylists:
-				m.playlists = msg.playlists
-			case tabTracks:
-				m.tracks = msg.tracks
-			}
+			m.playlists = msg.playlists
 			m.refreshList()
 		}
 		return m, nil
 
 	case playlistTracksMsg:
 		m.drillLoading = false
+		m.drillErr = msg.err
 		if msg.err == nil {
 			m.drillTracks = msg.tracks
 			items := make([]list.Item, len(msg.tracks))
@@ -195,39 +178,16 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 
 		// Top-level pane.
 		switch msg.String() {
-		case "tab":
-			m.activeTab = (m.activeTab + 1) % 3
-			if m.activeTab == tabTracks && m.tracks == nil {
-				return m, m.loadTracks()
-			}
-			m.refreshList()
-			return m, nil
 		case "enter":
 			if selected := m.list.SelectedItem(); selected != nil {
-				switch m.activeTab {
-				case tabTracks:
-					if item, ok := selected.(trackListItem); ok {
-						idx := m.list.Index()
-						allTracks := m.tracks[idx:]
-						ids := make([]string, len(allTracks))
-						for i, t := range allTracks {
-							ids[i] = PlaybackID(t)
-						}
-						t := item.t
-						tracks := append([]provider.Track{}, allTracks...)
-						return m, func() tea.Msg {
-							return PlayTracksMsg{IDs: ids, Tracks: tracks, Track: &t}
-						}
-					}
-				case tabPlaylists:
-					if item, ok := selected.(playlistItem); ok {
-						pl := provider.Playlist(item)
-						m.drillPlaylist = pl
-						m.pane = paneTracks
-						m.drillTracks = nil
-						m.drillList.SetItems(nil)
-						return m, tea.Batch(m.spinner.Tick, m.loadPlaylistTracks(pl))
-					}
+				if item, ok := selected.(playlistItem); ok {
+					pl := provider.Playlist(item)
+					m.drillPlaylist = pl
+					m.pane = paneTracks
+					m.drillTracks = nil
+					m.drillErr = nil
+					m.drillList.SetItems(nil)
+					return m, tea.Batch(m.spinner.Tick, m.loadPlaylistTracks(pl))
 				}
 			}
 			return m, nil
@@ -250,15 +210,8 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 
 func (m *LibraryModel) refreshList() {
 	var items []list.Item
-	switch m.activeTab {
-	case tabPlaylists:
-		for _, pl := range m.playlists {
-			items = append(items, playlistItem(pl))
-		}
-	case tabTracks:
-		for _, t := range m.tracks {
-			items = append(items, trackListItem{t})
-		}
+	for _, pl := range m.playlists {
+		items = append(items, playlistItem(pl))
 	}
 	m.list.SetItems(items)
 }
@@ -267,11 +220,14 @@ func (m *LibraryModel) View() string {
 	if m.pane == paneTracks {
 		return m.renderDrillView()
 	}
-	tabs := m.renderTabs()
+	header := m.renderHeader()
 	if m.loading {
-		return tabs + "\n\n  " + m.spinner.View() + " Loading…"
+		return header + "\n\n  " + m.spinner.View() + " Loading…"
 	}
-	return tabs + "\n" + m.list.View()
+	if len(m.playlists) == 0 {
+		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render("No playlists found"), m.width)
+	}
+	return header + "\n" + m.list.View()
 }
 
 func (m *LibraryModel) renderDrillView() string {
@@ -285,20 +241,14 @@ func (m *LibraryModel) renderDrillView() string {
 	if len(m.drillTracks) == 0 {
 		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render("No tracks found"), m.width)
 	}
+	listH := max(0, m.height-3)
+	m.drillList.SetSize(m.width, listH)
 	return header + "\n" + m.drillList.View()
 }
 
-func (m *LibraryModel) renderTabs() string {
-	tabLabels := []string{"Playlists", "Albums", "Tracks"}
-	rendered := make([]string, len(tabLabels))
-	for i, label := range tabLabels {
-		if libraryTab(i) == m.activeTab {
-			rendered[i] = styles.TabActive.Render(label)
-		} else {
-			rendered[i] = styles.TabInactive.Render(label)
-		}
-	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, rendered...) +
+func (m *LibraryModel) renderHeader() string {
+	title := styles.TabActive.Render("Playlists")
+	return title +
 		"\n" + lipgloss.NewStyle().Foreground(styles.ColorMuted).Render("─────────────────────────")
 }
 

--- a/internal/tui/views/library_test.go
+++ b/internal/tui/views/library_test.go
@@ -111,7 +111,6 @@ func TestLibrary_Update_LibraryLoadedMsg_Playlists(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 24)
 	msg := libraryLoadedMsg{
-		tab: tabPlaylists,
 		playlists: []provider.Playlist{
 			{ID: "p1", Name: "Playlist One", TrackCount: 10},
 			{ID: "p2", Name: "Playlist Two", TrackCount: 20},
@@ -120,21 +119,6 @@ func TestLibrary_Update_LibraryLoadedMsg_Playlists(t *testing.T) {
 	lib, _ = lib.Update(msg)
 	if len(lib.playlists) != 2 {
 		t.Errorf("playlists not set: got %d, want 2", len(lib.playlists))
-	}
-}
-
-func TestLibrary_Update_LibraryLoadedMsg_Tracks(t *testing.T) {
-	lib := NewLibrary(&mockProvider{})
-	lib.SetSize(80, 24)
-	msg := libraryLoadedMsg{
-		tab: tabTracks,
-		tracks: []provider.Track{
-			{ID: "t1", Title: "Track One"},
-		},
-	}
-	lib, _ = lib.Update(msg)
-	if len(lib.tracks) != 1 {
-		t.Errorf("tracks not set: got %d, want 1", len(lib.tracks))
 	}
 }
 
@@ -153,19 +137,8 @@ func TestLibrary_Update_LibraryLoadedMsg_Error(t *testing.T) {
 func TestLibrary_Update_TabKey(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 24)
-	// Just verify it doesn't panic; tab assertion is in TestLibrary_Update_TabString.
+	// Tab key has no effect with single-tab library; just verify no panic.
 	_, _ = lib.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("\t")})
-}
-
-func TestLibrary_Update_TabString(t *testing.T) {
-	lib := NewLibrary(&mockProvider{})
-	lib.SetSize(80, 24)
-	lib.activeTab = tabPlaylists
-	// Send "tab" key (the string "tab" matches msg.String() == "tab")
-	lib, _ = lib.Update(tea.KeyMsg{Type: tea.KeyTab})
-	if lib.activeTab != tabAlbums {
-		t.Errorf("after tab key: activeTab = %d, want %d (tabAlbums)", lib.activeTab, tabAlbums)
-	}
 }
 
 func TestLibrary_Update_SpinnerTick_WhenLoading(t *testing.T) {
@@ -180,16 +153,13 @@ func TestLibrary_Update_SpinnerTick_WhenLoading(t *testing.T) {
 func TestLibrary_RefreshList_Indirect(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 24)
-	// Load playlists and then switch to tracks tab to exercise refreshList
+	// Load playlists and verify no panic.
 	lib, _ = lib.Update(libraryLoadedMsg{
-		tab:       tabPlaylists,
 		playlists: []provider.Playlist{{Name: "PL", TrackCount: 5}},
 	})
-	// Switch to albums tab
-	lib, _ = lib.Update(tea.KeyMsg{Type: tea.KeyTab})
-	// Switch to tracks tab — final result unused, test verifies no panic
-	_, _ = lib.Update(tea.KeyMsg{Type: tea.KeyTab})
-	// No panic = success
+	if lib.list.Items() == nil {
+		t.Error("expected non-nil items after loading playlists")
+	}
 }
 
 func TestLibrary_Init_NoPanic(t *testing.T) {
@@ -220,29 +190,6 @@ func TestLibrary_LoadPlaylists_Executes(t *testing.T) {
 		t.Errorf("got %d playlists, want 1", len(loaded.playlists))
 	}
 }
-
-func TestLibrary_LoadTracks_Executes(t *testing.T) {
-	prov := &mockProvider{
-		libraryTracks: []provider.Track{
-			{ID: "t1", Title: "Track One", Artist: "Artist One"},
-		},
-	}
-	lib := NewLibrary(prov)
-	cmd := lib.loadTracks()
-	if cmd == nil {
-		t.Fatal("loadTracks() should return non-nil cmd")
-	}
-	msg := cmd() // execute the cmd
-	loaded, ok := msg.(libraryLoadedMsg)
-	if !ok {
-		t.Fatalf("loadTracks cmd returned %T, want libraryLoadedMsg", msg)
-	}
-	if len(loaded.tracks) != 1 {
-		t.Errorf("got %d tracks, want 1", len(loaded.tracks))
-	}
-}
-
-// --- loadPlaylistTracks ---
 
 func TestLibrary_LoadPlaylistTracks_Executes(t *testing.T) {
 	prov := &mockProvider{} // returns nil tracks, nil error by default
@@ -377,10 +324,8 @@ func TestLibrary_Update_DrillPane_Enter_NoSelection(t *testing.T) {
 func TestLibrary_Update_Tab_CyclesTabs(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 20)
-	lib.activeTab = tabPlaylists
-
-	updated, _ := lib.Update(tea.KeyMsg{Type: tea.KeyTab})
-	_ = updated
+	// Tab key has no effect (single tab); verify no panic.
+	_, _ = lib.Update(tea.KeyMsg{Type: tea.KeyTab})
 }
 
 // --- Library: playlistItem.Description no TrackCount ---


### PR DESCRIPTION
Closes #16

## Changes

- **Pointer identity fix**: `EngineReadyMsg` now updates `m.library.m` in-place instead of replacing the pointer, so `m.panels[0] == m.library` stays true and `l` correctly activates the panel
- **Zero-size rendering fix**: window dimensions are re-applied after the inner model is replaced in `EngineReadyMsg`; lazy `SetSize` added on every library render (consistent with queue panel)
- **API limit fix**: lowered `limit` from 300 → 100 in all four track-fetching endpoints (`GetPlaylistTracks`, `GetAlbumTracks`, `GetLibraryAlbumTracks`, `GetCatalogPlaylistTracks`) to stay within Apple Music API limits
- **Error routing**: playlist-load and track-fetch errors are now written to the debug-log view (`d`) instead of being silently dropped
- **Simplified library view**: removed Albums and Tracks tabs; panel shows playlists only