### PR TITLE
fix: detect and recover from expired Apple Music auth token at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against the published `checksums.txt`, the binary is atomically replaced, the TUI quits
   cleanly, and the process re-execs the new binary transparently.
   Pass `--no-update` to skip the check. Closes #26.
+- **Expired-auth detection** — before starting the audio engine, vibez probes
+  `/v1/me/storefront` with the stored user token. A 401/403 response clears the
+  cached token and triggers a fresh login, preventing a silent failure loop after
+  the Apple Music session expires. Closes #10.
 
 ---
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,7 +151,17 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 			return
 		}
 
-		// Step 2: Ensure Chrome is installed — may download ~130 MB on first run.
+		// Step 2: Validate stored token — avoids launching Chrome with a stale token.
+		if cfg.AppleUserToken != "" {
+			prog.Send(tui.InitStatusMsg("Checking Apple Music session…"))
+			if !auth.ValidateToken(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
+				prog.Send(tui.InitStatusMsg("Session expired — re-authenticating…"))
+				cfg.AppleUserToken = ""
+				_ = cfg.Save("")
+			}
+		}
+
+		// Step 3: Ensure Chrome is installed — may download ~130 MB on first run.
 		prog.Send(tui.InitStatusMsg("Initializing vibez…"))
 		if err := cdp.EnsureBrowser(func(msg string) {
 			prog.Send(tui.InitStatusMsg(msg))
@@ -160,7 +170,7 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 			return
 		}
 
-		// Step 3: Auth — opens the system browser; TUI shows status.
+		// Step 4: Auth — opens the system browser; TUI shows status.
 		if cfg.AppleUserToken == "" {
 			prog.Send(tui.InitStatusMsg("Authorizing with Apple Music…"))
 			if err := auth.Login(cfg); err != nil {
@@ -169,7 +179,7 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 			}
 		}
 
-		// Step 4: Start engine — Chrome launches headless because token is already set.
+		// Step 5: Start engine — Chrome launches headless because token is already set.
 		prog.Send(tui.InitStatusMsg("Starting audio engine…"))
 		cdpPlayer, err := cdp.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront)
 		if err != nil {
@@ -269,6 +279,14 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 	fmt.Fprintln(os.Stderr, "Engine: WebKit + GStreamer (30 s preview)")
 
 	// Auth before engine creation (no loading TUI in WebKit path).
+	if cfg.AppleUserToken != "" {
+		fmt.Fprintln(os.Stderr, "Checking Apple Music session…")
+		if !auth.ValidateToken(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
+			fmt.Fprintln(os.Stderr, "Session expired — re-authenticating…")
+			cfg.AppleUserToken = ""
+			_ = cfg.Save("")
+		}
+	}
 	if cfg.AppleUserToken == "" {
 		if err := auth.Login(cfg); err != nil {
 			return fmt.Errorf("authentication: %w", err)

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+const storefrontURL = "https://api.music.apple.com/v1/me/storefront"
+
+// ValidateToken makes a lightweight Apple Music API call to check whether
+// the stored user token is still valid.
+//
+// Returns false when the API responds with 401 or 403 (token expired or
+// revoked). Returns true on network errors so that a temporary connectivity
+// problem does not force an unnecessary re-login.
+func ValidateToken(devToken, userToken string) bool {
+	return probeURL(storefrontURL, devToken, userToken)
+}
+
+// probeURL is the testable core of ValidateToken. It accepts an explicit URL
+// so tests can point it at an httptest server.
+func probeURL(url, devToken, userToken string) bool {
+	if devToken == "" || userToken == "" {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // URL is a hardcoded constant or test server
+	if err != nil {
+		return true // assume valid
+	}
+	req.Header.Set("Authorization", "Bearer "+devToken)
+	req.Header.Set("Music-User-Token", userToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return true // network error → assume valid, let the engine surface it
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden
+}

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValidateToken_ValidToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if !probeURL(srv.URL, "dev", "user") {
+		t.Error("expected true for 200 response, got false")
+	}
+}
+
+func TestValidateToken_ExpiredToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	if probeURL(srv.URL, "dev", "user") {
+		t.Error("expected false for 401 response, got true")
+	}
+}
+
+func TestValidateToken_ForbiddenToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	if probeURL(srv.URL, "dev", "user") {
+		t.Error("expected false for 403 response, got true")
+	}
+}
+
+func TestValidateToken_EmptyTokens(t *testing.T) {
+	if ValidateToken("", "user") {
+		t.Error("expected false for empty devToken")
+	}
+	if ValidateToken("dev", "") {
+		t.Error("expected false for empty userToken")
+	}
+	if ValidateToken("", "") {
+		t.Error("expected false for both empty")
+	}
+}
+
+func TestValidateToken_NetworkError(t *testing.T) {
+	// Point at a port that refuses connections → should return true (assume valid).
+	if !probeURL("http://127.0.0.1:1", "dev", "user") {
+		t.Error("expected true on network error (assume valid), got false")
+	}
+}
+
+func TestValidateToken_HeadersSet(t *testing.T) {
+	var gotAuth, gotUserToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotUserToken = r.Header.Get("Music-User-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	probeURL(srv.URL, "mydev", "myuser")
+
+	if gotAuth != "Bearer mydev" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer mydev")
+	}
+	if gotUserToken != "myuser" {
+		t.Errorf("Music-User-Token = %q, want %q", gotUserToken, "myuser")
+	}
+}


### PR DESCRIPTION
## Problem
Closes #10

When the Apple Music session token expires, vibez would silently fail on startup — the stored token was present so the login flow was skipped, but the engine would get 401s from MusicKit.

## Solution

Before launching Chrome, vibez now makes a lightweight probe to `GET /v1/me/storefront` with the stored user token.

- **401 or 403** → token is expired/revoked: clear it from config and trigger a fresh login
- **2xx** → all good, continue as normal
- **network error** → assume valid (don't force re-login on connectivity issues)

Progress is shown on the TUI loading screen: *"Checking Apple Music session…"* / *"Session expired — re-authenticating…"*

The same check is also wired into the WebKit fallback path.

## Changes
- `internal/auth/validate.go` — new `ValidateToken(devToken, userToken string) bool`
- `internal/auth/validate_test.go` — 6 tests (200 → true, 401 → false, 403 → false, empty tokens → false, network error → true, correct headers set)
- `cmd/root.go` — step 2 in CDP goroutine + WebKit flow
- `CHANGELOG.md` — updated