### PR TITLE
feat: persist volume across sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Persistent volume** — the playback volume is now saved to `~/.config/vibez/config.json`
+  whenever the user changes it (arrow keys, `+`/`-`, or `:vol`). On the next launch vibez
+  restores the saved level automatically. Muting (`m` / `:mute`) is intentionally not
+  persisted so vibez never starts silent. Closes #39.
+
+### Added
 - **Auto-update** — on startup vibez checks GitHub for a newer release (once per 24 h).
   Progress is shown on the TUI loading screen alongside the Chrome download / auth steps.
   If an update is available the binary is downloaded, its SHA-256 checksum is verified

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,12 +16,28 @@ type Config struct {
 	AuthPort            int    `json:"auth_port"`
 	Provider            string `json:"provider"`
 	Theme               string `json:"theme"`
+	// Volume is the last user-set playback volume (0.0–1.0). nil means
+	// "not yet saved" and the player default (1.0) is used on startup.
+	Volume *float64 `json:"volume,omitempty"`
 	// Last.fm scrobbling. LastfmAPIKey and LastfmAPISecret are typically
 	// embedded in the binary at build time via ldflags; set them manually here
 	// only when building from source without the embedded keys.
 	LastfmAPIKey     string `json:"lastfm_api_key,omitempty"`
 	LastfmAPISecret  string `json:"lastfm_api_secret,omitempty"`
 	LastfmSessionKey string `json:"lastfm_session_key,omitempty"`
+}
+
+// VolumeOrDefault returns the saved volume, or 1.0 if none has been stored yet.
+func (c *Config) VolumeOrDefault() float64 {
+	if c.Volume != nil {
+		return *c.Volume
+	}
+	return 1.0
+}
+
+// SetVolume updates the in-memory volume field. Call Save to persist it.
+func (c *Config) SetVolume(v float64) {
+	c.Volume = &v
 }
 
 func defaults() *Config {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -125,6 +125,10 @@ type glowTickMsg time.Time
 type introTickMsg time.Time
 type memTickMsg struct{ stats string }
 type errMsg struct{ err error }
+
+// saveVolumeMsg is returned by volume-change commands to persist the new
+// volume to the config file.
+type saveVolumeMsg struct{ vol float64 }
 type playlistCreatedMsg struct{ name string }
 type SessionExpiredMsg struct{}
 type SessionRestoredMsg struct{}
@@ -784,6 +788,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.helperPaths = msg.HelperPaths
 		m.appendLog("[engine] backend: " + msg.Backend)
 		cmds = append(cmds, waitForState(m.stateCh), m.library.Init())
+		if m.cfg.Volume != nil {
+			v := m.cfg.VolumeOrDefault()
+			cmds = append(cmds, m.playerCmd(func() error {
+				return m.player.SetVolume(v)
+			}))
+			m.appendLog(fmt.Sprintf("[vol] restored %.0f%% from config", v*100))
+		}
 		if m.memProfiling {
 			cmds = append(cmds, memTick(m.helperPaths))
 		}
@@ -799,6 +810,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.errMsg = msg.Err.Error()
 		m.errExpiry = time.Now().Add(30 * time.Second)
 		m.introStep = introDone
+
+	case saveVolumeMsg:
+		m.cfg.SetVolume(msg.vol)
+		if err := m.cfg.Save(""); err != nil {
+			m.appendLog(fmt.Sprintf("[vol] config save error: %v", err))
+		}
 
 	case errMsg:
 		m.appendLog("[error] " + msg.err.Error())
@@ -1178,7 +1195,16 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 		}
 		m.preMuteVol = -1 // clear mute state on explicit vol change
 		m.appendLog(fmt.Sprintf("[vol] → %.0f%%", newVol*100))
-		return m.playerCmd(func() error { return m.player.SetVolume(newVol) })
+		vol := newVol
+		return func() tea.Msg {
+			if m.player == nil {
+				return errMsg{fmt.Errorf("no player")}
+			}
+			if err := m.player.SetVolume(vol); err != nil {
+				return errMsg{err}
+			}
+			return saveVolumeMsg{vol}
+		}
 
 	case strings.HasPrefix(cmd, "seek"):
 		arg := strings.TrimSpace(strings.TrimPrefix(cmd, "seek"))
@@ -2210,7 +2236,7 @@ func (m *Model) adjustVolume(delta float64) tea.Cmd {
 		if err := m.player.SetVolume(newVol); err != nil {
 			return errMsg{err}
 		}
-		return nil
+		return saveVolumeMsg{newVol}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -417,8 +417,8 @@ func TestAdjustVolume_ClampHi(t *testing.T) {
 	m.playerState.Volume = 0.99
 	cmd := m.adjustVolume(0.05) // would exceed 1.0
 	msg := cmd()
-	if msg != nil {
-		t.Errorf("adjustVolume should succeed, got %v", msg)
+	if _, ok := msg.(saveVolumeMsg); !ok {
+		t.Errorf("adjustVolume should return saveVolumeMsg on success, got %T", msg)
 	}
 }
 
@@ -428,8 +428,8 @@ func TestAdjustVolume_ClampLo(t *testing.T) {
 	m.playerState.Volume = 0.01
 	cmd := m.adjustVolume(-0.05) // would go below 0
 	msg := cmd()
-	if msg != nil {
-		t.Errorf("adjustVolume should succeed, got %v", msg)
+	if _, ok := msg.(saveVolumeMsg); !ok {
+		t.Errorf("adjustVolume should return saveVolumeMsg on success, got %T", msg)
 	}
 }
 


### PR DESCRIPTION
Save the playback volume to config.json whenever the user changes it (arrow keys, +/-, or :vol command). Restore it on the next launch via the EngineReadyMsg handler.

Muting (m / :mute) is intentionally not persisted so vibez never starts silent.

Closes #39