### PR TITLE
Feature/equalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **10-band parametric equalizer** — press `e` to open the equalizer panel. Each of the 10
+  ISO bands (32 Hz, 64 Hz, 125 Hz, 250 Hz, 500 Hz, 1 kHz, 2 kHz, 4 kHz, 8 kHz, 16 kHz)
+  exposes independent frequency, Q factor, and gain (±12 dB, in 0.5 dB steps). Changes apply
+  live via the Web Audio API (`BiquadFilterNode` chain). Use `←`/`→` to navigate bands,
+  `↑`/`↓` to adjust gain, `0` to reset the current band, `r` to reset all bands, and `e`
+  to close the panel. The EQ curve is persisted to `eq_bands` in `config.json` and restored
+  automatically on the next launch. Closes #41.
+
 ---
 
 ## [0.1.0] — 2026-05-08

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Full tracks stream via an embedded headless Chrome with Widevine DRM (auto-downl
 - **Provider architecture** — the player core is decoupled from the music source
 - **More services coming** — Spotify, YouTube Music, Deezer, and Tidal are on the roadmap
 
+### 🎛️ Equalizer
+
+- **10-band parametric EQ** — press `e` to open a full-width equalizer panel
+- **Per-band control** — adjust frequency (32 Hz–16 kHz), Q factor, and gain (±12 dB) for each band
+- **Live preview** — changes apply immediately to the audio stream via Web Audio API
+- **Persistent settings** — your EQ curve is saved to `~/.config/vibez/config.json` and restored on next launch
+
 ### 🎨 Themes
 
 - **Built-in themes** — `default` (Tokyo Night / Catppuccin), `dracula`, `gruvbox`, `nord`
@@ -224,6 +231,7 @@ Then set `"theme": "<name>"` in `config.json` and restart vibez.
 | `s` | Toggle shuffle |
 | `f` | Heart / favourite current track |
 | `v` | Open vibe input (mood-driven search) |
+| `e` | Toggle equalizer panel |
 | `d` | Toggle discovery mode |
 | `/` | Open search |
 | `l` | Toggle library panel |
@@ -287,6 +295,16 @@ Use `↑` / `↓` (or `ctrl+p` / `ctrl+n`) to cycle through suggestions, and `ta
 | `+` / `=` | Increase similarity (stay closer to current artist / genre) |
 | `-` | Decrease similarity (explore further afield) |
 | `d` | Stop discovery mode |
+
+### Equalizer (`e`)
+
+| Key | Action |
+|-----|--------|
+| `←` / `→` | Navigate between bands |
+| `↑` / `↓` | Increase / decrease gain (±0.5 dB per step) |
+| `0` | Reset current band to flat (0 dB) |
+| `r` | Reset all bands to flat |
+| `e` | Close equalizer panel |
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,14 @@ type Config struct {
 	LastfmAPIKey     string `json:"lastfm_api_key,omitempty"`
 	LastfmAPISecret  string `json:"lastfm_api_secret,omitempty"`
 	LastfmSessionKey string `json:"lastfm_session_key,omitempty"`
+	// EQBands stores the last saved 10-band equalizer settings. nil means flat.
+	EQBands []EQBand `json:"eq_bands,omitempty"`
+}
+
+type EQBand struct {
+	Frequency float64 `json:"frequency"`
+	Q         float64 `json:"q"`
+	Gain      float64 `json:"gain"`
 }
 
 // VolumeOrDefault returns the saved volume, or 1.0 if none has been stored yet.

--- a/internal/player/cdp/js.go
+++ b/internal/player/cdp/js.go
@@ -3,6 +3,8 @@ package cdp
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/simone-vibes/vibez/internal/player"
 )
 
 // buildSetQueueJS returns the JS expression that calls vibezSetQueue.
@@ -40,4 +42,16 @@ func buildAppendQueueJS(ids []string) (string, error) {
 		return "", fmt.Errorf("cdp: marshal append json string: %w", err)
 	}
 	return fmt.Sprintf(`window.vibezAppendQueue && window.vibezAppendQueue(%s)`, js), nil
+}
+
+func buildSetEqualizerJS(bands []player.EQBand) (string, error) {
+	b, err := json.Marshal(bands)
+	if err != nil {
+		return "", fmt.Errorf("cdp: marshal eq bands: %w", err)
+	}
+	js, err := json.Marshal(string(b))
+	if err != nil {
+		return "", fmt.Errorf("cdp: marshal eq json string: %w", err)
+	}
+	return fmt.Sprintf(`window.vibezSetEqualizer && window.vibezSetEqualizer(%s)`, js), nil
 }

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -505,6 +505,15 @@ func (p *Player) SetShuffle(on bool) error {
 	return nil
 }
 
+func (p *Player) SetEqualizer(bands []player.EQBand) error {
+	js, err := buildSetEqualizerJS(bands)
+	if err != nil {
+		return err
+	}
+	p.dispatch(js)
+	return nil
+}
+
 func (p *Player) RemoveFromQueue(idx int) error {
 	p.dispatch(fmt.Sprintf(`window.vibezQueueRemove && window.vibezQueueRemove(%d)`, idx))
 	return nil

--- a/internal/player/demo/player.go
+++ b/internal/player/demo/player.go
@@ -262,6 +262,8 @@ func (p *Player) ClearQueue() error {
 	return nil
 }
 
+func (p *Player) SetEqualizer(_ []player.EQBand) error { return nil }
+
 func (p *Player) GetState() (*player.State, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -26,7 +26,7 @@ func DefaultEQBands() []EQBand {
 	freqs := []float64{32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000}
 	bands := make([]EQBand, len(freqs))
 	for i, f := range freqs {
-		bands[i] = EQBand{Frequency: f, Q: 1.4, Gain: 0}
+		bands[i] = EQBand{Frequency: f, Q: 1.46, Gain: 0}
 	}
 	return bands
 }

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -13,6 +13,24 @@ const (
 	RepeatModeAll = 2 // repeat entire queue
 )
 
+// EQBand describes a single parametric equalizer band.
+// Gain is in dB (-12.0 to +12.0). Frequency is in Hz. Q is the quality factor.
+type EQBand struct {
+	Frequency float64 `json:"frequency"`
+	Q         float64 `json:"q"`
+	Gain      float64 `json:"gain"`
+}
+
+// DefaultEQBands returns the 10 standard ISO bands with flat (0 dB) gain.
+func DefaultEQBands() []EQBand {
+	freqs := []float64{32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000}
+	bands := make([]EQBand, len(freqs))
+	for i, f := range freqs {
+		bands[i] = EQBand{Frequency: f, Q: 1.4, Gain: 0}
+	}
+	return bands
+}
+
 type State struct {
 	Track       *provider.Track
 	Playing     bool
@@ -48,6 +66,8 @@ type Player interface {
 	SetRepeat(mode int) error
 	// SetShuffle enables or disables shuffle playback.
 	SetShuffle(on bool) error
+	// SetEqualizer applies the given 10-band parametric EQ. Pass nil to bypass.
+	SetEqualizer(bands []EQBand) error
 	// RemoveFromQueue removes the track at idx from the queue without
 	// interrupting playback of any other track.
 	RemoveFromQueue(idx int) error

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -451,6 +451,49 @@
         const _repeatName = ['off', 'one', 'all'];
         window.vibezSeek      = (t) => { _log(`[js:seek] → ${t.toFixed(1)}s`); _m().seekToTime(t); };
         window.vibezSetVolume = (v) => { _log(`[js:volume] → ${Math.round(v*100)}%`); _m().volume = v; };
+
+        // ── 10-band parametric equalizer (Web Audio API) ─────────────────────
+        let _eqCtx    = null;
+        let _eqNodes  = [];
+        let _eqSource = null;
+
+        async function _ensureEQContext() {
+          if (_eqCtx) return;
+          const audioEl = document.querySelector('audio');
+          if (!audioEl) { _log('[js:eq] no audio element'); return; }
+          _eqCtx   = new AudioContext();
+          _eqSource = _eqCtx.createMediaElementSource(audioEl);
+          _eqSource.connect(_eqCtx.destination);
+        }
+
+        window.vibezSetEqualizer = async function(bandsJSON) {
+          const bands = JSON.parse(bandsJSON);
+          _log(`[js:eq] apply ${bands.length} band(s)`);
+          await _ensureEQContext();
+          if (!_eqCtx) return;
+
+          _eqNodes.forEach(n => n.disconnect());
+          _eqSource.disconnect();
+          _eqNodes = [];
+
+          if (!bands || bands.length === 0) {
+            _eqSource.connect(_eqCtx.destination);
+            return;
+          }
+
+          bands.forEach((b, i) => {
+            const f = _eqCtx.createBiquadFilter();
+            f.type      = (i === 0) ? 'lowshelf' : (i === bands.length - 1) ? 'highshelf' : 'peaking';
+            f.frequency.value = b.frequency;
+            f.Q.value         = b.q;
+            f.gain.value      = b.gain;
+            _eqNodes.push(f);
+          });
+
+          _eqNodes.reduce((prev, cur) => { prev.connect(cur); return cur; }, _eqSource);
+          _eqNodes[_eqNodes.length - 1].connect(_eqCtx.destination);
+          if (_eqCtx.state === 'suspended') _eqCtx.resume();
+        };
         window.vibezSetRepeat  = (mode) => { _log(`[js:repeat] → ${_repeatName[mode]||mode}`); _m().repeatMode  = mode; };
         window.vibezSetShuffle = (on) => {
           _log(`[js:shuffle] → ${on ? 'on' : 'off'}`);

--- a/internal/player/webkit/player.go
+++ b/internal/player/webkit/player.go
@@ -266,6 +266,10 @@ func (p *Player) SetShuffle(on bool) error {
 	return nil
 }
 
+func (p *Player) SetEqualizer(_ []player.EQBand) error {
+	return nil
+}
+
 func (p *Player) RemoveFromQueue(idx int) error {
 	p.dispatch(fmt.Sprintf(`window.vibezQueueRemove && window.vibezQueueRemove(%d)`, idx))
 	return nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -90,6 +90,20 @@ func (p *feedPanel) SetSize(w, h int)                   { p.m.SetSize(w, h) }
 func (p *feedPanel) Update(msg tea.KeyPressMsg) tea.Cmd { return p.m.Update(msg) }
 func (p *feedPanel) View() string                       { return p.m.View() }
 
+// eqPanel wraps views.EQModel to satisfy ContentView.
+type eqPanel struct{ m *views.EQModel }
+
+func (p *eqPanel) NavKey() string   { return "e" }
+func (p *eqPanel) NavLabel() string { return "equalizer" }
+func (p *eqPanel) SetSize(w, h int) { p.m.SetSize(w, h) }
+func (p *eqPanel) Update(msg tea.KeyPressMsg) tea.Cmd {
+	if msg.String() == "e" {
+		return nil
+	}
+	return p.m.Update(msg)
+}
+func (p *eqPanel) View() string { return p.m.View() }
+
 // ── Messages ──────────────────────────────────────────────────────────────
 
 type playerStateMsg player.State
@@ -219,6 +233,7 @@ type Model struct {
 	queue       *queuePanel
 	lyricsP     *lyricsPanel
 	feedP       *feedPanel
+	eqP         *eqPanel
 
 	// Lyrics
 	lyricsClient      *lyrics.Client
@@ -297,10 +312,12 @@ func New(cfg *config.Config, prov provider.Provider, plyr player.Player, opts Op
 	m.lyricsP = &lyricsPanel{m: views.NewLyrics()}
 	m.lyricsClient = lyrics.NewClient()
 	m.feedP = &feedPanel{m: views.NewFeed()}
+	eqBands := configEQBandsToPlayer(cfg.EQBands)
+	m.eqP = &eqPanel{m: views.NewEqualizer(eqBands)}
 	m.vibe = views.NewVibe()
 	m.search = views.NewSearch(prov)
 	m.favorites = make(map[string]bool)
-	m.panels = []ContentView{m.library, m.queue, m.lyricsP, m.feedP}
+	m.panels = []ContentView{m.library, m.queue, m.lyricsP, m.feedP, m.eqP}
 	if opts.Backend != "" {
 		m.appendLog("[engine] backend: " + opts.Backend)
 	}
@@ -378,6 +395,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.search.SetSize(contentW, panelH)
 		m.lyricsP.SetSize(contentW, panelH)
 		m.feedP.SetSize(contentW, panelH)
+		m.eqP.SetSize(contentW, panelH)
 
 	case tickMsg:
 		if m.errMsg != "" && time.Now().After(m.errExpiry) {
@@ -545,6 +563,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.feedP.m.SetRecommendations(msg.groups)
 			m.appendLog(fmt.Sprintf("[feed] loaded %d groups", len(msg.groups)))
+		}
+
+	case views.EQChangeMsg:
+		if m.player != nil {
+			if err := m.player.SetEqualizer(msg.Bands); err != nil {
+				m.appendLog(fmt.Sprintf("[eq] error: %v", err))
+			}
+		}
+		m.cfg.EQBands = playerEQBandsToConfig(msg.Bands)
+		if err := m.cfg.Save(""); err != nil {
+			m.appendLog(fmt.Sprintf("[eq] config save error: %v", err))
 		}
 
 	case feedTracksMsg:
@@ -794,6 +823,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.player.SetVolume(v)
 			}))
 			m.appendLog(fmt.Sprintf("[vol] restored %.0f%% from config", v*100))
+		}
+		if len(m.cfg.EQBands) > 0 {
+			bands := configEQBandsToPlayer(m.cfg.EQBands)
+			cmds = append(cmds, m.playerCmd(func() error {
+				return m.player.SetEqualizer(bands)
+			}))
+			m.appendLog("[eq] restored from config")
 		}
 		if m.memProfiling {
 			cmds = append(cmds, memTick(m.helperPaths))
@@ -3084,4 +3120,23 @@ func (m *Model) renderPlaylistPickerModal() string {
 		Padding(0, 1).
 		Width(innerW).
 		Render(strings.Join(lines, "\n"))
+}
+
+func configEQBandsToPlayer(bands []config.EQBand) []player.EQBand {
+	if len(bands) == 0 {
+		return nil
+	}
+	out := make([]player.EQBand, len(bands))
+	for i, b := range bands {
+		out[i] = player.EQBand{Frequency: b.Frequency, Q: b.Q, Gain: b.Gain}
+	}
+	return out
+}
+
+func playerEQBandsToConfig(bands []player.EQBand) []config.EQBand {
+	out := make([]config.EQBand, len(bands))
+	for i, b := range bands {
+		out[i] = config.EQBand{Frequency: b.Frequency, Q: b.Q, Gain: b.Gain}
+	}
+	return out
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2322,7 +2322,8 @@ func (m *Model) renderBoxLayout() string {
 	queueActive := m.activePanel >= 0 && m.panels[m.activePanel] == m.queue
 	lyricsActive := m.activePanel >= 0 && m.panels[m.activePanel] == m.lyricsP
 	feedActive := m.activePanel >= 0 && m.panels[m.activePanel] == m.feedP
-	fullWidth := libraryActive || queueActive || lyricsActive || feedActive || m.mode == modeSearch || m.mode == modeCommand || m.debugView
+	eqActive := m.activePanel >= 0 && m.panels[m.activePanel] == m.eqP
+	fullWidth := libraryActive || queueActive || lyricsActive || feedActive || eqActive || m.mode == modeSearch || m.mode == modeCommand || m.debugView
 
 	var sb strings.Builder
 
@@ -2379,6 +2380,11 @@ func (m *Model) renderBoxLayout() string {
 	case feedActive:
 		m.feedP.SetSize(inner-2, panelH)
 		for _, line := range toLines(m.feedP.View(), panelH) {
+			sb.WriteString("│ " + padRight(line, inner-2) + " │\n")
+		}
+	case eqActive:
+		m.eqP.SetSize(inner-2, panelH)
+		for _, line := range toLines(m.eqP.View(), panelH) {
 			sb.WriteString("│ " + padRight(line, inner-2) + " │\n")
 		}
 	default:
@@ -2773,6 +2779,15 @@ func (m *Model) statusNavContent(_ int) string {
 				accent.Render("r") + muted.Render(" refresh"),
 				accent.Render("esc") + muted.Render(" close"),
 			}
+		case m.activePanel >= 0 && m.panels[m.activePanel] == m.eqP:
+			parts = []string{
+				styles.ModeNormal.Render("EQUALIZER"),
+				accent.Render("←/→") + muted.Render(" band"),
+				accent.Render("↑/↓") + muted.Render(" gain"),
+				accent.Render("0") + muted.Render(" reset band"),
+				accent.Render("r") + muted.Render(" reset all"),
+				accent.Render("e") + muted.Render(" close"),
+			}
 		default:
 			parts = []string{
 				styles.ModeNormal.Render("NORMAL"),
@@ -2782,6 +2797,7 @@ func (m *Model) statusNavContent(_ int) string {
 				accent.Render("q") + muted.Render(" queue"),
 				accent.Render("y") + muted.Render(" lyrics"),
 				accent.Render("F") + muted.Render(" feed"),
+				accent.Render("e") + muted.Render(" equalizer"),
 				accent.Render("v") + muted.Render(" vibe"),
 				accent.Render(":q") + muted.Render(" quit"),
 			}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -46,11 +46,12 @@ func (m *mockPlayer) Seek(pos time.Duration) error {
 	m.seekPos = pos
 	return m.err
 }
-func (m *mockPlayer) SetVolume(_ float64) error         { return m.err }
-func (m *mockPlayer) SetRepeat(_ int) error             { return m.err }
-func (m *mockPlayer) SetShuffle(_ bool) error           { return m.err }
-func (m *mockPlayer) SetQueue(ids []string) error       { m.setQueueIDs = ids; return m.err }
-func (m *mockPlayer) SetPlaylist(_ string, _ int) error { return m.err }
+func (m *mockPlayer) SetVolume(_ float64) error            { return m.err }
+func (m *mockPlayer) SetRepeat(_ int) error                { return m.err }
+func (m *mockPlayer) SetShuffle(_ bool) error              { return m.err }
+func (m *mockPlayer) SetEqualizer(_ []player.EQBand) error { return m.err }
+func (m *mockPlayer) SetQueue(ids []string) error          { m.setQueueIDs = ids; return m.err }
+func (m *mockPlayer) SetPlaylist(_ string, _ int) error    { return m.err }
 func (m *mockPlayer) AppendQueue(ids []string) error {
 	m.appendQueueIDs = append(m.appendQueueIDs, ids)
 	return m.err

--- a/internal/tui/views/equalizer.go
+++ b/internal/tui/views/equalizer.go
@@ -12,10 +12,13 @@ import (
 )
 
 const (
-	eqMinGain  = -12.0
-	eqMaxGain  = 12.0
-	eqStep     = 0.5
-	eqBarSteps = 24
+	eqMinGain = -12.0
+	eqMaxGain = 12.0
+	eqStep    = 0.5
+
+	eqOverheadRows = 5 // title + blank + gain row + freq label + help line
+	eqMinBarH      = 4
+	eqMaxBarH      = 24
 )
 
 type EQChangeMsg struct {
@@ -70,6 +73,11 @@ func (m *EQModel) Update(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func (m *EQModel) barHeight() int {
+	available := m.height - eqOverheadRows
+	return max(eqMinBarH, min(eqMaxBarH, available))
+}
+
 func (m *EQModel) View() string {
 	if len(m.bands) == 0 {
 		return ""
@@ -84,11 +92,12 @@ func (m *EQModel) View() string {
 		Foreground(styles.ColorMuted).
 		Render("←/→ band  ↑/↓ gain  0 reset band  r reset all  e close")
 
-	colW := max(6, (m.width-2)/len(m.bands))
+	colW := max(7, (m.width-2)/len(m.bands))
+	barH := m.barHeight()
 
 	var cols []string
 	for i, b := range m.bands {
-		cols = append(cols, m.renderBand(i, b, colW))
+		cols = append(cols, m.renderBand(i, b, colW, barH))
 	}
 
 	bands := lipgloss.JoinHorizontal(lipgloss.Top, cols...)
@@ -97,15 +106,13 @@ func (m *EQModel) View() string {
 		title,
 		"",
 		bands,
-		"",
 		help,
 	)
 }
 
-func (m *EQModel) renderBand(idx int, b player.EQBand, colW int) string {
-	barH := eqBarSteps
+func (m *EQModel) renderBand(idx int, b player.EQBand, colW, barH int) string {
 	filled := int(math.Round((b.Gain - eqMinGain) / (eqMaxGain - eqMinGain) * float64(barH)))
-	zeroLine := int(math.Round(float64(barH) / 2))
+	zeroLine := barH / 2
 
 	selected := idx == m.cursor
 
@@ -133,30 +140,28 @@ func (m *EQModel) renderBand(idx int, b player.EQBand, colW int) string {
 		default:
 			ch = " "
 		}
-		cell := lipgloss.NewStyle().Foreground(barColor).Render(ch)
-		rows = append(rows, cell)
+		rows = append(rows, lipgloss.NewStyle().Foreground(barColor).Render(ch))
 	}
 
 	bar := strings.Join(rows, "\n")
 
-	label := formatFreq(b.Frequency)
+	freq := formatFreq(b.Frequency)
 	gain := fmt.Sprintf("%+.1f", b.Gain)
 
-	labelStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center).Foreground(styles.ColorMuted)
-	gainStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center)
+	freqStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center).Foreground(styles.ColorMuted)
+	gainStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center).Foreground(styles.ColorFg)
 	if selected {
-		labelStyle = labelStyle.Foreground(styles.ColorPrimary).Bold(true)
+		freqStyle = freqStyle.Foreground(styles.ColorPrimary).Bold(true)
 		gainStyle = gainStyle.Foreground(styles.ColorPrimary).Bold(true)
 	}
 
 	col := lipgloss.JoinVertical(lipgloss.Center,
 		gainStyle.Render(gain),
 		bar,
-		labelStyle.Render(label),
+		freqStyle.Render(freq),
 	)
 
-	colStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center)
-	return colStyle.Render(col)
+	return lipgloss.NewStyle().Width(colW).Align(lipgloss.Center).Render(col)
 }
 
 func formatFreq(f float64) string {

--- a/internal/tui/views/equalizer.go
+++ b/internal/tui/views/equalizer.go
@@ -1,0 +1,167 @@
+package views
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/simone-vibes/vibez/internal/player"
+	"github.com/simone-vibes/vibez/internal/tui/styles"
+)
+
+const (
+	eqMinGain  = -12.0
+	eqMaxGain  = 12.0
+	eqStep     = 0.5
+	eqBarSteps = 24
+)
+
+type EQChangeMsg struct {
+	Bands []player.EQBand
+}
+
+type EQModel struct {
+	bands  []player.EQBand
+	cursor int
+	width  int
+	height int
+}
+
+func NewEqualizer(bands []player.EQBand) *EQModel {
+	if len(bands) == 0 {
+		bands = player.DefaultEQBands()
+	}
+	return &EQModel{bands: bands}
+}
+
+func (m *EQModel) SetSize(w, h int) { m.width = w; m.height = h }
+
+func (m *EQModel) Bands() []player.EQBand { return m.bands }
+
+func (m *EQModel) Update(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "left", "h":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "right", "l":
+		if m.cursor < len(m.bands)-1 {
+			m.cursor++
+		}
+	case "up", "k":
+		b := &m.bands[m.cursor]
+		b.Gain = math.Min(eqMaxGain, b.Gain+eqStep)
+		return func() tea.Msg { return EQChangeMsg{Bands: m.bands} }
+	case "down", "j":
+		b := &m.bands[m.cursor]
+		b.Gain = math.Max(eqMinGain, b.Gain-eqStep)
+		return func() tea.Msg { return EQChangeMsg{Bands: m.bands} }
+	case "0":
+		m.bands[m.cursor].Gain = 0
+		return func() tea.Msg { return EQChangeMsg{Bands: m.bands} }
+	case "r":
+		for i := range m.bands {
+			m.bands[i].Gain = 0
+		}
+		return func() tea.Msg { return EQChangeMsg{Bands: m.bands} }
+	}
+	return nil
+}
+
+func (m *EQModel) View() string {
+	if len(m.bands) == 0 {
+		return ""
+	}
+
+	title := lipgloss.NewStyle().
+		Foreground(styles.ColorPrimary).
+		Bold(true).
+		Render("Equalizer")
+
+	help := lipgloss.NewStyle().
+		Foreground(styles.ColorMuted).
+		Render("←/→ band  ↑/↓ gain  0 reset band  r reset all  e close")
+
+	colW := max(6, (m.width-2)/len(m.bands))
+
+	var cols []string
+	for i, b := range m.bands {
+		cols = append(cols, m.renderBand(i, b, colW))
+	}
+
+	bands := lipgloss.JoinHorizontal(lipgloss.Top, cols...)
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		title,
+		"",
+		bands,
+		"",
+		help,
+	)
+}
+
+func (m *EQModel) renderBand(idx int, b player.EQBand, colW int) string {
+	barH := eqBarSteps
+	filled := int(math.Round((b.Gain - eqMinGain) / (eqMaxGain - eqMinGain) * float64(barH)))
+	zeroLine := int(math.Round(float64(barH) / 2))
+
+	selected := idx == m.cursor
+
+	barColor := styles.ColorSubtle
+	if b.Gain > 0 {
+		barColor = styles.ColorActive
+	} else if b.Gain < 0 {
+		barColor = styles.ColorError
+	}
+	if selected {
+		barColor = styles.ColorPrimary
+	}
+
+	var rows []string
+	for row := barH; row >= 0; row-- {
+		var ch string
+		switch {
+		case row == zeroLine:
+			ch = "─"
+		case row == filled:
+			ch = "█"
+		case (b.Gain > 0 && row <= filled && row > zeroLine) ||
+			(b.Gain < 0 && row >= filled && row < zeroLine):
+			ch = "│"
+		default:
+			ch = " "
+		}
+		cell := lipgloss.NewStyle().Foreground(barColor).Render(ch)
+		rows = append(rows, cell)
+	}
+
+	bar := strings.Join(rows, "\n")
+
+	label := formatFreq(b.Frequency)
+	gain := fmt.Sprintf("%+.1f", b.Gain)
+
+	labelStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center).Foreground(styles.ColorMuted)
+	gainStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center)
+	if selected {
+		labelStyle = labelStyle.Foreground(styles.ColorPrimary).Bold(true)
+		gainStyle = gainStyle.Foreground(styles.ColorPrimary).Bold(true)
+	}
+
+	col := lipgloss.JoinVertical(lipgloss.Center,
+		gainStyle.Render(gain),
+		bar,
+		labelStyle.Render(label),
+	)
+
+	colStyle := lipgloss.NewStyle().Width(colW).Align(lipgloss.Center)
+	return colStyle.Render(col)
+}
+
+func formatFreq(f float64) string {
+	if f >= 1000 {
+		return fmt.Sprintf("%.0fk", f/1000)
+	}
+	return fmt.Sprintf("%.0f", f)
+}


### PR DESCRIPTION
Closes #41

## Summary

- 10-band parametric EQ accessible via `e` in the TUI
- Each band covers a standard ISO frequency (32 Hz–16 kHz) with a hardcoded Q of 1.46 and gain adjustable from -12 to +12 dB in 0.5 dB steps
- Changes apply live via Web Audio API (`BiquadFilterNode` chain in Chrome/Widevine mode)
- EQ curve persisted to `eq_bands` in `~/.config/vibez/config.json` and restored on next launch