### PR TITLE
feat(themes): add custom theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Custom themes** — set `"theme"` in `~/.config/vibez/config.json` to switch palette.
+  Four built-in themes ship out of the box: `default` (Tokyo Night / Catppuccin Mocha),
+  `dracula`, `gruvbox`, and `nord`. Custom palettes can be created as JSON files in
+  `~/.config/vibez/themes/<name>.json`; any missing or invalid color fields fall back to
+  the default theme automatically. All 20+ color roles are themeable: core palette,
+  semantic accents, bear mascot, progress-bar gradient, glow animation, and mode chips.
+  Closes #14.
+
+---
+
 ## [0.0.9] — 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Full tracks stream via an embedded headless Chrome with Widevine DRM (auto-downl
 - **Provider architecture** — the player core is decoupled from the music source
 - **More services coming** — Spotify, YouTube Music, Deezer, and Tidal are on the roadmap
 
+### 🎨 Themes
+
+- **Built-in themes** — `default` (Tokyo Night / Catppuccin), `dracula`, `gruvbox`, `nord`
+- **Custom themes** — create your own palette as a JSON file in `~/.config/vibez/themes/<name>.json`
+
 ---
 
 ## Installation
@@ -133,6 +138,50 @@ vibez auth lastfm status    # check Last.fm connection status
 vibez auth lastfm logout    # disconnect Last.fm
 vibez version               # print version
 ```
+
+---
+
+## Theming
+
+Set the `theme` key in `~/.config/vibez/config.json`:
+
+```json
+{
+  "theme": "dracula"
+}
+```
+
+**Built-in themes:** `default`, `dracula`, `gruvbox`, `nord`
+
+### Custom themes
+
+Create `~/.config/vibez/themes/<name>.json` with any subset of fields — missing or invalid values fall back to `default`:
+
+```json
+{
+  "primary":      "#ff79c6",
+  "secondary":    "#50fa7b",
+  "muted":        "#6272a4",
+  "error":        "#ff5555",
+  "fg":           "#f8f8f2",
+  "subtle":       "#8be9fd",
+  "bg":           "#282a36",
+  "love":         "#ff6e6e",
+  "active":       "#50fa7b",
+  "progress":     "#8be9fd",
+  "surface":      "#44475a",
+  "accent":       "#bd93f9",
+  "accent_warm":  "#f1fa8c",
+  "bear":         "#ffb86c",
+  "glow_palette": ["#282a36","#383a52","#44475a","#6272a4","#9580ff","#bd93f9","#caa9fa","#e9e0ff"],
+  "mode_normal_bg":  "#50fa7b",
+  "mode_search_bg":  "#8be9fd",
+  "mode_command_bg": "#f1fa8c",
+  "mode_chip_fg":    "#282a36"
+}
+```
+
+Then set `"theme": "<name>"` in `config.json` and restart vibez.
 
 ---
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/simone-vibes/vibez/internal/provider/apple"
 	demoProvider "github.com/simone-vibes/vibez/internal/provider/demo"
 	"github.com/simone-vibes/vibez/internal/tui"
+	"github.com/simone-vibes/vibez/internal/tui/styles"
 	"github.com/spf13/cobra"
 )
 
@@ -49,12 +51,23 @@ func init() {
 }
 
 func runTUI(_ *cobra.Command, _ []string) error {
+	cfgPath, err := config.ConfigPath(cfgFile)
+	if err != nil {
+		return fmt.Errorf("resolving config path: %w", err)
+	}
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
 	opts := tui.Options{MemProfiling: memProfiling}
+
+	// Apply theme before creating any TUI model so all panels pick up the palette.
+	theme, themeErr := styles.LoadTheme(cfg.Theme, filepath.Dir(cfgPath))
+	if themeErr != nil && debug {
+		fmt.Fprintf(os.Stderr, "debug: theme: %v (falling back to default)\n", themeErr)
+	}
+	styles.Apply(theme)
 
 	if demo {
 		iconPath := assets.InstallIcon()

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -2,7 +2,9 @@ package styles
 
 import "github.com/charmbracelet/lipgloss"
 
-const (
+// Color variables — all mutable so Apply(Theme) can swap the palette at startup.
+// Initial values match DefaultTheme (Tokyo Night / Catppuccin Mocha blend).
+var (
 	ColorPrimary   = lipgloss.Color("#C678DD")
 	ColorSecondary = lipgloss.Color("#98C379")
 	ColorMuted     = lipgloss.Color("#5C6370")
@@ -10,19 +12,16 @@ const (
 	ColorFg        = lipgloss.Color("#ABB2BF")
 	ColorSubtle    = lipgloss.Color("#61AFEF")
 
-	// Core theme — Tokyo Night base
 	ColorBg = lipgloss.Color("#1a1b26")
 
-	// Catppuccin Mocha semantic accents
-	ColorLove     = lipgloss.Color("#f38ba8") // rose pink — loved / favourited
-	ColorActive   = lipgloss.Color("#a6e3a1") // mint green — on/active controls
-	ColorProgress = lipgloss.Color("#89b4fa") // cornflower blue — progress & time
-	ColorSurface  = lipgloss.Color("#2a2b3d") // dim surface — unfilled bars
+	ColorLove       = lipgloss.Color("#f38ba8")
+	ColorActive     = lipgloss.Color("#a6e3a1")
+	ColorProgress   = lipgloss.Color("#89b4fa")
+	ColorSurface    = lipgloss.Color("#2a2b3d")
+	ColorAccent     = lipgloss.Color("#7aa2f7")
+	ColorAccentWarm = lipgloss.Color("#E5C07B") // amber — labels, search, note animations
+	ColorBear       = lipgloss.Color("#C4A265") // bear mascot body
 
-	// Blue key-binding accent (unchanged)
-	ColorAccent = lipgloss.Color("#7aa2f7")
-
-	// Glow sweep — dark purple → bright lavender (used for title & bear animation)
 	ColorGlow0 = lipgloss.Color("#1e1e2e")
 	ColorGlow1 = lipgloss.Color("#2d2b55")
 	ColorGlow2 = lipgloss.Color("#4a3f8a")
@@ -52,35 +51,33 @@ var (
 	NowPlayingLabel = lipgloss.NewStyle().
 			Italic(true).
 			Bold(true).
-			Foreground(lipgloss.Color("#E5C07B")) // warm amber
+			Foreground(ColorAccentWarm)
 
 	NowPlayingTitle = lipgloss.NewStyle().
 			Italic(true).
-			Foreground(ColorFg) // soft gray when paused
+			Foreground(ColorFg)
 
 	NowPlayingTitlePlaying = lipgloss.NewStyle().
 				Italic(true).
 				Bold(true).
-				Foreground(lipgloss.Color("#E0D4FF")) // bright lavender when playing
+				Foreground(ColorGlow7)
 
 	NowPlayingArtist = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#C678DD")) // violet
+				Foreground(ColorPrimary)
 
 	NowPlayingAlbum = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6c7086")) // slightly brighter than raw muted
+			Foreground(ColorMuted)
 
-	// ControlActive is used for controls that are in their ON state
-	// (▶ playing, ↺ repeat on, ⇄ shuffle on). Green universally reads as "active".
 	ControlActive = lipgloss.NewStyle().Foreground(ColorActive)
 
 	Playing = lipgloss.NewStyle().
-		Foreground(ColorGlow5) // lavender — status text, vibe panel results
+		Foreground(ColorGlow5)
 
 	Paused = lipgloss.NewStyle().
 		Foreground(ColorMuted)
 
 	VibingStatus = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#585b70")) // slightly warmer muted
+			Foreground(ColorMuted)
 
 	Selected = lipgloss.NewStyle().
 			Foreground(ColorPrimary).
@@ -141,20 +138,22 @@ var (
 	Header = lipgloss.NewStyle().
 		Foreground(ColorAccent)
 
-	// Mode indicator chips — distinct background blocks like nvim mode line
-	ModeNormal  = lipgloss.NewStyle().Background(lipgloss.Color("#98C379")).Foreground(lipgloss.Color("#1a1b26")).Bold(true).Padding(0, 1)
-	ModeSearch  = lipgloss.NewStyle().Background(lipgloss.Color("#61AFEF")).Foreground(lipgloss.Color("#1a1b26")).Bold(true).Padding(0, 1)
-	ModeCommand = lipgloss.NewStyle().Background(lipgloss.Color("#E5C07B")).Foreground(lipgloss.Color("#1a1b26")).Bold(true).Padding(0, 1)
+	ModeNormal  = lipgloss.NewStyle().Background(ColorSecondary).Foreground(ColorBg).Bold(true).Padding(0, 1)
+	ModeSearch  = lipgloss.NewStyle().Background(ColorSubtle).Foreground(ColorBg).Bold(true).Padding(0, 1)
+	ModeCommand = lipgloss.NewStyle().Background(ColorAccentWarm).Foreground(ColorBg).Bold(true).Padding(0, 1)
 
-	// Progress bar — blue filled, dim surface unfilled
 	ProgressBar = lipgloss.NewStyle().Foreground(ColorProgress)
 	ProgressBg  = lipgloss.NewStyle().Foreground(ColorSurface)
 
 	TimeStyle      = lipgloss.NewStyle().Foreground(ColorMuted)
-	NowPlayingTime = lipgloss.NewStyle().Foreground(ColorProgress) // matches progress bar
+	NowPlayingTime = lipgloss.NewStyle().Foreground(ColorProgress)
 
-	// FavoriteActive — rose pink, clearly distinct from ColorError (red)
 	FavoriteActive = lipgloss.NewStyle().Foreground(ColorLove)
+
+	// Bear mascot styles — updated by Apply().
+	BearStyle  = lipgloss.NewStyle().Foreground(ColorBear)
+	NoteStyle  = lipgloss.NewStyle().Foreground(ColorAccentWarm)
+	SleepStyle = lipgloss.NewStyle().Foreground(ColorAccent).Faint(true)
 )
 
 // GlowPalette drives the "now playing" breathing animation, from dark to bright.
@@ -167,6 +166,89 @@ var GlowPalette = []lipgloss.Color{
 	ColorGlow5,
 	ColorGlow6,
 	ColorGlow7, // 7 — peak brightness
+}
+
+// ProgressGradStops are the colour stops for the progress-bar filled gradient
+// (left → right: blue → lavender → rose pink). Updated by Apply().
+var ProgressGradStops = []lipgloss.Color{
+	ColorProgress, // blue
+	ColorGlow6,    // lavender
+	ColorLove,     // rose pink
+}
+
+// Apply replaces every style and color variable with values derived from t.
+// It must be called once at program startup, before any TUI model is created.
+func Apply(t Theme) {
+	// Update color vars.
+	ColorPrimary = lipgloss.Color(t.Primary)
+	ColorSecondary = lipgloss.Color(t.Secondary)
+	ColorMuted = lipgloss.Color(t.Muted)
+	ColorError = lipgloss.Color(t.Error)
+	ColorFg = lipgloss.Color(t.Fg)
+	ColorSubtle = lipgloss.Color(t.Subtle)
+	ColorBg = lipgloss.Color(t.Bg)
+	ColorLove = lipgloss.Color(t.Love)
+	ColorActive = lipgloss.Color(t.Active)
+	ColorProgress = lipgloss.Color(t.Progress)
+	ColorSurface = lipgloss.Color(t.Surface)
+	ColorAccent = lipgloss.Color(t.Accent)
+	ColorAccentWarm = lipgloss.Color(t.AccentWarm)
+	ColorBear = lipgloss.Color(t.Bear)
+	ColorGlow0 = lipgloss.Color(t.GlowPalette[0])
+	ColorGlow1 = lipgloss.Color(t.GlowPalette[1])
+	ColorGlow2 = lipgloss.Color(t.GlowPalette[2])
+	ColorGlow3 = lipgloss.Color(t.GlowPalette[3])
+	ColorGlow4 = lipgloss.Color(t.GlowPalette[4])
+	ColorGlow5 = lipgloss.Color(t.GlowPalette[5])
+	ColorGlow6 = lipgloss.Color(t.GlowPalette[6])
+	ColorGlow7 = lipgloss.Color(t.GlowPalette[7])
+
+	// Update glow slices.
+	GlowPalette = []lipgloss.Color{
+		ColorGlow0, ColorGlow1, ColorGlow2, ColorGlow3,
+		ColorGlow4, ColorGlow5, ColorGlow6, ColorGlow7,
+	}
+	ProgressGradStops = []lipgloss.Color{ColorProgress, ColorGlow6, ColorLove}
+
+	// Recreate style vars.
+	TitleBar = lipgloss.NewStyle().Italic(true).Foreground(ColorPrimary).PaddingLeft(1).PaddingRight(1)
+	ViewName = lipgloss.NewStyle().Foreground(ColorMuted).PaddingLeft(2)
+	StatusBar = lipgloss.NewStyle().Foreground(ColorFg).PaddingLeft(1).PaddingRight(1)
+	NowPlayingLabel = lipgloss.NewStyle().Italic(true).Bold(true).Foreground(ColorAccentWarm)
+	NowPlayingTitle = lipgloss.NewStyle().Italic(true).Foreground(ColorFg)
+	NowPlayingTitlePlaying = lipgloss.NewStyle().Italic(true).Bold(true).Foreground(ColorGlow7)
+	NowPlayingArtist = lipgloss.NewStyle().Foreground(ColorPrimary)
+	NowPlayingAlbum = lipgloss.NewStyle().Foreground(ColorMuted)
+	ControlActive = lipgloss.NewStyle().Foreground(ColorActive)
+	Playing = lipgloss.NewStyle().Foreground(ColorGlow5)
+	Paused = lipgloss.NewStyle().Foreground(ColorMuted)
+	VibingStatus = lipgloss.NewStyle().Foreground(ColorMuted)
+	Selected = lipgloss.NewStyle().Foreground(ColorPrimary).Italic(true)
+	QueueItem = lipgloss.NewStyle().Foreground(ColorFg)
+	QueueItemMuted = lipgloss.NewStyle().Foreground(ColorMuted)
+	Border = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(ColorMuted)
+	KeyHint = lipgloss.NewStyle().Foreground(ColorMuted).PaddingLeft(1)
+	KeyName = lipgloss.NewStyle().Foreground(ColorAccent)
+	ErrorStyle = lipgloss.NewStyle().Foreground(ColorError).Italic(true).PaddingLeft(1)
+	ArtworkFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(ColorPrimary).Padding(1, 2).Align(lipgloss.Center)
+	TabActive = lipgloss.NewStyle().Foreground(ColorAccent).Underline(true).PaddingLeft(1).PaddingRight(1)
+	TabInactive = lipgloss.NewStyle().Foreground(ColorMuted).PaddingLeft(1).PaddingRight(1)
+	Spinner = lipgloss.NewStyle().Foreground(ColorGlow4)
+	SidebarActive = lipgloss.NewStyle().Foreground(ColorGlow5).Italic(true)
+	SidebarInactive = lipgloss.NewStyle().Foreground(ColorMuted)
+	Separator = lipgloss.NewStyle().Foreground(ColorMuted)
+	Header = lipgloss.NewStyle().Foreground(ColorAccent)
+	ModeNormal = lipgloss.NewStyle().Background(ColorSecondary).Foreground(ColorBg).Bold(true).Padding(0, 1)
+	ModeSearch = lipgloss.NewStyle().Background(ColorSubtle).Foreground(ColorBg).Bold(true).Padding(0, 1)
+	ModeCommand = lipgloss.NewStyle().Background(ColorAccentWarm).Foreground(ColorBg).Bold(true).Padding(0, 1)
+	ProgressBar = lipgloss.NewStyle().Foreground(ColorProgress)
+	ProgressBg = lipgloss.NewStyle().Foreground(ColorSurface)
+	TimeStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+	NowPlayingTime = lipgloss.NewStyle().Foreground(ColorProgress)
+	FavoriteActive = lipgloss.NewStyle().Foreground(ColorLove)
+	BearStyle = lipgloss.NewStyle().Foreground(ColorBear)
+	NoteStyle = lipgloss.NewStyle().Foreground(ColorAccentWarm)
+	SleepStyle = lipgloss.NewStyle().Foreground(ColorAccent).Faint(true)
 }
 
 // LerpColor linearly interpolates between two hex colours by factor t ∈ [0,1].

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -1,0 +1,236 @@
+package styles
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// Theme holds every color used by the UI as hex strings (#RRGGBB or #RGB).
+// An empty field falls back to the corresponding value in DefaultTheme.
+type Theme struct {
+	// Core palette
+	Primary   string `json:"primary"`
+	Secondary string `json:"secondary"`
+	Muted     string `json:"muted"`
+	Error     string `json:"error"`
+	Fg        string `json:"fg"`
+	Subtle    string `json:"subtle"`
+	Bg        string `json:"bg"`
+
+	// Semantic accents
+	Love       string `json:"love"`
+	Active     string `json:"active"`
+	Progress   string `json:"progress"`
+	Surface    string `json:"surface"`
+	Accent     string `json:"accent"`
+	AccentWarm string `json:"accent_warm"` // amber — labels, search Tracks header, note animations
+
+	// Bear mascot
+	Bear string `json:"bear"` // bear body colour
+
+	// Glow animation palette — dark (index 0) → bright (index 7)
+	GlowPalette [8]string `json:"glow_palette"`
+
+	// Mode chips (status-bar mode indicator background colours)
+	ModeNormalBg  string `json:"mode_normal_bg"`
+	ModeSearchBg  string `json:"mode_search_bg"`
+	ModeCommandBg string `json:"mode_command_bg"`
+	ModeChipFg    string `json:"mode_chip_fg"` // shared foreground for all mode chips
+}
+
+// DefaultTheme returns the built-in Tokyo Night / Catppuccin Mocha blend.
+func DefaultTheme() Theme {
+	return Theme{
+		Primary:    "#C678DD",
+		Secondary:  "#98C379",
+		Muted:      "#5C6370",
+		Error:      "#E06C75",
+		Fg:         "#ABB2BF",
+		Subtle:     "#61AFEF",
+		Bg:         "#1a1b26",
+		Love:       "#f38ba8",
+		Active:     "#a6e3a1",
+		Progress:   "#89b4fa",
+		Surface:    "#2a2b3d",
+		Accent:     "#7aa2f7",
+		AccentWarm: "#E5C07B",
+		Bear:       "#C4A265",
+		GlowPalette: [8]string{
+			"#1e1e2e", "#2d2b55", "#4a3f8a", "#6e57c4",
+			"#9d7fea", "#bb9af7", "#cba6f7", "#e0d4ff",
+		},
+		ModeNormalBg:  "#98C379",
+		ModeSearchBg:  "#61AFEF",
+		ModeCommandBg: "#E5C07B",
+		ModeChipFg:    "#1a1b26",
+	}
+}
+
+// DraculaTheme returns a Dracula-inspired color scheme.
+func DraculaTheme() Theme {
+	return Theme{
+		Primary:    "#ff79c6",
+		Secondary:  "#50fa7b",
+		Muted:      "#6272a4",
+		Error:      "#ff5555",
+		Fg:         "#f8f8f2",
+		Subtle:     "#8be9fd",
+		Bg:         "#282a36",
+		Love:       "#ff6e6e",
+		Active:     "#50fa7b",
+		Progress:   "#8be9fd",
+		Surface:    "#44475a",
+		Accent:     "#bd93f9",
+		AccentWarm: "#f1fa8c",
+		Bear:       "#ffb86c",
+		GlowPalette: [8]string{
+			"#282a36", "#383a52", "#44475a", "#6272a4",
+			"#9580ff", "#bd93f9", "#caa9fa", "#e9e0ff",
+		},
+		ModeNormalBg:  "#50fa7b",
+		ModeSearchBg:  "#8be9fd",
+		ModeCommandBg: "#f1fa8c",
+		ModeChipFg:    "#282a36",
+	}
+}
+
+// GruvboxTheme returns a Gruvbox Dark-inspired color scheme.
+func GruvboxTheme() Theme {
+	return Theme{
+		Primary:    "#d3869b",
+		Secondary:  "#b8bb26",
+		Muted:      "#928374",
+		Error:      "#fb4934",
+		Fg:         "#ebdbb2",
+		Subtle:     "#83a598",
+		Bg:         "#282828",
+		Love:       "#fe8019",
+		Active:     "#b8bb26",
+		Progress:   "#83a598",
+		Surface:    "#3c3836",
+		Accent:     "#458588",
+		AccentWarm: "#d79921",
+		Bear:       "#e8c88b",
+		GlowPalette: [8]string{
+			"#282828", "#32302f", "#3c3836", "#504945",
+			"#665c54", "#928374", "#d5c4a1", "#ebdbb2",
+		},
+		ModeNormalBg:  "#b8bb26",
+		ModeSearchBg:  "#83a598",
+		ModeCommandBg: "#d79921",
+		ModeChipFg:    "#282828",
+	}
+}
+
+// NordTheme returns a Nord-inspired color scheme.
+func NordTheme() Theme {
+	return Theme{
+		Primary:    "#b48ead",
+		Secondary:  "#a3be8c",
+		Muted:      "#4c566a",
+		Error:      "#bf616a",
+		Fg:         "#eceff4",
+		Subtle:     "#88c0d0",
+		Bg:         "#2e3440",
+		Love:       "#bf616a",
+		Active:     "#a3be8c",
+		Progress:   "#81a1c1",
+		Surface:    "#3b4252",
+		Accent:     "#5e81ac",
+		AccentWarm: "#ebcb8b",
+		Bear:       "#d08770",
+		GlowPalette: [8]string{
+			"#2e3440", "#3b4252", "#434c5e", "#4c566a",
+			"#81a1c1", "#88c0d0", "#8fbcbb", "#eceff4",
+		},
+		ModeNormalBg:  "#a3be8c",
+		ModeSearchBg:  "#88c0d0",
+		ModeCommandBg: "#ebcb8b",
+		ModeChipFg:    "#2e3440",
+	}
+}
+
+var builtinThemes = map[string]func() Theme{
+	"default": DefaultTheme,
+	"dracula": DraculaTheme,
+	"gruvbox": GruvboxTheme,
+	"nord":    NordTheme,
+}
+
+// BuiltinThemeNames returns the sorted list of built-in theme names.
+func BuiltinThemeNames() []string {
+	return []string{"default", "dracula", "gruvbox", "nord"}
+}
+
+// LoadTheme resolves name to a Theme. Resolution order:
+//  1. Built-in theme by name.
+//  2. File at <configDir>/themes/<name>.json.
+//  3. DefaultTheme on any error.
+//
+// The returned error is non-nil when a non-built-in name was requested but
+// the file could not be loaded or parsed. The returned Theme is always usable.
+func LoadTheme(name, configDir string) (Theme, error) {
+	if name == "" || name == "default" {
+		return DefaultTheme(), nil
+	}
+	if fn, ok := builtinThemes[name]; ok {
+		return fn(), nil
+	}
+
+	// Attempt to load a custom JSON theme file.
+	path := filepath.Join(configDir, "themes", name+".json")
+	data, err := os.ReadFile(path) //nolint:gosec // path is user-controlled config, not external input
+	if err != nil {
+		return DefaultTheme(), fmt.Errorf("theme %q: %w", name, err)
+	}
+
+	var t Theme
+	if err := json.Unmarshal(data, &t); err != nil {
+		return DefaultTheme(), fmt.Errorf("theme %q: parsing JSON: %w", name, err)
+	}
+
+	t = mergeWithDefault(t)
+	return t, nil
+}
+
+var hexColorRE = regexp.MustCompile(`^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
+
+func validColor(s string) bool {
+	return hexColorRE.MatchString(s)
+}
+
+// mergeWithDefault fills any missing or invalid color fields from DefaultTheme.
+func mergeWithDefault(t Theme) Theme {
+	d := DefaultTheme()
+	merge := func(field, def string) string {
+		if !validColor(field) {
+			return def
+		}
+		return field
+	}
+	t.Primary = merge(t.Primary, d.Primary)
+	t.Secondary = merge(t.Secondary, d.Secondary)
+	t.Muted = merge(t.Muted, d.Muted)
+	t.Error = merge(t.Error, d.Error)
+	t.Fg = merge(t.Fg, d.Fg)
+	t.Subtle = merge(t.Subtle, d.Subtle)
+	t.Bg = merge(t.Bg, d.Bg)
+	t.Love = merge(t.Love, d.Love)
+	t.Active = merge(t.Active, d.Active)
+	t.Progress = merge(t.Progress, d.Progress)
+	t.Surface = merge(t.Surface, d.Surface)
+	t.Accent = merge(t.Accent, d.Accent)
+	t.AccentWarm = merge(t.AccentWarm, d.AccentWarm)
+	t.Bear = merge(t.Bear, d.Bear)
+	t.ModeNormalBg = merge(t.ModeNormalBg, d.ModeNormalBg)
+	t.ModeSearchBg = merge(t.ModeSearchBg, d.ModeSearchBg)
+	t.ModeCommandBg = merge(t.ModeCommandBg, d.ModeCommandBg)
+	t.ModeChipFg = merge(t.ModeChipFg, d.ModeChipFg)
+	for i := range t.GlowPalette {
+		t.GlowPalette[i] = merge(t.GlowPalette[i], d.GlowPalette[i])
+	}
+	return t
+}

--- a/internal/tui/styles/theme_test.go
+++ b/internal/tui/styles/theme_test.go
@@ -1,0 +1,176 @@
+package styles_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/simone-vibes/vibez/internal/tui/styles"
+)
+
+func TestLoadTheme_BuiltIn(t *testing.T) {
+	for _, name := range styles.BuiltinThemeNames() {
+		t.Run(name, func(t *testing.T) {
+			theme, err := styles.LoadTheme(name, "/tmp")
+			if err != nil {
+				t.Fatalf("unexpected error for built-in %q: %v", name, err)
+			}
+			if theme.Primary == "" {
+				t.Errorf("expected non-empty Primary for theme %q", name)
+			}
+		})
+	}
+}
+
+func TestLoadTheme_Default(t *testing.T) {
+	d := styles.DefaultTheme()
+	for _, name := range []string{"", "default"} {
+		theme, err := styles.LoadTheme(name, "/tmp")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", name, err)
+		}
+		if theme.Primary != d.Primary {
+			t.Errorf("expected default primary %q, got %q", d.Primary, theme.Primary)
+		}
+	}
+}
+
+func TestLoadTheme_BuiltInsHaveDistinctColors(t *testing.T) {
+	def := styles.DefaultTheme()
+	for _, name := range []string{"dracula", "gruvbox", "nord"} {
+		theme, _ := styles.LoadTheme(name, "/tmp")
+		if theme.Primary == def.Primary {
+			t.Errorf("theme %q has same Primary as default; expected distinct color", name)
+		}
+	}
+}
+
+func TestLoadTheme_Custom(t *testing.T) {
+	dir := t.TempDir()
+	themesDir := filepath.Join(dir, "themes")
+	if err := os.MkdirAll(themesDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	custom := styles.DefaultTheme()
+	custom.Primary = "#ff0000"
+	custom.Bear = "#00ff00"
+
+	data, _ := json.Marshal(custom)
+	if err := os.WriteFile(filepath.Join(themesDir, "mycolor.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	theme, err := styles.LoadTheme("mycolor", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if theme.Primary != "#ff0000" {
+		t.Errorf("expected Primary #ff0000, got %q", theme.Primary)
+	}
+	if theme.Bear != "#00ff00" {
+		t.Errorf("expected Bear #00ff00, got %q", theme.Bear)
+	}
+}
+
+func TestLoadTheme_InvalidColor_FallsBackToDefault(t *testing.T) {
+	dir := t.TempDir()
+	themesDir := filepath.Join(dir, "themes")
+	_ = os.MkdirAll(themesDir, 0o700)
+
+	raw := `{"primary": "notacolor", "secondary": "#50fa7b"}`
+	_ = os.WriteFile(filepath.Join(themesDir, "bad.json"), []byte(raw), 0o600)
+
+	theme, err := styles.LoadTheme("bad", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	def := styles.DefaultTheme()
+	if theme.Primary != def.Primary {
+		t.Errorf("expected invalid Primary to fall back to %q, got %q", def.Primary, theme.Primary)
+	}
+	if theme.Secondary != "#50fa7b" {
+		t.Errorf("expected valid Secondary to be kept, got %q", theme.Secondary)
+	}
+}
+
+func TestLoadTheme_UnknownName_FallsBackToDefault(t *testing.T) {
+	theme, err := styles.LoadTheme("nonexistent-theme", "/tmp")
+	if err == nil {
+		t.Error("expected error for unknown theme, got nil")
+	}
+	def := styles.DefaultTheme()
+	if theme.Primary != def.Primary {
+		t.Errorf("expected default Primary %q, got %q", def.Primary, theme.Primary)
+	}
+}
+
+func TestLoadTheme_CustomGlowPalette_PartialDefault(t *testing.T) {
+	dir := t.TempDir()
+	themesDir := filepath.Join(dir, "themes")
+	_ = os.MkdirAll(themesDir, 0o700)
+
+	// Only first glow entry valid, rest invalid/empty.
+	raw := `{"glow_palette": ["#000000","","","","","","",""]}`
+	_ = os.WriteFile(filepath.Join(themesDir, "glow.json"), []byte(raw), 0o600)
+
+	theme, _ := styles.LoadTheme("glow", dir)
+	if theme.GlowPalette[0] != "#000000" {
+		t.Errorf("expected GlowPalette[0] to be #000000, got %q", theme.GlowPalette[0])
+	}
+	def := styles.DefaultTheme()
+	for i := 1; i < 8; i++ {
+		if theme.GlowPalette[i] != def.GlowPalette[i] {
+			t.Errorf("expected GlowPalette[%d] to fall back to default %q, got %q",
+				i, def.GlowPalette[i], theme.GlowPalette[i])
+		}
+	}
+}
+
+func TestApply_NoPanic(t *testing.T) {
+	for _, name := range styles.BuiltinThemeNames() {
+		t.Run(name, func(t *testing.T) {
+			theme, _ := styles.LoadTheme(name, "/tmp")
+			styles.Apply(theme) // must not panic
+		})
+	}
+	// Restore default.
+	styles.Apply(styles.DefaultTheme())
+}
+
+func TestApply_ChangesColors(t *testing.T) {
+	orig := styles.ColorPrimary
+
+	styles.Apply(styles.DraculaTheme())
+	if styles.ColorPrimary == orig {
+		t.Error("expected ColorPrimary to change after Apply(DraculaTheme)")
+	}
+	if string(styles.ColorPrimary) != styles.DraculaTheme().Primary {
+		t.Errorf("expected ColorPrimary %q, got %q", styles.DraculaTheme().Primary, styles.ColorPrimary)
+	}
+
+	// Restore.
+	styles.Apply(styles.DefaultTheme())
+	if styles.ColorPrimary != orig {
+		t.Errorf("expected ColorPrimary restored to %q, got %q", orig, styles.ColorPrimary)
+	}
+}
+
+func TestApply_UpdatesProgressGradStops(t *testing.T) {
+	styles.Apply(styles.DraculaTheme())
+	d := styles.DraculaTheme()
+	if string(styles.ProgressGradStops[0]) != d.Progress {
+		t.Errorf("ProgressGradStops[0] = %q, want %q", styles.ProgressGradStops[0], d.Progress)
+	}
+	styles.Apply(styles.DefaultTheme())
+}
+
+func TestApply_UpdatesGlowPalette(t *testing.T) {
+	styles.Apply(styles.NordTheme())
+	n := styles.NordTheme()
+	if string(styles.GlowPalette[0]) != n.GlowPalette[0] {
+		t.Errorf("GlowPalette[0] = %q, want %q", styles.GlowPalette[0], n.GlowPalette[0])
+	}
+	styles.Apply(styles.DefaultTheme())
+}

--- a/internal/tui/views/bear.go
+++ b/internal/tui/views/bear.go
@@ -36,12 +36,6 @@ var danceFrames = []bearFrame{
 	{above: "♪", expr: "ʕ•ᴥ•ʔゝ☆"},
 }
 
-var (
-	bearStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#C4A265"))
-	noteStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5C07B"))
-	sleepStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#7aa2f7")).Faint(true)
-)
-
 // RenderBearLine returns a single animated line: bear kaomoji + note/z + status text.
 // Used in the Now Playing section.
 func RenderBearLine(step int, playing bool) string {
@@ -54,14 +48,14 @@ func RenderBearLine(step int, playing bool) string {
 			note = f.below
 		}
 		status := styles.VibingStatus.Render("vibing...")
-		return bearStyle.Render(f.expr) + noteStyle.Render(note) + " " + status
+		return styles.BearStyle.Render(f.expr) + styles.NoteStyle.Render(note) + " " + status
 	}
 	f := sleepFrames[(step/12)%len(sleepFrames)]
 	zz := ""
 	if f.above != "" {
-		zz = sleepStyle.Render(f.above) + " "
+		zz = styles.SleepStyle.Render(f.above) + " "
 	}
-	return zz + bearStyle.Render(f.expr) + " " + sleepStyle.Render("zZz...")
+	return zz + styles.BearStyle.Render(f.expr) + " " + styles.SleepStyle.Render("zZz...")
 }
 
 // BearExpr returns just the styled bear kaomoji for the current animation step.
@@ -69,10 +63,10 @@ func RenderBearLine(step int, playing bool) string {
 func BearExpr(step int, playing bool) string {
 	if playing {
 		f := danceFrames[(step/6)%len(danceFrames)]
-		return bearStyle.Render(f.expr)
+		return styles.BearStyle.Render(f.expr)
 	}
 	f := sleepFrames[(step/12)%len(sleepFrames)]
-	return bearStyle.Render(f.expr)
+	return styles.BearStyle.Render(f.expr)
 }
 
 // RenderBear returns exactly BearLines centred lines.
@@ -83,17 +77,17 @@ func RenderBear(step int, playing bool, width int) string {
 
 	if playing {
 		f = danceFrames[(step/6)%len(danceFrames)]
-		annot = noteStyle
+		annot = styles.NoteStyle
 	} else {
 		f = sleepFrames[(step/12)%len(sleepFrames)] // slower: ≈960 ms/frame
-		annot = sleepStyle
+		annot = styles.SleepStyle
 	}
 
 	above := ""
 	if f.above != "" {
 		above = centerLine(annot.Render(f.above), width)
 	}
-	bear := centerLine(bearStyle.Render(f.expr), width)
+	bear := centerLine(styles.BearStyle.Render(f.expr), width)
 	below := ""
 	if f.below != "" {
 		below = centerLine(annot.Render(f.below), width)

--- a/internal/tui/views/nowplaying.go
+++ b/internal/tui/views/nowplaying.go
@@ -47,28 +47,21 @@ func FormatDuration(d time.Duration) string {
 // wavePattern is the repeating 4-char zigzag used for the progress bar wave.
 var wavePattern = []rune{'╱', '╱', '╲', '╲'}
 
-// gradStops are the colour stops for the filled-portion gradient
-// (cornflower blue → lavender → rose pink).
-var gradStops = []lipgloss.Color{
-	styles.ColorProgress,      // #89b4fa — blue
-	lipgloss.Color("#cba6f7"), // lavender
-	styles.ColorLove,          // #f38ba8 — rose pink
-}
-
 // progressGradient returns the gradient colour for position i out of total
-// cells, interpolating across gradStops.
+// cells, interpolating across styles.ProgressGradStops.
 func progressGradient(i, total int) lipgloss.Color {
-	if total <= 1 || len(gradStops) < 2 {
-		return gradStops[0]
+	stops := styles.ProgressGradStops
+	if total <= 1 || len(stops) < 2 {
+		return stops[0]
 	}
-	segments := len(gradStops) - 1
+	segments := len(stops) - 1
 	t := float64(i) / float64(total-1) // 0.0 … 1.0
 	seg := int(t * float64(segments))
 	if seg >= segments {
-		return gradStops[len(gradStops)-1]
+		return stops[len(stops)-1]
 	}
 	local := t*float64(segments) - float64(seg)
-	return styles.LerpColor(gradStops[seg], gradStops[seg+1], local)
+	return styles.LerpColor(stops[seg], stops[seg+1], local)
 }
 
 // RenderProgressBar renders a static flat zigzag (╱╱╲╲) progress bar.

--- a/internal/tui/views/search.go
+++ b/internal/tui/views/search.go
@@ -282,7 +282,7 @@ func sectionColor(label string) lipgloss.Color {
 	case "Playlists":
 		return styles.ColorSecondary // green  #98C379
 	default: // "Tracks"
-		return lipgloss.Color("#E5C07B") // warm amber — same as NowPlayingLabel
+		return styles.ColorAccentWarm // warm amber
 	}
 }
 

--- a/internal/tui/views/vibe.go
+++ b/internal/tui/views/vibe.go
@@ -255,7 +255,7 @@ func (v *VibeModel) Lines(w, h, step int) []string {
 	errSt := lipgloss.NewStyle().Foreground(styles.ColorError)
 
 	thinkFrames := []string{"ʕ•ᴥ•ʔ", "ʕ·ᴥ·ʔ", "ʕ˘ᴥ˘ʔ", "ʕ•̀ᴥ•́ʔ"}
-	bear := bearStyle.Render(thinkFrames[(step/10)%len(thinkFrames)])
+	bear := styles.BearStyle.Render(thinkFrames[(step/10)%len(thinkFrames)])
 
 	v.input.Width = max(w-4, 10)
 
@@ -392,7 +392,7 @@ func (v *VibeModel) Lines(w, h, step int) []string {
 			label, sep,
 			muted.Render(`"` + clip(v.lastQ, 0) + `"`),
 			"",
-			bearStyle.Render("ʕ•̀ᴥ•́ʔ") + " " + errSt.Render("no results"),
+			styles.BearStyle.Render("ʕ•̀ᴥ•́ʔ") + " " + errSt.Render("no results"),
 			"",
 			accent.Render("v") + muted.Render(" try again") +
 				"  " + accent.Render("d") + muted.Render(" set metric"),


### PR DESCRIPTION
Closes #14

## Summary

Introduces a full theming system — users can switch the entire colour palette by setting `"theme"` in `~/.config/vibez/config.json` and optionally writing a custom JSON file.

## Built-in themes

| Name | Inspiration |
|------|-------------|
| `default` | Tokyo Night / Catppuccin Mocha |
| `dracula` | Dracula |
| `gruvbox` | Gruvbox Dark |
| `nord` | Nord |

## Custom themes

Drop a file at `~/.config/vibez/themes/<name>.json` with any subset of the 20 color roles — missing or invalid hex values fall back to `default` automatically:

```json
{
  "primary": "#ff79c6",
  "secondary": "#50fa7b",
  "accent": "#bd93f9",
  "bg": "#282a36"
}
```

Then set `"theme": "<name>"` in `config.json` and restart.

## Technical details

- `Color*` identifiers converted from `const` to `var` so `Apply(Theme)` can swap the full palette at startup before any TUI model is created
- `Apply()` rewrites every color var, `GlowPalette`, `ProgressGradStops`, and all lipgloss style vars in one call — covers bear mascot, progress-bar gradient, glow animation, mode chips, and every UI element
- Hardcoded hex literals removed from `bear.go`, `nowplaying.go`, `search.go`, and `vibe.go`
- `LoadTheme()` called in `cmd/root.go` before any TUI model is created (both CDP and WebKit paths)
- 10 new tests covering built-in resolution, custom JSON loading, invalid color fallback, partial glow-palette merging, and `Apply()` assertions