### PR TITLE
fix: correct MPRIS app icon for desktop notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/v1/me/storefront` with the stored user token. A 401/403 response clears the
   cached token and triggers a fresh login, preventing a silent failure loop after
   the Apple Music session expires. Closes #10.
+- **Streaming quality in header** — the current MusicKit bitrate (e.g. `256 kbps`) is
+  displayed next to the volume indicator in the TUI box header. MusicKit is also
+  explicitly configured to request the highest available quality (256 kbps AAC).
+  Closes #29.
+
+### Fixed
+- **MPRIS app icon** — the `DesktopEntry` property was set to `"vibez"` instead of
+  `"io.github.simonepelosi.vibez"`, causing desktop environments to fall back to a
+  generic icon in media notifications and the media panel. The install script now also
+  installs the `.desktop` file and app icon to the correct XDG locations. Closes #31.
 
 ---
 

--- a/internal/player/mpris/server.go
+++ b/internal/player/mpris/server.go
@@ -161,7 +161,7 @@ func NewServer(ctrl Controller) (*Server, error) {
 			"CanRaise":            {Value: false, Writable: false, Emit: prop.EmitFalse},
 			"HasTrackList":        {Value: false, Writable: false, Emit: prop.EmitFalse},
 			"Identity":            {Value: "vibez", Writable: false, Emit: prop.EmitFalse},
-			"DesktopEntry":        {Value: "vibez", Writable: false, Emit: prop.EmitFalse},
+			"DesktopEntry":        {Value: "io.github.simonepelosi.vibez", Writable: false, Emit: prop.EmitFalse},
 			"SupportedUriSchemes": {Value: []string{}, Writable: false, Emit: prop.EmitFalse},
 			"SupportedMimeTypes":  {Value: []string{}, Writable: false, Emit: prop.EmitFalse},
 		},

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,7 +176,29 @@ chmod 755 "${INSTALL_DIR}/${BIN}"
 
 success "${INSTALL_DIR}/${BIN}"
 
-# ── PATH check & update ───────────────────────────────────────────────────────
+# ── desktop integration ───────────────────────────────────────────────────────
+
+step "Installing desktop integration…"
+
+RAW_BASE="https://raw.githubusercontent.com/${REPO}/main"
+APP_ID="io.github.simonepelosi.vibez"
+
+DESKTOP_DIR="${HOME}/.local/share/applications"
+ICON_DIR="${HOME}/.local/share/icons/hicolor/512x512/apps"
+
+mkdir -p "${DESKTOP_DIR}" "${ICON_DIR}"
+
+download "${RAW_BASE}/flatpak/${APP_ID}.desktop" "${DESKTOP_DIR}/${APP_ID}.desktop"
+download "${RAW_BASE}/assets/logo.png"            "${ICON_DIR}/${APP_ID}.png"
+
+# Refresh desktop and icon caches so the DE picks up the new entries immediately.
+command -v update-desktop-database >/dev/null 2>&1 \
+    && update-desktop-database "${DESKTOP_DIR}" 2>/dev/null || true
+command -v gtk-update-icon-cache >/dev/null 2>&1 \
+    && gtk-update-icon-cache -f -t "${HOME}/.local/share/icons/hicolor" 2>/dev/null || true
+
+success "Desktop file and icon installed"
+
 
 step "Checking PATH…"
 


### PR DESCRIPTION
## Problem
Closes #31

The MPRIS `DesktopEntry` property was set to `"vibez"` but the actual desktop file installed by Flatpak is `io.github.simonepelosi.vibez.desktop` with `Icon=io.github.simonepelosi.vibez`. Desktop environments look up the app icon by the `DesktopEntry` name, so the mismatch caused the generic fallback icon to appear in media notifications and the GNOME/KDE media panel.

## Changes

### `internal/player/mpris/server.go`
- `DesktopEntry`: `"vibez"` → `"io.github.simonepelosi.vibez"`

### `scripts/install.sh`
For non-Flatpak users the install script now also:
1. Downloads `flatpak/io.github.simonepelosi.vibez.desktop` → `~/.local/share/applications/`
2. Downloads `assets/logo.png` (500×500) → `~/.local/share/icons/hicolor/512x512/apps/io.github.simonepelosi.vibez.png`
3. Runs `update-desktop-database` and `gtk-update-icon-cache` if available

### `CHANGELOG.md`
- Added entries for streaming quality display (#29) and this fix (#31)