### PR TITLE
feat: show streaming quality next to volume in header bar

### DIFF
--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -346,6 +346,7 @@ type jsState struct {
 	CurrentTime   float64  `json:"currentTime"`
 	Duration      float64  `json:"duration"`
 	Volume        float64  `json:"volume"`
+	Bitrate       int      `json:"bitrate"`
 	RepeatMode    int      `json:"repeatMode"`
 	ShuffleMode   int      `json:"shuffleMode"`
 	NowPlaying    *jsTrack `json:"nowPlaying"`
@@ -367,6 +368,7 @@ func (p *Player) applyState(js jsState) {
 		Loading:     js.PlaybackState == 1 || js.PlaybackState == 7 || js.PlaybackState == 8,
 		Position:    time.Duration(js.CurrentTime * float64(time.Second)),
 		Volume:      js.Volume,
+		Bitrate:     js.Bitrate,
 		RepeatMode:  js.RepeatMode,
 		ShuffleMode: js.ShuffleMode != 0,
 	}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -19,6 +19,7 @@ type State struct {
 	Loading     bool // true when MusicKit playbackState is loading/buffering
 	Position    time.Duration
 	Volume      float64 // 0.0–1.0
+	Bitrate     int     // streaming bitrate in kbps; 0 = unknown
 	RepeatMode  int     // RepeatModeOff / RepeatModeOne / RepeatModeAll
 	ShuffleMode bool    // true = shuffle on
 	Error       string  // non-empty when JS reports a playback error

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -44,6 +44,13 @@
         try { music.isExplicitContentAllowed = true; } catch(_) {}
       }
 
+      // Request highest available streaming quality (256 kbps AAC — the ceiling
+      // for MusicKit JS on web). Falls back to the numeric value if the enum is
+      // not present in this build of MusicKit.
+      try {
+        music.bitrate = (MusicKit.PlaybackBitrate && MusicKit.PlaybackBitrate.HIGH) || 256;
+      } catch(_) {}
+
       const savedToken = '{{.UserToken}}';
       if (savedToken !== '') {
         music.musicUserToken = savedToken;
@@ -143,6 +150,7 @@
             currentTime:   m.currentPlaybackTime,
             duration:      m.currentPlaybackDuration,
             volume:        m.volume,
+            bitrate:       m.bitrate || 0,
             repeatMode:    m.repeatMode  || 0,
             shuffleMode:   m.shuffleMode || 0,
             nowPlaying: item ? {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2340,6 +2340,10 @@ func (m *Model) renderBoxHeader(inner int) string {
 		volStr = styles.QueueItemMuted.Render(fmt.Sprintf("♪ %d%%", vol))
 	}
 
+	if q := qualityLabel(m.playerState.Bitrate); q != "" {
+		volStr = styles.QueueItemMuted.Render(q+" ·") + " " + volStr
+	}
+
 	rightStr := volStr
 	if m.memStats != "" {
 		rightStr = styles.QueueItemMuted.Render(m.memStats) + "  " + volStr
@@ -2824,6 +2828,22 @@ func centerStr(s string, width int) string {
 	w := lipgloss.Width(s)
 	pad := max(0, (width-w)/2)
 	return strings.Repeat(" ", pad) + s
+}
+
+// qualityLabel converts a streaming bitrate (kbps) to a human-readable label.
+// Apple Music tiers: AAC ≤ 320 kbps, Lossless ~1411 kbps, Hi-Res > 2000 kbps.
+// Returns "" when bitrate is 0 (unknown / nothing playing).
+func qualityLabel(kbps int) string {
+	switch {
+	case kbps <= 0:
+		return ""
+	case kbps > 2000:
+		return "Hi-Res"
+	case kbps > 320:
+		return "Lossless"
+	default:
+		return fmt.Sprintf("%d kbps", kbps)
+	}
 }
 
 func clamp(v, lo, hi float64) float64 {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2439,3 +2439,26 @@ func TestHandleCommandKey_Space_AppendsSpace(t *testing.T) {
 		t.Errorf("cmdBuf after space = %q, want %q", m.cmdBuf, "save ")
 	}
 }
+
+func TestQualityLabel(t *testing.T) {
+	cases := []struct {
+		kbps int
+		want string
+	}{
+		{0, ""},
+		{-1, ""},
+		{64, "64 kbps"},
+		{256, "256 kbps"},
+		{320, "320 kbps"},
+		{321, "Lossless"},
+		{1411, "Lossless"},
+		{2000, "Lossless"},
+		{2001, "Hi-Res"},
+		{6000, "Hi-Res"},
+	}
+	for _, tc := range cases {
+		if got := qualityLabel(tc.kbps); got != tc.want {
+			t.Errorf("qualityLabel(%d) = %q, want %q", tc.kbps, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Closes #29

Displays the current MusicKit streaming bitrate next to the volume indicator in the TUI box header.

**Before:** `♪ 80%`
**After:** `256 kbps · ♪ 80%`

Also enforces the highest available quality by setting `music.bitrate = MusicKit.PlaybackBitrate.HIGH` immediately after `MusicKit.configure`.

## Quality tier labels
| Bitrate | Label |
|---------|-------|
| 0 / unknown | *(hidden)* |
| ≤ 320 kbps | `{n} kbps` |
| 321–2000 kbps | `Lossless` |
| > 2000 kbps | `Hi-Res` |

> Note: MusicKit JS caps at 256 kbps AAC. The Lossless/Hi-Res labels are future-proofing for if Apple ever enables it in the web API.

## Changes
- `musickit.html` — add `bitrate: m.bitrate || 0` to `notifyState`; set `HIGH` quality after configure
- `internal/player/player.go` — new `Bitrate int` field on `State`
- `internal/player/cdp/player.go` — `jsState.Bitrate` → `State.Bitrate` in `applyState`
- `internal/tui/model.go` — `qualityLabel()` helper; `renderBoxHeader` prepends quality to volume string
- `internal/tui/model_test.go` — `TestQualityLabel` covering all tier boundaries