### PR TITLE
fix(fav): pass catalogId in player state to fix 400 on library tracks

### DIFF
--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -353,6 +353,7 @@ type jsState struct {
 
 type jsTrack struct {
 	ID         string `json:"id"`
+	CatalogID  string `json:"catalogId"`
 	Title      string `json:"title"`
 	Artist     string `json:"artist"`
 	Album      string `json:"album"`
@@ -372,6 +373,7 @@ func (p *Player) applyState(js jsState) {
 	if js.NowPlaying != nil {
 		s.Track = &provider.Track{
 			ID:         js.NowPlaying.ID,
+			CatalogID:  js.NowPlaying.CatalogID,
 			Title:      js.NowPlaying.Title,
 			Artist:     js.NowPlaying.Artist,
 			Album:      js.NowPlaying.Album,

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -83,6 +83,7 @@
           volume:        1.0,
           nowPlaying: {
             id:         item.id,
+            catalogId:  item.attributes.playParams?.catalogId || '',
             title:      item.attributes.name,
             artist:     item.attributes.artistName,
             album:      item.attributes.albumName,
@@ -146,6 +147,7 @@
             shuffleMode:   m.shuffleMode || 0,
             nowPlaying: item ? {
               id:         item.id,
+              catalogId:  item.attributes.playParams?.catalogId || '',
               title:      item.attributes.name,
               artist:     item.attributes.artistName,
               album:      item.attributes.albumName,

--- a/internal/player/webkit/player.go
+++ b/internal/player/webkit/player.go
@@ -41,6 +41,7 @@ type jsState struct {
 
 type jsTrack struct {
 	ID         string `json:"id"`
+	CatalogID  string `json:"catalogId"`
 	Title      string `json:"title"`
 	Artist     string `json:"artist"`
 	Album      string `json:"album"`
@@ -320,6 +321,7 @@ func (p *Player) applyState(js jsState) {
 	if js.NowPlaying != nil {
 		s.Track = &provider.Track{
 			ID:         js.NowPlaying.ID,
+			CatalogID:  js.NowPlaying.CatalogID,
 			Title:      js.NowPlaying.Title,
 			Artist:     js.NowPlaying.Artist,
 			Album:      js.NowPlaying.Album,

--- a/internal/player/webkit/web/musickit.html
+++ b/internal/player/webkit/web/musickit.html
@@ -66,6 +66,7 @@
           volume:        1.0,
           nowPlaying: {
             id:         item.id,
+            catalogId:  item.attributes.playParams?.catalogId || '',
             title:      item.attributes.name,
             artist:     item.attributes.artistName,
             album:      item.attributes.albumName,
@@ -123,6 +124,7 @@
             shuffleMode:   m.shuffleMode || 0,
             nowPlaying: item ? {
               id:         item.id,
+              catalogId:  item.attributes.playParams?.catalogId || '',
               title:      item.attributes.name,
               artist:     item.attributes.artistName,
               album:      item.attributes.albumName,


### PR DESCRIPTION
## Summary

Fixes a 400 Bad Request "Invalid Path Value" error when trying to favourite/heart a track played from the user's Apple Music library.

## Root Cause

The Apple Music ratings API (`/v1/me/ratings/songs/{id}`) only accepts **numeric catalog IDs**, not library IDs (which have the form `i.XXXXX`).

For library songs, MusicKit exposes the library ID as `item.id`, while the real catalog ID lives in `item.attributes.playParams.catalogId`. The JS state notification was only forwarding `item.id`, so `Track.CatalogID` was always empty in Go. `loveSongCmd` then fell back to `Track.ID` (`i.XXXXX`) as the catalog ID → 400.

## Changes

- **musickit.html** (both CDP and WebKit copies): add `catalogId: item.attributes.playParams?.catalogId || ''` to the `nowPlaying` payload in `notifyState()` and `notifyStateFromItem()`
- **cdp/player.go** and **webkit/player.go**: add `CatalogID` field to `jsTrack` and propagate to `provider.Track.CatalogID`

No changes needed in `model.go` — `loveSongCmd` and `checkSongRatingCmd` already prefer `Track.CatalogID` when non-empty.

Closes #18