### PR TITLE
fix: eliminate 500ms TUI freeze on track change

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,91 @@
+# vibez — Copilot instructions
+
+vibez is a terminal Apple Music player written in Go. It streams via MusicKit JS
+running in a headless Chromium instance (CDP), and renders a TUI with Bubbletea v2.
+
+## Build & test
+
+```bash
+# Required system libs (Ubuntu/Debian)
+sudo apt-get install -y libwebkit2gtk-4.1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+
+# Always set PKG_CONFIG_PATH when building or testing
+PKG_CONFIG_PATH=$PWD/pkg-config go build ./...
+PKG_CONFIG_PATH=$PWD/pkg-config go test ./...
+```
+
+## Architecture
+
+```
+TUI (Bubbletea v2)
+  └── model.go — all player state, key handling, rendering
+        └── waitForState() — drains channel, returns latest state
+
+CDP player (internal/player/cdp/player.go)
+  └── applyState()  — JSON → player.State → fan-out to subscriber channels
+  └── dispatch()    — fire-and-forget goroutine (never block inside)
+  └── Subscribe()   — returns chan player.State (buffer=8)
+
+musickit.html (internal/player/web/musickit.html)
+  └── notifyState() — pushes state to Go via goPlayerStateChange binding
+  └── _doPlayAt()   — queues and plays a track
+  └── _stopAndWait() — waits only when mid-seek (states 6/7)
+  └── setInterval(notifyState, 200) — unconditional 200ms polling
+```
+
+### JS → Go state flow
+
+`goPlayerStateChange(JSON)` is a Playwright binding — async, non-blocking from Go's
+perspective. This is the **only** safe way to push state from JS to Go at any frequency.
+
+### CRITICAL: never call `page.Evaluate` at high frequency
+
+`page.Evaluate` in Playwright-Go is **synchronous and blocking**: it serialises ALL
+CDP traffic over a single WebSocket. Calling it faster than ~2 Hz will starve the
+`goPlayerStateChange` callbacks, causing a deadlock that can freeze the entire machine.
+
+**Rule:** all state polling must stay inside JavaScript via `setInterval`. Go only
+receives on the subscription channel.
+
+## MusicKit playback states
+
+| Value | Name      | Notes                          |
+|-------|-----------|--------------------------------|
+| 0     | none      |                                |
+| 1     | loading   | → Go `Loading=true`            |
+| 2     | playing   |                                |
+| 3     | paused    |                                |
+| 4     | stopped   |                                |
+| 5     | ended     |                                |
+| 6     | seekFwd   | → Go `Loading=true`; CE risk   |
+| 7     | seekBwd   | → Go `Loading=true`; CE risk   |
+| 8     | waiting   | → Go `Loading=true`            |
+| 9     | completed | natural auto-advance           |
+| 10    | completed | natural auto-advance           |
+
+**CE risk**: calling `setQueue` during states 6 or 7 triggers a spurious
+`CONTENT_EQUIVALENT` error. `_stopAndWait` guards against this.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `internal/player/web/musickit.html` | JS player; all MusicKit state management |
+| `internal/player/cdp/player.go` | CDP/Playwright Go side; state delivery |
+| `internal/tui/model.go` | TUI model; key handling, rendering |
+| `internal/tui/model_test.go` | Full test suite |
+
+## Bubbletea v2 test format
+
+```go
+// Key press (v2 format)
+tea.KeyPressMsg{Code: tea.KeyRune, Text: "n"}
+tea.KeyPressMsg{Code: tea.KeyEsc}
+```
+
+## Common pitfalls
+
+- **Do not** add `setInterval` calls from Go (via `page.Evaluate`) — use JS `setInterval` only.
+- **Do not** await `_stopAndWait` for completed/playing/paused states — only needed for seekFwd/seekBwd.
+- When adding new CDP bindings, always use `dispatch()` (fire-and-forget) on the Go side.
+- The TUI renderer runs at 60 FPS independently; `View()` must stay under ~1ms.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,31 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+
+      - name: Download Go modules
+        run: PKG_CONFIG_PATH=${{ github.workspace }}/pkg-config go mod download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Closes #14.
 
 ### Fixed
+- **TUI freezes ~500 ms on every track change** — `_stopAndWait` used
+  `stable = {none, stopped}` as its exit condition. After natural auto-advance
+  MusicKit enters state 9/10 (completed), which is never in that set, so every
+  transition hit the full 500 ms timeout before `setQueue` was called. During
+  this window no state events reached Go and the position poll was gated on
+  `isPlaying`, so the TUI appeared frozen even though audio played immediately.
+  `_stopAndWait` now only blocks when the player is mid-seek (seekFwd=6 /
+  seekBwd=7) — the only states that cause spurious `CONTENT_EQUIVALENT` errors —
+  and resolves instantly for all other states. The fallback timeout was reduced
+  from 500 ms to 200 ms. The `setInterval` position poll was changed from
+  "every 1 s while playing" to unconditional every 200 ms so transition states
+  reach Go without delay. Closes #23.
 - **Title glow and bear animation speed up on each track change** — a redundant
   `glowTick()` was spawned every time playback started, stacking on top of the
   one already running from `Init()`. After N track changes the glow step counter

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -162,8 +162,9 @@
         music.addEventListener('playbackStateDidChange',  notifyState);
         music.addEventListener('nowPlayingItemDidChange', notifyState);
 
-        // Poll position every second so the TUI timer advances while playing.
-        setInterval(function() { if (_m().isPlaying) notifyState(); }, 1000);
+        // Poll position every 200 ms so the TUI timer advances and transitions
+        // (completed → loading → playing) reach Go without delay.
+        setInterval(notifyState, 200);
 
         // Shorthand: send a debug-only log entry (never shown in status bar).
         const _stateN = ['none','loading','playing','paused','stopped','ended','seekFwd','seekBwd','waiting','completed','completed'];
@@ -234,18 +235,17 @@
           return items;
         }
 
-        // Stop playback and wait (event-driven) for MusicKit to fully settle in
-        // stopped(4) or none(0) state before returning.  m.stop() resolves its
-        // Promise as soon as the command is sent, but MusicKit still goes through
-        // intermediate states (paused→seekFwd→paused→stopped).  Calling setQueue
-        // during that transition triggers CONTENT_EQUIVALENT even for unrelated
-        // songs.  500 ms cap prevents hanging if the event never fires.
+        // Wait (event-driven) for MusicKit to leave a mid-seek state before
+        // calling setQueue.  Only seekFwd(6) and seekBwd(7) cause spurious
+        // CONTENT_EQUIVALENT errors on setQueue; all other states (playing,
+        // paused, completed, none, stopped) are safe to proceed immediately.
+        // 200 ms cap prevents hanging if the event never fires.
         function _stopAndWait(m) {
-          const stable = [0, 4]; // none, stopped
-          if (stable.includes(m.playbackState)) return Promise.resolve();
+          const seeking = [6, 7]; // seekFwd, seekBwd
+          if (!seeking.includes(m.playbackState)) return Promise.resolve();
           return new Promise(resolve => {
             const handler = () => {
-              if (stable.includes(m.playbackState)) {
+              if (!seeking.includes(m.playbackState)) {
                 m.removeEventListener('playbackStateDidChange', handler);
                 clearTimeout(t);
                 resolve();
@@ -254,9 +254,8 @@
             const t = setTimeout(() => {
               m.removeEventListener('playbackStateDidChange', handler);
               resolve();
-            }, 500);
+            }, 200);
             m.addEventListener('playbackStateDidChange', handler);
-            m.stop().catch(() => {});
           });
         }
 
@@ -294,8 +293,8 @@
         }
 
         // Play the item at idx in _q.
-        // Waits for MusicKit to fully settle in stopped state before setQueue so
-        // mid-transition states (seekFwd etc.) don't trigger spurious CE errors.
+        // Waits only if mid-seek (seekFwd/seekBwd) before setQueue to avoid
+        // spurious CONTENT_EQUIVALENT errors; all other states proceed instantly.
         // CONTENT_EQUIVALENT / CONTENT_UNAVAILABLE → library fallback then skip.
         // _busy + _wantIdx ensure only one call runs at a time; latest index wins.
         async function _doPlayAt(idx) {


### PR DESCRIPTION
Fixes #23

## What changed

Two targeted changes to `internal/player/web/musickit.html`:

### 1. Fix `_stopAndWait` — only block on mid-seek states

**Before:** waited for states `{none=0, stopped=4}` — called `m.stop()` and held up `setQueue` for up to 500 ms on every transition.

**After:** only blocks when `playbackState ∈ {seekFwd=6, seekBwd=7}` — the only states that genuinely cause `CONTENT_EQUIVALENT` errors. Timeout reduced to 200 ms.

### 2. Fix `setInterval` — fire unconditionally at 200 ms

**Before:** `setInterval(function() { if (_m().isPlaying) notifyState(); }, 1000)` — silently dropped all state during transitions because `isPlaying=false`.

**After:** `setInterval(notifyState, 200)` — state reaches Go every 200 ms regardless, so the TUI updates promptly during completed→loading→playing transitions.