### PR TITLE
feat: Tune Chrome audio flags for WSL2 and remove single-process mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **WSL2 audio workaround flag** — set `"wsl": true` in `~/.config/vibez/config.json`
+  to enable Chrome audio tuning for WSL2 environments. When enabled, Chrome launches
+  with `--audio-buffer-size=4096` (absorbs Hyper-V scheduler jitter) and
+  `AudioServiceOutOfProcess` is added to `--disable-features` (prevents distortion
+  caused by PulseAudio and Windows running at mismatched sample rates). Disabled by
+  default so native Linux users are unaffected.
 - **10-band parametric equalizer** — press `e` to open the equalizer panel. Each of the 10
   ISO bands (32 Hz, 64 Hz, 125 Hz, 250 Hz, 500 Hz, 1 kHz, 2 kHz, 4 kHz, 8 kHz, 16 kHz)
   exposes independent frequency, Q factor, and gain (±12 dB, in 0.5 dB steps). Changes apply

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Full tracks stream via an embedded headless Chrome with Widevine DRM (auto-downl
 - **Desktop notifications** — see the current track in your notification area
 - **No external player needed** — vibez is fully self-contained, no Cider, no VLC
 - **Last.fm scrobbling** — optional integration; connect with `vibez auth lastfm login` and your listening history is tracked automatically
+- **WSL2 support** — set `"wsl": true` in config to enable audio workarounds for WSL2 environments
 
 ### 🌀 Vibe Mode
 
@@ -316,6 +317,29 @@ Use `↑` / `↓` (or `ctrl+p` / `ctrl+n`) to cycle through suggestions, and `ta
 | **WebKit + GStreamer** *(fallback)* | 30 s previews | Embedded webkit2gtk-4.0; GStreamer decodes preview URLs |
 
 Chrome is downloaded once to `~/.cache/vibez/playwright` and reused on every start.
+
+---
+
+## WSL2 Audio Setup
+
+Running vibez inside WSL2 can cause audio underruns or sample-rate distortion because the Hyper-V scheduler introduces jitter and PulseAudio / Windows may run at mismatched rates (44 100 Hz vs 48 000 Hz).
+
+Enable the WSL2 workaround by adding `"wsl": true` to `~/.config/vibez/config.json`:
+
+```json
+{
+  "wsl": true
+}
+```
+
+When enabled, vibez launches Chrome with:
+
+| Flag | Purpose |
+|------|---------|
+| `--audio-buffer-size=4096` | Larger buffer absorbs Hyper-V scheduler jitter |
+| `--disable-features=…,AudioServiceOutOfProcess` | Disables out-of-process audio service that causes distortion at mismatched sample rates |
+
+The flag is `false` by default so native Linux users are unaffected.
 
 ---
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,7 +181,7 @@ func runCDPFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserTok
 
 		// Step 5: Start engine — Chrome launches headless because token is already set.
 		prog.Send(tui.InitStatusMsg("Starting audio engine…"))
-		cdpPlayer, err := cdp.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront)
+		cdpPlayer, err := cdp.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront, cfg.WSL)
 		if err != nil {
 			prog.Send(tui.InitErrMsg{Err: fmt.Errorf("audio engine: %w", err)})
 			return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	LastfmSessionKey string `json:"lastfm_session_key,omitempty"`
 	// EQBands stores the last saved 10-band equalizer settings. nil means flat.
 	EQBands []EQBand `json:"eq_bands,omitempty"`
+	// WSL enables audio tuning workarounds for WSL2 environments where Hyper-V
+	// scheduler jitter causes audio underruns with default Chrome buffer sizes.
+	WSL bool `json:"wsl,omitempty"`
 }
 
 type EQBand struct {

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -96,44 +96,7 @@ func New(devToken, userToken, storefront string) (*Player, error) {
 	// (no auth UI needed); show a real window for first-run interactive login.
 	headless := userToken != ""
 
-	args := []string{
-		// Sandbox requires suid/namespace support unavailable from a non-system path.
-		"--no-sandbox",
-		"--disable-setuid-sandbox",
-		// --no-zygote removes the Linux process-spawning shim; safe when sandbox
-		// is already disabled and cuts one helper process.
-		"--no-zygote",
-		"--autoplay-policy=no-user-gesture-required",
-		"--enable-features=MediaCapabilities,WidevineCdm",
-		"--disable-blink-features=AutomationControlled",
-		"--widevine-path=" + widevinePath,
-		// Suppress Chrome's built-in MPRIS D-Bus registration so our Go
-		// MPRIS server (org.mpris.MediaPlayer2.vibez) is the sole player
-		// visible to the desktop environment.
-		// Also disable the certificate-verifier component updater: when
-		// Chrome swaps it mid-session it raises ERR_CERT_VERIFIER_CHANGED
-		// which breaks all TLS connections including the MusicKit.js CDN load.
-		"--disable-features=HardwareMediaKeyHandling,MediaSessionService,CertificateTransparencyComponentUpdater",
-		"--disable-component-update",
-		"--ignore-certificate-errors",
-		// Memory footprint reduction:
-		// Removes the GPU compositor process (~100–200 MB) — not needed for
-		// audio-only headless playback; Widevine CDM runs in a utility process
-		// and does not require GPU acceleration for audio DRM.
-		"--disable-gpu",
-		// Use /tmp for shared-memory segments instead of /dev/shm to avoid
-		// exhausting the (often small) tmpfs mounted there.
-		"--disable-dev-shm-usage",
-		// Cap the V8 JavaScript heap at 256 MB. MusicKit.js runs comfortably
-		// within this limit; without it Chrome can balloon to 500 MB+.
-		"--js-flags=--max-old-space-size=256",
-		// Disable background network activity (prefetch, DNS pre-resolve,
-		// speculative connections). Not needed for a single-page music player.
-		"--disable-background-networking",
-		// Run browser and renderer in a single OS process. Validated to work
-		// with Widevine DRM; cuts helper count from 8 → 4 and saves ~50 MB PSS.
-		"--single-process",
-	}
+	args := launchArgs(widevinePath)
 
 	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
 		ExecutablePath:    &chromePath,
@@ -279,6 +242,49 @@ func New(devToken, userToken, storefront string) (*Player, error) {
 	}()
 
 	return p, nil
+}
+
+func launchArgs(widevinePath string) []string {
+	return []string{
+		// Sandbox requires suid/namespace support unavailable from a non-system path.
+		"--no-sandbox",
+		"--disable-setuid-sandbox",
+		// --no-zygote removes the Linux process-spawning shim; safe when sandbox
+		// is already disabled and cuts one helper process.
+		"--no-zygote",
+		"--autoplay-policy=no-user-gesture-required",
+		"--enable-features=MediaCapabilities,WidevineCdm",
+		"--disable-blink-features=AutomationControlled",
+		"--widevine-path=" + widevinePath,
+		// Suppress Chrome's built-in MPRIS D-Bus registration so our Go
+		// MPRIS server (org.mpris.MediaPlayer2.vibez) is the sole player
+		// visible to the desktop environment.
+		// Also disable the certificate-verifier component updater: when
+		// Chrome swaps it mid-session it raises ERR_CERT_VERIFIER_CHANGED
+		// which breaks all TLS connections including the MusicKit.js CDN load.
+		"--disable-features=HardwareMediaKeyHandling,MediaSessionService,CertificateTransparencyComponentUpdater",
+		"--disable-component-update",
+		"--ignore-certificate-errors",
+		// Memory footprint reduction:
+		// Removes the GPU compositor process (~100–200 MB) — not needed for
+		// audio-only headless playback; Widevine CDM runs in a utility process
+		// and does not require GPU acceleration for audio DRM.
+		"--disable-gpu",
+		// Use /tmp for shared-memory segments instead of /dev/shm to avoid
+		// exhausting the (often small) tmpfs mounted there.
+		"--disable-dev-shm-usage",
+		// Cap the V8 JavaScript heap at 256 MB. MusicKit.js runs comfortably
+		// within this limit; without it Chrome can balloon to 500 MB+.
+		"--js-flags=--max-old-space-size=256",
+		// Disable background network activity (prefetch, DNS pre-resolve,
+		// speculative connections). Not needed for a single-page music player.
+		"--disable-background-networking",
+		// WSL2/PulseAudio: increase audio buffering to absorb Hyper-V scheduler jitter.
+		"--audio-buffer-size=4096",
+		// Disable Chrome's out-of-process audio service to avoid distortion
+		// when PulseAudio and Windows run at different sample rates (44100 vs 48000).
+		"--disable-features=AudioServiceOutOfProcess",
+	}
 }
 
 func (p *Player) sendError(err error) {

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -49,7 +49,7 @@ type Player struct {
 }
 
 // New creates a CDP Player. EnsureBrowser must be called once before New().
-func New(devToken, userToken, storefront string) (*Player, error) {
+func New(devToken, userToken, storefront string, wsl bool) (*Player, error) {
 	html, err := web.RenderHTML(devToken, userToken, storefront, "1.0.0")
 	if err != nil {
 		return nil, fmt.Errorf("cdp: render html: %w", err)
@@ -96,7 +96,7 @@ func New(devToken, userToken, storefront string) (*Player, error) {
 	// (no auth UI needed); show a real window for first-run interactive login.
 	headless := userToken != ""
 
-	args := launchArgs(widevinePath)
+	args := launchArgs(widevinePath, wsl)
 
 	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
 		ExecutablePath:    &chromePath,
@@ -244,8 +244,15 @@ func New(devToken, userToken, storefront string) (*Player, error) {
 	return p, nil
 }
 
-func launchArgs(widevinePath string) []string {
-	return []string{
+func launchArgs(widevinePath string, wsl bool) []string {
+	disableFeatures := "HardwareMediaKeyHandling,MediaSessionService,CertificateTransparencyComponentUpdater"
+	if wsl {
+		// WSL2: disable out-of-process audio service to avoid distortion when
+		// PulseAudio and Windows run at different sample rates (44100 vs 48000).
+		disableFeatures += ",AudioServiceOutOfProcess"
+	}
+
+	args := []string{
 		// Sandbox requires suid/namespace support unavailable from a non-system path.
 		"--no-sandbox",
 		"--disable-setuid-sandbox",
@@ -262,7 +269,7 @@ func launchArgs(widevinePath string) []string {
 		// Also disable the certificate-verifier component updater: when
 		// Chrome swaps it mid-session it raises ERR_CERT_VERIFIER_CHANGED
 		// which breaks all TLS connections including the MusicKit.js CDN load.
-		"--disable-features=HardwareMediaKeyHandling,MediaSessionService,CertificateTransparencyComponentUpdater",
+		"--disable-features=" + disableFeatures,
 		"--disable-component-update",
 		"--ignore-certificate-errors",
 		// Memory footprint reduction:
@@ -279,12 +286,14 @@ func launchArgs(widevinePath string) []string {
 		// Disable background network activity (prefetch, DNS pre-resolve,
 		// speculative connections). Not needed for a single-page music player.
 		"--disable-background-networking",
-		// WSL2/PulseAudio: increase audio buffering to absorb Hyper-V scheduler jitter.
-		"--audio-buffer-size=4096",
-		// Disable Chrome's out-of-process audio service to avoid distortion
-		// when PulseAudio and Windows run at different sample rates (44100 vs 48000).
-		"--disable-features=AudioServiceOutOfProcess",
 	}
+
+	if wsl {
+		// WSL2/PulseAudio: increase audio buffering to absorb Hyper-V scheduler jitter.
+		args = append(args, "--audio-buffer-size=4096")
+	}
+
+	return args
 }
 
 func (p *Player) sendError(err error) {

--- a/internal/player/cdp/player_test.go
+++ b/internal/player/cdp/player_test.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package cdp
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestLaunchArgs_WSL2AudioFlags(t *testing.T) {
+	args := launchArgs("/tmp/widevine")
+
+	if !slices.Contains(args, "--audio-buffer-size=4096") {
+		t.Fatalf("launch args missing audio buffer flag")
+	}
+	if !slices.Contains(args, "--disable-features=AudioServiceOutOfProcess") {
+		t.Fatalf("launch args missing AudioServiceOutOfProcess flag")
+	}
+	if slices.Contains(args, "--single-process") {
+		t.Fatalf("launch args should not include --single-process")
+	}
+	if !slices.Contains(args, "--widevine-path=/tmp/widevine") {
+		t.Fatalf("launch args missing widevine path")
+	}
+}

--- a/internal/player/cdp/player_test.go
+++ b/internal/player/cdp/player_test.go
@@ -4,22 +4,53 @@ package cdp
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
-func TestLaunchArgs_WSL2AudioFlags(t *testing.T) {
-	args := launchArgs("/tmp/widevine")
+func TestLaunchArgs_WSL(t *testing.T) {
+	args := launchArgs("/tmp/widevine", true)
 
 	if !slices.Contains(args, "--audio-buffer-size=4096") {
-		t.Fatalf("launch args missing audio buffer flag")
+		t.Fatal("wsl=true: missing --audio-buffer-size=4096")
 	}
-	if !slices.Contains(args, "--disable-features=AudioServiceOutOfProcess") {
-		t.Fatalf("launch args missing AudioServiceOutOfProcess flag")
+	disableFeaturesContains(t, args, "AudioServiceOutOfProcess", true)
+	if !slices.Contains(args, "--widevine-path=/tmp/widevine") {
+		t.Fatal("missing --widevine-path")
 	}
 	if slices.Contains(args, "--single-process") {
-		t.Fatalf("launch args should not include --single-process")
+		t.Fatal("--single-process must not be present")
 	}
+}
+
+func TestLaunchArgs_NonWSL(t *testing.T) {
+	args := launchArgs("/tmp/widevine", false)
+
+	if slices.Contains(args, "--audio-buffer-size=4096") {
+		t.Fatal("wsl=false: --audio-buffer-size=4096 should not be present")
+	}
+	disableFeaturesContains(t, args, "AudioServiceOutOfProcess", false)
 	if !slices.Contains(args, "--widevine-path=/tmp/widevine") {
-		t.Fatalf("launch args missing widevine path")
+		t.Fatal("missing --widevine-path")
 	}
+}
+
+// disableFeaturesContains checks whether a feature name appears inside the
+// --disable-features=... argument in args.
+func disableFeaturesContains(t *testing.T, args []string, feature string, want bool) {
+	t.Helper()
+	for _, a := range args {
+		if strings.HasPrefix(a, "--disable-features=") {
+			got := strings.Contains(a, feature)
+			if got != want {
+				if want {
+					t.Fatalf("--disable-features missing %q", feature)
+				} else {
+					t.Fatalf("--disable-features should not contain %q", feature)
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("--disable-features flag not found")
 }


### PR DESCRIPTION
This pull request refactors how Chromium launch arguments are constructed for the player, moving them into a dedicated helper function and updating the arguments to improve audio handling on Linux/WSL2. It also adds a unit test to ensure the correct flags are present.

**Refactoring and code organization:**

* Extracted the Chromium launch arguments from inline construction in `New` to a new helper function `launchArgs`, improving maintainability and readability (`internal/player/cdp/player.go`). [[1]](diffhunk://#diff-df65b0d60f24506fe46f9559365fe1e5da78dcf68cfb2826e098604b30e4c02cL99-R99) [[2]](diffhunk://#diff-df65b0d60f24506fe46f9559365fe1e5da78dcf68cfb2826e098604b30e4c02cR247-R289)

**Audio handling improvements for Linux/WSL2:**

* Added `--audio-buffer-size=4096` and `--disable-features=AudioServiceOutOfProcess` flags in `launchArgs` to address audio buffering and distortion issues on WSL2/PulseAudio setups (`internal/player/cdp/player.go`).

**Testing:**

* Introduced a new Linux-only test `TestLaunchArgs_WSL2AudioFlags` to verify that `launchArgs` includes the necessary audio flags and the correct Widevine path (`internal/player/cdp/player_test.go`).