### PR TITLE
feat: auto-update on startup loading screen

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     gobinary: ./scripts/garble-go
     ldflags:
       - -s -w
+      - -X 'github.com/simone-vibes/vibez/internal/version.Version={{ .Version }}'
       - -X 'github.com/simone-vibes/vibez/internal/auth.devToken={{ .Env.APPLE_DEV_TOKEN }}'
     env:
       - CGO_ENABLED=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Auto-update** — on startup vibez checks GitHub for a newer release (once per 24 h).
+  Progress is shown on the TUI loading screen alongside the Chrome download / auth steps.
+  If an update is available the binary is downloaded, its SHA-256 checksum is verified
+  against the published `checksums.txt`, the binary is atomically replaced, the TUI quits
+  cleanly, and the process re-execs the new binary transparently.
+  Pass `--no-update` to skip the check. Closes #26.
+
 ---
 
 ## [0.0.9] — 2026-04-30

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -21,6 +22,8 @@ import (
 	demoProvider "github.com/simone-vibes/vibez/internal/provider/demo"
 	"github.com/simone-vibes/vibez/internal/tui"
 	"github.com/simone-vibes/vibez/internal/tui/styles"
+	"github.com/simone-vibes/vibez/internal/updater"
+	"github.com/simone-vibes/vibez/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +31,7 @@ var cfgFile string
 var debug bool
 var memProfiling bool
 var demo bool
+var noUpdate bool
 
 var rootCmd = &cobra.Command{
 	Use:   "vibez",
@@ -48,6 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().BoolVar(&memProfiling, "mem-profiling", false, "show live RSS for vibez and its Chrome helper in the header")
 	rootCmd.PersistentFlags().BoolVar(&demo, "demo", false, "run with built-in fake data — no Apple account or internet required")
+	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "skip automatic update check on startup")
 }
 
 func runTUI(_ *cobra.Command, _ []string) error {
@@ -132,9 +137,21 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 	playerCh := make(chan *cdp.Player, 1)
 	// runDone is closed after cdpPlayer.Run() returns (browser + pw shutdown).
 	runDone := make(chan struct{})
+	// restartExe is set when an update has been installed; non-empty means we
+	// should re-exec after the TUI exits cleanly.
+	restartExe := make(chan string, 1)
 
 	go func() {
-		// Step 1: Ensure Chrome is installed — may download ~130 MB on first run.
+		// Step 1: Check for updates — shows on the loading screen.
+		if exe := updater.CheckAndUpdate(version.Version, noUpdate, func(msg string) {
+			prog.Send(tui.InitStatusMsg(msg))
+		}); exe != "" {
+			restartExe <- exe
+			prog.Send(tui.RestartMsg{})
+			return
+		}
+
+		// Step 2: Ensure Chrome is installed — may download ~130 MB on first run.
 		prog.Send(tui.InitStatusMsg("Initializing vibez…"))
 		if err := cdp.EnsureBrowser(func(msg string) {
 			prog.Send(tui.InitStatusMsg(msg))
@@ -143,7 +160,7 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 			return
 		}
 
-		// Step 2: Auth — opens the system browser; TUI shows status.
+		// Step 3: Auth — opens the system browser; TUI shows status.
 		if cfg.AppleUserToken == "" {
 			prog.Send(tui.InitStatusMsg("Authorizing with Apple Music…"))
 			if err := auth.Login(cfg); err != nil {
@@ -152,7 +169,7 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 			}
 		}
 
-		// Step 3: Start engine — Chrome launches headless because token is already set.
+		// Step 4: Start engine — Chrome launches headless because token is already set.
 		prog.Send(tui.InitStatusMsg("Starting audio engine…"))
 		cdpPlayer, err := cdp.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront)
 		if err != nil {
@@ -233,6 +250,14 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 		<-runDone     // wait for browser.Close() + pw.Stop() to finish
 	default:
 		// Player was never started (init failed); nothing to clean up.
+	}
+
+	// If an update was installed, re-exec now that the TUI has exited cleanly
+	// and the terminal is restored to its normal state.
+	select {
+	case exe := <-restartExe:
+		_ = syscall.Exec(exe, os.Args, os.Environ()) //nolint:gosec // intentional self-re-exec after update
+	default:
 	}
 
 	return err

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -32,6 +32,10 @@ type EngineReadyMsg struct {
 // InitErrMsg is sent when initialization fails fatally.
 type InitErrMsg struct{ Err error }
 
+// RestartMsg is sent when vibez has self-updated and needs to re-exec.
+// The model handles it by quitting cleanly so the caller can exec the new binary.
+type RestartMsg struct{}
+
 // DebugLogMsg appends a line to the TUI debug log (visible via :debug-logs).
 // Use this to surface background-goroutine events (e.g. scrobbling) without
 // printing to stderr.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -808,6 +808,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.errMsg = "✓ Re-authenticated with Apple Music"
 		m.errExpiry = time.Now().Add(5 * time.Second)
 
+	case RestartMsg:
+		return m, tea.Quit
+
 	case tea.KeyPressMsg:
 		cmd := m.handleKey(msg)
 		cmds = append(cmds, cmd)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,324 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	repo          = "simonepelosi/vibez"
+	apiURL        = "https://api.github.com/repos/" + repo + "/releases/latest"
+	checkInterval = 24 * time.Hour
+	apiTimeout    = 5 * time.Second
+	dlTimeout     = 2 * time.Minute
+	// maxBinarySize caps extraction to guard against decompression bombs.
+	maxBinarySize = 256 << 20 // 256 MB
+)
+
+type ghRelease struct {
+	TagName string    `json:"tag_name"`
+	Assets  []ghAsset `json:"assets"`
+}
+
+type ghAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// CheckAndUpdate checks GitHub for a newer release. If one is found it
+// downloads, verifies the SHA-256 checksum, and installs it in-place.
+// It returns the path of the updated binary when a restart is needed, or ""
+// when already up to date, on error, or when noUpdate is true.
+//
+// The caller is responsible for re-execing after cleaning up (e.g. after the
+// TUI exits). All errors are handled internally — the function never blocks
+// startup fatally.
+func CheckAndUpdate(current string, noUpdate bool, log func(string)) string {
+	if noUpdate {
+		return ""
+	}
+	if !shouldCheck() {
+		return ""
+	}
+
+	log("Checking for updates…")
+
+	rel, err := fetchLatestRelease()
+	if err != nil {
+		return ""
+	}
+
+	markChecked()
+
+	if !isNewer(rel.TagName, current) {
+		return ""
+	}
+
+	assetName := fmt.Sprintf("vibez_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	var downloadURL, checksumURL string
+	for _, a := range rel.Assets {
+		switch a.Name {
+		case assetName:
+			downloadURL = a.BrowserDownloadURL
+		case "checksums.txt":
+			checksumURL = a.BrowserDownloadURL
+		}
+	}
+	if downloadURL == "" {
+		return "" // no asset for this platform
+	}
+
+	// Only attempt self-update for writable, self-managed installs.
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return ""
+	}
+	if !isWritable(exe) {
+		return ""
+	}
+
+	log(fmt.Sprintf("Downloading update %s…", rel.TagName))
+
+	tmpDir, err := os.MkdirTemp("", "vibez-update-*")
+	if err != nil {
+		return ""
+	}
+
+	tarPath := filepath.Join(tmpDir, assetName)
+	if err := downloadFile(downloadURL, tarPath); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return ""
+	}
+
+	if checksumURL != "" {
+		if err := verifyChecksum(tarPath, assetName, checksumURL); err != nil {
+			log("Update aborted: checksum verification failed")
+			_ = os.RemoveAll(tmpDir)
+			return ""
+		}
+	}
+
+	log("Installing update…")
+
+	newBin := filepath.Join(tmpDir, "vibez")
+	if err := extractBinary(tarPath, "vibez", newBin); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return ""
+	}
+	if err := os.Chmod(newBin, 0o755); err != nil { //nolint:gosec // executables require 0755
+		_ = os.RemoveAll(tmpDir)
+		return ""
+	}
+
+	// Atomic replace: write to exe.new, rename over exe.
+	tmpBin := exe + ".new"
+	data, err := os.ReadFile(newBin) //nolint:gosec // path comes from our own tmpDir
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return ""
+	}
+	if err := os.WriteFile(tmpBin, data, 0o755); err != nil { //nolint:gosec // executable permissions required
+		_ = os.RemoveAll(tmpDir)
+		return ""
+	}
+	if err := os.Rename(tmpBin, exe); err != nil {
+		_ = os.Remove(tmpBin)
+		_ = os.RemoveAll(tmpDir)
+		return ""
+	}
+
+	log(fmt.Sprintf("Updated to %s — restarting…", rel.TagName))
+	_ = os.RemoveAll(tmpDir)
+	return exe
+}
+
+func fetchLatestRelease() (*ghRelease, error) {
+	client := &http.Client{Timeout: apiTimeout}
+	resp, err := client.Get(apiURL) //nolint:gosec // URL is a hardcoded constant
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API: unexpected status %d", resp.StatusCode)
+	}
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, err
+	}
+	return &rel, nil
+}
+
+func downloadFile(url, dst string) error {
+	client := &http.Client{Timeout: dlTimeout}
+	resp, err := client.Get(url) //nolint:gosec // URL comes from the GitHub releases API response
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	f, err := os.Create(dst) //nolint:gosec // dst is a path inside our own tmpDir
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, resp.Body)
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func verifyChecksum(tarPath, assetName, checksumURL string) error {
+	client := &http.Client{Timeout: apiTimeout}
+	resp, err := client.Get(checksumURL) //nolint:gosec // URL comes from the GitHub releases API response
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// checksums.txt format: "<sha256>  <filename>" per line.
+	var expected string
+	for line := range strings.SplitSeq(string(body), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == assetName {
+			expected = parts[0]
+			break
+		}
+	}
+	if expected == "" {
+		return fmt.Errorf("checksum for %s not found in checksums.txt", assetName)
+	}
+
+	f, err := os.Open(tarPath) //nolint:gosec // tarPath is a path inside our own tmpDir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	if actual := hex.EncodeToString(h.Sum(nil)); actual != expected {
+		return fmt.Errorf("checksum mismatch: got %s, want %s", actual, expected)
+	}
+	return nil
+}
+
+func extractBinary(tarPath, binaryName, dst string) error {
+	f, err := os.Open(tarPath) //nolint:gosec // tarPath is a path inside our own tmpDir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if filepath.Base(hdr.Name) == binaryName && hdr.Typeflag == tar.TypeReg {
+			out, err := os.Create(dst) //nolint:gosec // dst is a path inside our own tmpDir
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(out, io.LimitReader(tr, maxBinarySize))
+			if closeErr := out.Close(); closeErr != nil && copyErr == nil {
+				copyErr = closeErr
+			}
+			return copyErr
+		}
+	}
+	return fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func isWritable(path string) bool {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0) //nolint:gosec // intentional write-check
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+// isNewer reports whether latestTag represents a higher version than currentTag.
+// Both may carry a leading "v". Uses integer comparison per component so that
+// e.g. 0.0.10 > 0.0.9 is handled correctly.
+func isNewer(latestTag, currentTag string) bool {
+	l := parseVersion(strings.TrimPrefix(latestTag, "v"))
+	c := parseVersion(strings.TrimPrefix(currentTag, "v"))
+	for i := range l {
+		if l[i] != c[i] {
+			return l[i] > c[i]
+		}
+	}
+	return false
+}
+
+func parseVersion(v string) [3]int {
+	parts := strings.SplitN(v, ".", 3)
+	var r [3]int
+	for i, p := range parts {
+		if i >= 3 {
+			break
+		}
+		r[i], _ = strconv.Atoi(p) //nolint:gosec // i is always < 3: SplitN cap + guard above
+	}
+	return r
+}
+
+func cacheDir() string {
+	if d := os.Getenv("XDG_CACHE_HOME"); d != "" {
+		return filepath.Join(d, "vibez")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".cache", "vibez")
+}
+
+func shouldCheck() bool {
+	stamp := filepath.Join(cacheDir(), "last_update_check")
+	info, err := os.Stat(stamp)
+	if err != nil {
+		return true // file missing → check
+	}
+	return time.Since(info.ModTime()) > checkInterval
+}
+
+func markChecked() {
+	dir := cacheDir()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return
+	}
+	stamp := filepath.Join(dir, "last_update_check")
+	f, err := os.OpenFile(stamp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // stamp path is derived from our own cacheDir()
+	if err != nil {
+		return
+	}
+	_ = f.Close()
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,176 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ── isNewer ───────────────────────────────────────────────────────────────────
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v0.0.10", "v0.0.9", true},  // integer, not lexicographic
+		{"v0.0.9", "v0.0.9", false},  // same version
+		{"v0.0.8", "v0.0.9", false},  // older
+		{"v1.0.0", "v0.9.9", true},   // major bump
+		{"v0.1.0", "v0.0.9", true},   // minor bump
+		{"0.0.10", "0.0.9", true},    // no leading v
+		{"v0.0.9", "v0.0.10", false}, // current is newer
+	}
+	for _, tc := range cases {
+		got := isNewer(tc.latest, tc.current)
+		if got != tc.want {
+			t.Errorf("isNewer(%q, %q) = %v, want %v", tc.latest, tc.current, got, tc.want)
+		}
+	}
+}
+
+// ── verifyChecksum ────────────────────────────────────────────────────────────
+
+func TestVerifyChecksum_Valid(t *testing.T) {
+	data := []byte("fake tarball content")
+	sum := sha256.Sum256(data)
+	hashHex := hex.EncodeToString(sum[:])
+	assetName := "vibez_linux_amd64.tar.gz"
+
+	checksumBody := hashHex + "  " + assetName + "\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksumBody))
+	}))
+	defer srv.Close()
+
+	tarPath := filepath.Join(t.TempDir(), assetName)
+	if err := os.WriteFile(tarPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyChecksum(tarPath, assetName, srv.URL); err != nil {
+		t.Errorf("verifyChecksum unexpectedly failed: %v", err)
+	}
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	data := []byte("tampered content")
+	assetName := "vibez_linux_amd64.tar.gz"
+
+	checksumBody := "0000000000000000000000000000000000000000000000000000000000000000  " + assetName + "\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksumBody))
+	}))
+	defer srv.Close()
+
+	tarPath := filepath.Join(t.TempDir(), assetName)
+	if err := os.WriteFile(tarPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyChecksum(tarPath, assetName, srv.URL); err == nil {
+		t.Error("verifyChecksum should fail on hash mismatch")
+	}
+}
+
+// ── extractBinary ─────────────────────────────────────────────────────────────
+
+func TestExtractBinary_Found(t *testing.T) {
+	binaryContent := []byte("#!/bin/sh\necho vibez")
+	tarPath := filepath.Join(t.TempDir(), "vibez_linux_amd64.tar.gz")
+
+	f, err := os.Create(tarPath) //nolint:gosec // tarPath is a path inside t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "vibez",
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(binaryContent)),
+		Mode:     0o755,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binaryContent); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "vibez")
+	if err := extractBinary(tarPath, "vibez", dst); err != nil {
+		t.Fatalf("extractBinary failed: %v", err)
+	}
+	got, err := os.ReadFile(dst) //nolint:gosec // dst is a path inside t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(binaryContent) {
+		t.Errorf("extracted content = %q, want %q", got, binaryContent)
+	}
+}
+
+func TestExtractBinary_NotFound(t *testing.T) {
+	tarPath := filepath.Join(t.TempDir(), "empty.tar.gz")
+
+	f, err := os.Create(tarPath) //nolint:gosec // tarPath is a path inside t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "vibez")
+	if err := extractBinary(tarPath, "vibez", dst); err == nil {
+		t.Error("extractBinary should error when binary not in archive")
+	}
+}
+
+// ── shouldCheck / markChecked ─────────────────────────────────────────────────
+
+func TestShouldCheck_NoStamp(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	if !shouldCheck() {
+		t.Error("shouldCheck should return true when stamp does not exist")
+	}
+}
+
+func TestShouldCheck_RecentStamp(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	if err := os.MkdirAll(filepath.Join(dir, "vibez"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	stamp := filepath.Join(dir, "vibez", "last_update_check")
+	if err := os.WriteFile(stamp, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if shouldCheck() {
+		t.Error("shouldCheck should return false when stamp was just written")
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.0.6"
+var Version = "0.0.9"


### PR DESCRIPTION
## Summary

Closes #26

On launch, vibez checks GitHub for a newer release and updates itself transparently — shown right on the TUI loading screen alongside the Chrome download and auth steps.

## How it works

1. **Check** — GitHub releases API is queried (once per 24h, rate-limited via `~/.cache/vibez/last_update_check`)
2. **Download** — the platform tarball (`vibez_linux_amd64.tar.gz`) is fetched
3. **Verify** — SHA-256 checksum is validated against the published `checksums.txt`
4. **Install** — binary is atomically replaced (`exe.new` → rename)
5. **Restart** — `RestartMsg` causes the TUI to quit cleanly, then `syscall.Exec` re-launches the new binary in-place (same PID slot, terminal fully restored)

If anything fails (network error, bad checksum, read-only install) the update is silently skipped and vibez starts normally.

## Changes

| File | Change |
|------|--------|
| `internal/updater/updater.go` | New package: `CheckAndUpdate`, checksum verification, tar extraction, daily rate-limit stamp, 256 MB decompression cap |
| `internal/updater/updater_test.go` | 7 tests covering `isNewer`, checksum verify, tar extraction, rate-limit stamp |
| `cmd/root.go` | Update check as step 1 in CDP init goroutine; `syscall.Exec` after TUI exits; `--no-update` flag |
| `internal/tui/messages.go` | New `RestartMsg` type |
| `internal/tui/model.go` | Handle `RestartMsg` → `tea.Quit` |
| `.goreleaser.yml` | Inject version via `-X` ldflags so releases self-report the correct tag |
| `internal/version/version.go` | Bump hardcoded fallback to `0.0.9` |
| `CHANGELOG.md` | Document under `[Unreleased]` |

## Flags

```
vibez --no-update   # skip the update check on this launch
```