### PR TITLE
Add configurable Apple Music audio quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AudioServiceOutOfProcess` is added to `--disable-features` (prevents distortion
   caused by PulseAudio and Windows running at mismatched sample rates). Disabled by
   default so native Linux users are unaffected.
+- **Configurable Apple Music audio quality** — set `audio_quality` in
+  `config.json` or use `:quality <high|standard|256|64>` in the TUI to switch
+  between MusicKit's supported AAC streaming tiers. Unsupported values such as
+  lossless, Hi-Res, 320 kbps, or ALAC are rejected with a clear message because
+  MusicKit JS/web playback only exposes 64 kbps and 256 kbps AAC.
+
 - **10-band parametric equalizer** — press `e` to open the equalizer panel. Each of the 10
   ISO bands (32 Hz, 64 Hz, 125 Hz, 250 Hz, 500 Hz, 1 kHz, 2 kHz, 4 kHz, 8 kHz, 16 kHz)
   exposes independent frequency, Q factor, and gain (±12 dB, in 0.5 dB steps). Changes apply

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Vim-style command mode — press `:` from anywhere to open the command prompt.
 | `:vol +n` / `:vol -n` | Raise or lower volume by *n* percent (e.g. `:vol +10`) |
 | `:vol` | Show current volume in the status bar |
 | `:mute` | Toggle mute (run again to restore the previous volume) |
+| `:quality <high|standard|256|64>` | Set Apple Music AAC bitrate |
+| `:bitrate <high|standard|256|64>` | Alias for `:quality` |
 | `:seek <seconds>` | Jump to an absolute position in the current song |
 | `:debug-logs` | Toggle the debug log panel |
 | `:q` / `:quit` | Quit vibez |
@@ -348,6 +350,18 @@ When enabled, vibez launches Chrome with:
 | `--disable-features=…,AudioServiceOutOfProcess` | Disables out-of-process audio service that causes distortion at mismatched sample rates |
 
 The flag is `false` by default so native Linux users are unaffected.
+
+### Audio quality
+
+Set `audio_quality` in `~/.config/vibez/config.json`:
+
+```json
+{
+  "audio_quality": "high"
+}
+```
+
+Supported values: `"high"`/`"256"` for 256 kbps AAC (default), `"standard"`/`"64"` for 64 kbps AAC. MusicKit JS/web playback maxes out at 256 kbps AAC; lossless and Hi-Res/ALAC are not available through the Chrome/CDP backend. WebKit + GStreamer uses fixed 30 s preview URLs and cannot change bitrate at runtime.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ Vim-style command mode — press `:` from anywhere to open the command prompt.
 | `:vol` | Show current volume in the status bar |
 | `:mute` | Toggle mute (run again to restore the previous volume) |
 | `:quality <high|standard|256|64>` | Set Apple Music AAC bitrate |
-| `:bitrate <high|standard|256|64>` | Alias for `:quality` |
 | `:seek <seconds>` | Jump to an absolute position in the current song |
 | `:debug-logs` | Toggle the debug log panel |
 | `:q` / `:quit` | Quit vibez |

--- a/cmd/cdp_common.go
+++ b/cmd/cdp_common.go
@@ -25,10 +25,10 @@ type cdpPlatformHooks struct {
 	initStatus  string
 	afterReady  func(*cdp.Player)
 	helperPaths func() []string
-	backend     func() string
+	backend     func(audioBitrateKbps int) string
 }
 
-func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront func(string), hooks cdpPlatformHooks) error {
+func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int, hooks cdpPlatformHooks) error {
 	prog := tea.NewProgram(tui.New(cfg, nil, nil, opts))
 	playerCh := make(chan *cdp.Player, 1)
 	runDone := make(chan struct{})
@@ -73,7 +73,7 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 		}
 
 		prog.Send(tui.InitStatusMsg("Starting audio engine..."))
-		cdpPlayer, err := cdp.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront, cfg.WSL)
+		cdpPlayer, err := cdp.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront, cfg.WSL, audioBitrateKbps)
 		if err != nil {
 			prog.Send(tui.InitErrMsg{Err: fmt.Errorf("audio engine: %w", err)})
 			return
@@ -119,7 +119,7 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 			Player:      cdpPlayer,
 			Provider:    apple.New(cfg),
 			HelperPaths: hooks.helperPaths(),
-			Backend:     hooks.backend(),
+			Backend:     hooks.backend(audioBitrateKbps),
 		})
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,11 @@ func runTUI(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
+	audioBitrateKbps, err := cfg.AudioBitrateKbps()
+	if err != nil {
+		return err
+	}
+
 	opts := tui.Options{MemProfiling: memProfiling}
 
 	// Apply theme before creating any TUI model so all panels pick up the palette.
@@ -104,5 +109,6 @@ func runTUI(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	return runPlatform(cfg, iconPath, opts, onUserToken, onStorefront)
+	return runPlatform(cfg, iconPath, opts, onUserToken, onStorefront, audioBitrateKbps)
+
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,7 @@ func runTUI(_ *cobra.Command, _ []string) error {
 	// but lets the DE resolve the icon via the MPRIS DesktopEntry property.
 	iconPath := assets.InstallIcon()
 	assets.InstallDesktopEntry()
+	opts.IconPath = iconPath
 
 	onUserToken := func(token string) {
 		cfg.AppleUserToken = token

--- a/cmd/root_darwin.go
+++ b/cmd/root_darwin.go
@@ -10,14 +10,14 @@ import (
 	"github.com/simone-vibes/vibez/internal/tui"
 )
 
-func runPlatform(cfg *config.Config, _ string, opts tui.Options, onUserToken, onStorefront func(string)) error {
-	return runCDPFlow(cfg, opts, onUserToken, onStorefront, cdpPlatformHooks{
+func runPlatform(cfg *config.Config, _ string, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int) error {
+	return runCDPFlow(cfg, opts, onUserToken, onStorefront, audioBitrateKbps, cdpPlatformHooks{
 		initStatus: "Checking Google Chrome...",
 		helperPaths: func() []string {
 			return []string{cdp.ChromePath()}
 		},
-		backend: func() string {
-			return fmt.Sprintf("Chrome/CDP · provider: Apple Music · helper: %s", cdp.ChromePath())
+		backend: func(audioBitrateKbps int) string {
+			return fmt.Sprintf("Chrome/CDP · provider: Apple Music · %d kbps AAC · helper: %s", audioBitrateKbps, cdp.ChromePath())
 		},
 	})
 }

--- a/cmd/root_linux.go
+++ b/cmd/root_linux.go
@@ -19,12 +19,12 @@ import (
 	"github.com/simone-vibes/vibez/internal/tui"
 )
 
-func runPlatform(cfg *config.Config, iconPath string, opts tui.Options, onUserToken, onStorefront func(string)) error {
+func runPlatform(cfg *config.Config, iconPath string, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int) error {
 	_, chromeErr := os.Stat(cdp.ChromePath())
 	cdpAvailable := chromeErr == nil || runtime.GOARCH == "amd64"
 
 	if cdpAvailable {
-		return runCDPFlow(cfg, opts, onUserToken, onStorefront, cdpPlatformHooks{
+		return runCDPFlow(cfg, opts, onUserToken, onStorefront, audioBitrateKbps, cdpPlatformHooks{
 			initStatus: "Initializing vibez...",
 			afterReady: func(cdpPlayer *cdp.Player) {
 				if srv, mprisErr := mpris.NewServer(cdpPlayer); mprisErr == nil {
@@ -38,18 +38,18 @@ func runPlatform(cfg *config.Config, iconPath string, opts tui.Options, onUserTo
 			helperPaths: func() []string {
 				return []string{cdp.HelperPath(), cdp.ChromePath()}
 			},
-			backend: func() string {
-				return fmt.Sprintf("Chrome/CDP · provider: Apple Music · helper: %s", cdp.HelperPath())
+			backend: func(audioBitrateKbps int) string {
+				return fmt.Sprintf("Chrome/CDP · provider: Apple Music · %d kbps AAC · helper: %s", audioBitrateKbps, cdp.HelperPath())
 			},
 		})
 	}
-	return runWebKitFlow(cfg, iconPath, opts, onUserToken, onStorefront)
+	return runWebKitFlow(cfg, iconPath, opts, onUserToken, onStorefront, audioBitrateKbps)
 }
 
 // runWebKitFlow is the legacy path: GTK must own the main OS thread so auth
 // and engine setup happen before the TUI, and BubbleTea runs in a goroutine.
-func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserToken, onStorefront func(string)) error {
-	fmt.Fprintln(os.Stderr, "Engine: WebKit + GStreamer (30 s preview)")
+func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int) error {
+	fmt.Fprintln(os.Stderr, "Engine: WebKit + GStreamer (30 s preview, bitrate changes unsupported)")
 
 	if cfg.AppleUserToken != "" {
 		fmt.Fprintln(os.Stderr, "Checking Apple Music session...")
@@ -65,7 +65,7 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 		}
 	}
 
-	wkPlayer, err := webkit.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront)
+	wkPlayer, err := webkit.New(cfg.AppleDeveloperToken, cfg.AppleUserToken, cfg.StoreFront, audioBitrateKbps)
 	if err != nil {
 		return fmt.Errorf("creating audio engine: %w", err)
 	}
@@ -94,7 +94,7 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 			}()
 		}
 
-		opts.Backend = "WebKit/GStreamer · 30s preview · provider: Apple Music"
+		opts.Backend = "WebKit/GStreamer · fixed 30s previews · bitrate changes unsupported · provider: Apple Music"
 		m := tui.New(cfg, prov, wkPlayer, opts)
 		p := tea.NewProgram(m)
 

--- a/cmd/root_linux.go
+++ b/cmd/root_linux.go
@@ -94,6 +94,7 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 			}()
 		}
 
+		opts.IconPath = iconPath
 		opts.Backend = "WebKit/GStreamer · fixed 30s previews · bitrate changes unsupported · provider: Apple Music"
 		m := tui.New(cfg, prov, wkPlayer, opts)
 		p := tea.NewProgram(m)

--- a/internal/audioquality/quality.go
+++ b/internal/audioquality/quality.go
@@ -1,0 +1,51 @@
+package audioquality
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	StandardKbps = 64
+	HighKbps     = 256
+	DefaultKbps  = HighKbps
+)
+
+const unsupportedMessage = "MusicKit JS/web playback max is 256 kbps AAC; supported values are standard/64 kbps AAC and high/256 kbps AAC"
+
+func Parse(value string) (int, error) {
+	v := strings.ToLower(strings.TrimSpace(value))
+	if v == "" || v == "high" || v == "256" || v == "256kbps" || v == "256 kbps" {
+		return HighKbps, nil
+	}
+	if v == "standard" || v == "64" || v == "64kbps" || v == "64 kbps" {
+		return StandardKbps, nil
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return 0, fmt.Errorf("unsupported Apple Music bitrate %d kbps: %s", n, unsupportedMessage)
+	}
+	return 0, fmt.Errorf("unsupported Apple Music audio quality %q: lossless and hi-res are unavailable through MusicKit JS/web playback; %s", value, unsupportedMessage)
+}
+
+func Validate(kbps int) error {
+	switch kbps {
+	case StandardKbps, HighKbps:
+		return nil
+	default:
+		return fmt.Errorf("unsupported Apple Music bitrate %d kbps: %s", kbps, unsupportedMessage)
+	}
+}
+
+func ConfigValue(kbps int) (string, error) {
+	switch kbps {
+	case StandardKbps:
+		return "standard", nil
+	case HighKbps:
+		return "high", nil
+	default:
+		return "", fmt.Errorf("unsupported Apple Music bitrate %d kbps: %s", kbps, unsupportedMessage)
+	}
+}
+
+func UnsupportedMessage() string { return unsupportedMessage }

--- a/internal/audioquality/quality_test.go
+++ b/internal/audioquality/quality_test.go
@@ -1,0 +1,39 @@
+package audioquality
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSupportedQuality(t *testing.T) {
+	tests := map[string]int{"": HighKbps, "high": HighKbps, "256": HighKbps, "standard": StandardKbps, "64": StandardKbps}
+	for input, want := range tests {
+		got, err := Parse(input)
+		if err != nil || got != want {
+			t.Fatalf("Parse(%q) = %d, %v; want %d, nil", input, got, err, want)
+		}
+	}
+}
+
+func TestRejectUnsupportedQuality(t *testing.T) {
+	for _, input := range []string{"lossless", "hi-res", "1411", "320"} {
+		_, err := Parse(input)
+		if err == nil {
+			t.Fatalf("Parse(%q) succeeded", input)
+		}
+		if !strings.Contains(err.Error(), "MusicKit JS/web playback max is 256 kbps AAC") {
+			t.Fatalf("Parse(%q) error = %q", input, err)
+		}
+	}
+}
+
+func TestConfigValue(t *testing.T) {
+	got, err := ConfigValue(StandardKbps)
+	if err != nil || got != "standard" {
+		t.Fatalf("ConfigValue(64) = %q, %v", got, err)
+	}
+	got, err = ConfigValue(HighKbps)
+	if err != nil || got != "high" {
+		t.Fatalf("ConfigValue(256) = %q, %v", got, err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/simone-vibes/vibez/internal/audioquality"
 )
 
 type Config struct {
@@ -16,6 +18,7 @@ type Config struct {
 	AuthPort            int    `json:"auth_port"`
 	Provider            string `json:"provider"`
 	Theme               string `json:"theme"`
+	AudioQuality        string `json:"audio_quality,omitempty"`
 	// Volume is the last user-set playback volume (0.0–1.0). nil means
 	// "not yet saved" and the player default (1.0) is used on startup.
 	Volume *float64 `json:"volume,omitempty"`
@@ -53,10 +56,24 @@ func (c *Config) SetVolume(v float64) {
 
 func defaults() *Config {
 	return &Config{
-		AuthPort: 7777,
-		Provider: "apple",
-		Theme:    "default",
+		AuthPort:     7777,
+		Provider:     "apple",
+		Theme:        "default",
+		AudioQuality: "high",
 	}
+}
+
+func (c *Config) AudioBitrateKbps() (int, error) {
+	return audioquality.Parse(c.AudioQuality)
+}
+
+func (c *Config) SetAudioBitrate(kbps int) error {
+	value, err := audioquality.ConfigValue(kbps)
+	if err != nil {
+		return err
+	}
+	c.AudioQuality = value
+	return nil
 }
 
 func ConfigPath(override string) (string, error) {
@@ -105,6 +122,9 @@ func (c *Config) normalize() {
 	}
 	if c.Provider == "" {
 		c.Provider = "apple"
+	}
+	if c.AudioQuality == "" {
+		c.AudioQuality = "high"
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -300,3 +300,50 @@ func TestSave_WithOverridePath(t *testing.T) {
 		t.Errorf("AuthPort = %d, want 1234", loaded.AuthPort)
 	}
 }
+
+func TestAudioQualityDefaultsHigh(t *testing.T) {
+	path := writeCfg(t, map[string]any{"storefront": "us"})
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, err := cfg.AudioBitrateKbps()
+	if err != nil || got != 256 {
+		t.Fatalf("AudioBitrateKbps = %d, %v; want 256, nil", got, err)
+	}
+}
+
+func TestAudioQualityStandardRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := testConfigWithDefaults()
+	if err := cfg.SetAudioBitrate(64); err != nil {
+		t.Fatalf("SetAudioBitrate: %v", err)
+	}
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, err := loaded.AudioBitrateKbps()
+	if err != nil || got != 64 {
+		t.Fatalf("AudioBitrateKbps = %d, %v; want 64, nil", got, err)
+	}
+}
+
+func TestAudioQualityInvalidConfig(t *testing.T) {
+	path := writeCfg(t, map[string]any{"audio_quality": "lossless"})
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = cfg.AudioBitrateKbps()
+	if err == nil || !strings.Contains(err.Error(), "MusicKit JS/web playback max is 256 kbps AAC") {
+		t.Fatalf("AudioBitrateKbps error = %v", err)
+	}
+}
+
+func testConfigWithDefaults() *config.Config {
+	return &config.Config{AuthPort: 7777, Provider: "apple", Theme: "default"}
+}

--- a/internal/player/cdp/js.go
+++ b/internal/player/cdp/js.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/simone-vibes/vibez/internal/audioquality"
 	"github.com/simone-vibes/vibez/internal/player"
 )
 
@@ -42,6 +43,13 @@ func buildAppendQueueJS(ids []string) (string, error) {
 		return "", fmt.Errorf("cdp: marshal append json string: %w", err)
 	}
 	return fmt.Sprintf(`window.vibezAppendQueue && window.vibezAppendQueue(%s)`, js), nil
+}
+
+func buildSetAudioBitrateJS(kbps int) (string, error) {
+	if err := audioquality.Validate(kbps); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`window.vibezSetAudioBitrate && window.vibezSetAudioBitrate(%d)`, kbps), nil
 }
 
 func buildSetEqualizerJS(bands []player.EQBand) (string, error) {

--- a/internal/player/cdp/js_test.go
+++ b/internal/player/cdp/js_test.go
@@ -238,3 +238,22 @@ func TestBuildSetPlaylistJS_GuardPrefix(t *testing.T) {
 		t.Errorf("guard prefix missing in: %s", expr)
 	}
 }
+
+func TestBuildSetAudioBitrateJS_Supported(t *testing.T) {
+	for _, kbps := range []int{64, 256} {
+		expr, err := buildSetAudioBitrateJS(kbps)
+		if err != nil {
+			t.Fatalf("buildSetAudioBitrateJS(%d): %v", kbps, err)
+		}
+		if !strings.Contains(expr, "vibezSetAudioBitrate") {
+			t.Fatalf("expression does not call bitrate setter: %s", expr)
+		}
+	}
+}
+
+func TestBuildSetAudioBitrateJS_Unsupported(t *testing.T) {
+	_, err := buildSetAudioBitrateJS(320)
+	if err == nil || !strings.Contains(err.Error(), "MusicKit JS/web playback max is 256 kbps AAC") {
+		t.Fatalf("buildSetAudioBitrateJS(320) error = %v", err)
+	}
+}

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -48,8 +48,8 @@ type Player struct {
 }
 
 // New creates a CDP Player. EnsureBrowser must be called once before New().
-func New(devToken, userToken, storefront string, wsl bool) (*Player, error) {
-	html, err := web.RenderHTML(devToken, userToken, storefront, "1.0.0")
+func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int) (*Player, error) {
+	html, err := web.RenderHTML(devToken, userToken, storefront, "1.0.0", audioBitrateKbps)
 	if err != nil {
 		return nil, fmt.Errorf("cdp: render html: %w", err)
 	}
@@ -418,6 +418,15 @@ func (p *Player) Seek(position time.Duration) error {
 
 func (p *Player) SetVolume(v float64) error {
 	p.dispatch(fmt.Sprintf(`window.vibezSetVolume && window.vibezSetVolume(%f)`, v))
+	return nil
+}
+
+func (p *Player) SetAudioBitrate(kbps int) error {
+	expr, err := buildSetAudioBitrateJS(kbps)
+	if err != nil {
+		return err
+	}
+	p.dispatch(expr)
 	return nil
 }
 

--- a/internal/player/demo/player.go
+++ b/internal/player/demo/player.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/simone-vibes/vibez/internal/audioquality"
 	"github.com/simone-vibes/vibez/internal/player"
 	"github.com/simone-vibes/vibez/internal/provider"
 	demodp "github.com/simone-vibes/vibez/internal/provider/demo"
@@ -41,6 +42,7 @@ func New() *Player {
 		Track:   &p.queue[0],
 		Playing: true,
 		Volume:  0.8,
+		Bitrate: audioquality.HighKbps,
 	}
 	go p.run()
 	return p
@@ -144,6 +146,18 @@ func (p *Player) Seek(pos time.Duration) error {
 	if p.state.Track != nil && pos <= p.state.Track.Duration {
 		p.state.Position = pos
 	}
+	st := p.state
+	p.mu.Unlock()
+	p.broadcast(st)
+	return nil
+}
+
+func (p *Player) SetAudioBitrate(kbps int) error {
+	if err := audioquality.Validate(kbps); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.state.Bitrate = kbps
 	st := p.state
 	p.mu.Unlock()
 	p.broadcast(st)

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"errors"
 	"time"
 
 	"github.com/simone-vibes/vibez/internal/provider"
@@ -12,6 +13,8 @@ const (
 	RepeatModeOne = 1 // repeat current track
 	RepeatModeAll = 2 // repeat entire queue
 )
+
+var ErrAudioBitrateRequiresRestart = errors.New("audio bitrate change requires restarting the audio engine")
 
 // EQBand describes a single parametric equalizer band.
 // Gain is in dB (-12.0 to +12.0). Frequency is in Hz. Q is the quality factor.

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -53,6 +53,7 @@ type Player interface {
 	Previous() error
 	Seek(position time.Duration) error
 	SetVolume(v float64) error
+	SetAudioBitrate(kbps int) error
 	// SetQueue replaces the playback queue with the given catalog track IDs and
 	// starts playback from the first entry.
 	SetQueue(ids []string) error

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -14,7 +14,7 @@ const (
 	RepeatModeAll = 2 // repeat entire queue
 )
 
-var ErrAudioBitrateRequiresRestart = errors.New("audio bitrate change requires restarting the audio engine")
+var ErrAudioBitrateSavedPreferenceOnly = errors.New("audio bitrate saved as preference; backend cannot change bitrate at runtime")
 
 // EQBand describes a single parametric equalizer band.
 // Gain is in dB (-12.0 to +12.0). Frequency is in Hz. Q is the quality factor.

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -44,12 +44,18 @@
         try { music.isExplicitContentAllowed = true; } catch(_) {}
       }
 
-      // Request highest available streaming quality (256 kbps AAC — the ceiling
-      // for MusicKit JS on web). Falls back to the numeric value if the enum is
-      // not present in this build of MusicKit.
-      try {
-        music.bitrate = (MusicKit.PlaybackBitrate && MusicKit.PlaybackBitrate.HIGH) || 256;
-      } catch(_) {}
+      function resolveAudioBitrate(kbps) {
+        const n = Number(kbps);
+        if (n === 64) return (MusicKit.PlaybackBitrate && MusicKit.PlaybackBitrate.STANDARD) || 64;
+        if (n === 256) return (MusicKit.PlaybackBitrate && MusicKit.PlaybackBitrate.HIGH) || 256;
+        throw new Error('MusicKit JS/web playback max is 256 kbps AAC; supported values are 64 and 256 kbps AAC');
+      }
+
+      function applyAudioBitrate(kbps) {
+        music.bitrate = resolveAudioBitrate(kbps);
+      }
+
+      try { applyAudioBitrate({{.AudioBitrateKbps}}); } catch(e) { goError(e.message || String(e)).catch(() => {}); }
 
       const savedToken = '{{.UserToken}}';
       if (savedToken !== '') {
@@ -451,6 +457,11 @@
         const _repeatName = ['off', 'one', 'all'];
         window.vibezSeek      = (t) => { _log(`[js:seek] → ${t.toFixed(1)}s`); _m().seekToTime(t); };
         window.vibezSetVolume = (v) => { _log(`[js:volume] → ${Math.round(v*100)}%`); _m().volume = v; };
+        window.vibezSetAudioBitrate = (kbps) => {
+          applyAudioBitrate(kbps);
+          _log(`[js:bitrate] → ${Number(kbps)} kbps AAC`);
+          notifyState();
+        };
 
         // ── 10-band parametric equalizer (Web Audio API) ─────────────────────
         let _eqCtx    = null;

--- a/internal/player/web/musickit_test.mjs
+++ b/internal/player/web/musickit_test.mjs
@@ -389,5 +389,32 @@ test('vibezSetShuffle: setQueue resets shuffle snapshot', () => {
   _qUnshuffled = [];
   eq(_qUnshuffled.length, 0, 'shuffle snapshot cleared on setQueue');
 });
+
+// ─── audio bitrate ───────────────────────────────────────────────────────────
+const resolveAudioBitrate = (kbps, MusicKit) => {
+  const n = Number(kbps);
+  if (n === 64) return (MusicKit.PlaybackBitrate && MusicKit.PlaybackBitrate.STANDARD) || 64;
+  if (n === 256) return (MusicKit.PlaybackBitrate && MusicKit.PlaybackBitrate.HIGH) || 256;
+  throw new Error('MusicKit JS/web playback max is 256 kbps AAC; supported values are 64 and 256 kbps AAC');
+};
+
+console.log('\nresolveAudioBitrate()');
+test('64 uses STANDARD enum when present', () =>
+  eq(resolveAudioBitrate(64, { PlaybackBitrate: { STANDARD: 'standard' } }), 'standard'));
+test('256 uses HIGH enum when present', () =>
+  eq(resolveAudioBitrate(256, { PlaybackBitrate: { HIGH: 'high' } }), 'high'));
+test('64/256 fall back to numeric MusicKit values', () => {
+  eq(resolveAudioBitrate(64, {}), 64);
+  eq(resolveAudioBitrate(256, {}), 256);
+});
+test('lossless/unsupported values are rejected with web max', () => {
+  for (const input of ['lossless', 'hi-res', 320, 1411]) {
+    let ok = false;
+    try { resolveAudioBitrate(input, {}); }
+    catch (e) { ok = String(e.message).includes('MusicKit JS/web playback max is 256 kbps AAC'); }
+    if (!ok) throw new Error(`${input} was not rejected with MusicKit web max`);
+  }
+});
+
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/internal/player/web/web.go
+++ b/internal/player/web/web.go
@@ -8,23 +8,29 @@ import (
 	"text/template"
 
 	_ "embed"
+
+	"github.com/simone-vibes/vibez/internal/audioquality"
 )
 
 //go:embed musickit.html
 var musickitHTML string
 
 // RenderHTML renders the MusicKit HTML template with the provided parameters.
-func RenderHTML(devToken, userToken, storefront, version string) (string, error) {
+func RenderHTML(devToken, userToken, storefront, version string, audioBitrateKbps int) (string, error) {
+	if err := audioquality.Validate(audioBitrateKbps); err != nil {
+		return "", err
+	}
 	tmpl, err := template.New("musickit").Parse(musickitHTML)
 	if err != nil {
 		return "", fmt.Errorf("parsing musickit template: %w", err)
 	}
 	var buf strings.Builder
-	if err := tmpl.Execute(&buf, map[string]string{
-		"DeveloperToken": devToken,
-		"UserToken":      userToken,
-		"Storefront":     storefront,
-		"Version":        version,
+	if err := tmpl.Execute(&buf, map[string]any{
+		"DeveloperToken":   devToken,
+		"UserToken":        userToken,
+		"Storefront":       storefront,
+		"Version":          version,
+		"AudioBitrateKbps": audioBitrateKbps,
 	}); err != nil {
 		return "", fmt.Errorf("rendering musickit template: %w", err)
 	}

--- a/internal/player/web/web_test.go
+++ b/internal/player/web/web_test.go
@@ -1,0 +1,25 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderHTMLAcceptsSupportedBitrates(t *testing.T) {
+	for _, kbps := range []int{64, 256} {
+		html, err := RenderHTML("dev", "user", "us", "test", kbps)
+		if err != nil {
+			t.Fatalf("RenderHTML(%d): %v", kbps, err)
+		}
+		if html == "" {
+			t.Fatalf("RenderHTML(%d) returned empty HTML", kbps)
+		}
+	}
+}
+
+func TestRenderHTMLRejectsUnsupportedBitrate(t *testing.T) {
+	_, err := RenderHTML("dev", "user", "us", "test", 320)
+	if err == nil || !strings.Contains(err.Error(), "MusicKit JS/web playback max is 256 kbps AAC") {
+		t.Fatalf("RenderHTML(320) error = %v", err)
+	}
+}

--- a/internal/player/webkit/player.go
+++ b/internal/player/webkit/player.go
@@ -231,7 +231,7 @@ func (p *Player) SetAudioBitrate(kbps int) error {
 	if err := audioquality.Validate(kbps); err != nil {
 		return err
 	}
-	return fmt.Errorf("WebKit/GStreamer uses fixed 30 s preview URLs and cannot change bitrate; MusicKit JS/web playback max is 256 kbps AAC")
+	return player.ErrAudioBitrateRequiresRestart
 }
 
 func (p *Player) SetQueue(ids []string) error {

--- a/internal/player/webkit/player.go
+++ b/internal/player/webkit/player.go
@@ -231,7 +231,7 @@ func (p *Player) SetAudioBitrate(kbps int) error {
 	if err := audioquality.Validate(kbps); err != nil {
 		return err
 	}
-	return player.ErrAudioBitrateRequiresRestart
+	return player.ErrAudioBitrateSavedPreferenceOnly
 }
 
 func (p *Player) SetQueue(ids []string) error {

--- a/internal/player/webkit/player.go
+++ b/internal/player/webkit/player.go
@@ -23,6 +23,7 @@ import (
 
 	webview "github.com/webview/webview_go"
 
+	"github.com/simone-vibes/vibez/internal/audioquality"
 	"github.com/simone-vibes/vibez/internal/player"
 	"github.com/simone-vibes/vibez/internal/player/gst"
 	"github.com/simone-vibes/vibez/internal/player/web"
@@ -69,8 +70,8 @@ type Player struct {
 
 // New creates a Player and loads MusicKit JS into a fully hidden WebView.
 // Call Run() on the main OS goroutine to start the GTK event loop.
-func New(devToken, userToken, storefront string) (*Player, error) {
-	html, err := web.RenderHTML(devToken, userToken, storefront, "1.0.0")
+func New(devToken, userToken, storefront string, audioBitrateKbps int) (*Player, error) {
+	html, err := web.RenderHTML(devToken, userToken, storefront, "1.0.0", audioBitrateKbps)
 	if err != nil {
 		return nil, err
 	}
@@ -224,6 +225,13 @@ func (p *Player) Seek(position time.Duration) error {
 func (p *Player) SetVolume(v float64) error {
 	p.gst.SetVolume(v)
 	return nil
+}
+
+func (p *Player) SetAudioBitrate(kbps int) error {
+	if err := audioquality.Validate(kbps); err != nil {
+		return err
+	}
+	return fmt.Errorf("WebKit/GStreamer uses fixed 30 s preview URLs and cannot change bitrate; MusicKit JS/web playback max is 256 kbps AAC")
 }
 
 func (p *Player) SetQueue(ids []string) error {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1105,7 +1105,6 @@ var allCommands = []cmdEntry{
 	{"discover", "discover <n>|auto", "Queue n discovered songs now, or auto-discover indefinitely"},
 	{"vol", "vol <0-100|+n|-n>", "Set, raise, or lower volume (e.g. vol 80, vol +10, vol -5)"},
 	{"quality", "quality <high|standard|256|64>", "Set Apple Music AAC bitrate"},
-	{"bitrate", "bitrate <high|standard|256|64>", "Set Apple Music AAC bitrate"},
 	{"mute", "mute", "Toggle mute"},
 	{"debug-logs", "debug-logs", "Toggle debug log panel"},
 	{"q", "q", "Quit vibez"},
@@ -1211,7 +1210,7 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 		m.appendLog("[vol] muted")
 		return m.playerCmd(func() error { return m.player.SetVolume(0) })
 
-	case strings.HasPrefix(cmd, "quality") || strings.HasPrefix(cmd, "bitrate"):
+	case strings.HasPrefix(cmd, "quality"):
 		name, arg, _ := strings.Cut(cmd, " ")
 		arg = strings.TrimSpace(arg)
 		if arg == "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"slices"
@@ -144,7 +145,10 @@ type errMsg struct{ err error }
 // saveVolumeMsg is returned by volume-change commands to persist the new
 // volume to the config file.
 type saveVolumeMsg struct{ vol float64 }
-type saveAudioQualityMsg struct{ kbps int }
+type saveAudioQualityMsg struct {
+	kbps            int
+	requiresRestart bool
+}
 type playlistCreatedMsg struct{ name string }
 type SessionExpiredMsg struct{}
 type SessionRestoredMsg struct{}
@@ -441,7 +445,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.appendLog(fmt.Sprintf("[skip] restricted: %s", title))
 				if m.player != nil {
-					cmds = append(cmds, m.playerCmd(func() error { return m.player.Next() }))
+					cmds = append(cmds, m.playerCmd(func(p player.Player) error { return p.Next() }))
 				}
 			} else {
 				m.appendLog("[error] " + s.Error)
@@ -599,13 +603,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.queueIDs = ids
 			m.queue.SetTracks(m.queueTracks)
 			m.appendLog(fmt.Sprintf("[feed] playing %q (%d tracks)", msg.item.Title, len(ids)))
-			return m, m.playerCmd(func() error { return m.player.SetQueue(ids) })
+			return m, m.playerCmd(func(p player.Player) error { return p.SetQueue(ids) })
 		}
 		m.queueTracks = append(m.queueTracks, msg.tracks...)
 		m.queueIDs = append(m.queueIDs, ids...)
 		m.queue.SetTracks(m.queueTracks)
 		m.appendLog(fmt.Sprintf("[feed] queued %q (%d tracks)", msg.item.Title, len(ids)))
-		return m, m.playerCmd(func() error { return m.player.AppendQueue(ids) })
+		return m, m.playerCmd(func(p player.Player) error { return p.AppendQueue(ids) })
 
 	case views.VibeQueryMsg:
 		// User submitted a vibe description — start async provider search.
@@ -770,13 +774,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.playerState.Loading = true
 			m.playerState.Playing = false
 			m.playerState.Position = 0
-			return m, m.playerCmd(func() error { return m.player.SetQueue(ids) })
+			return m, m.playerCmd(func(p player.Player) error { return p.SetQueue(ids) })
 		}
 		m.queueTracks = append(m.queueTracks, msg.tracks...)
 		m.queueIDs = append(m.queueIDs, ids...)
 		m.queue.SetTracks(m.queueTracks)
 		m.appendLog(fmt.Sprintf("[search] queued %q (%d tracks)", msg.label, len(ids)))
-		return m, m.playerCmd(func() error { return m.player.AppendQueue(ids) })
+		return m, m.playerCmd(func(p player.Player) error { return p.AppendQueue(ids) })
 
 	case views.PlayTracksMsg:
 		if msg.Track != nil {
@@ -792,11 +796,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.queueIDs = msg.IDs
 		m.queue.SetTracks(m.queueTracks)
-		cmds = append(cmds, m.playerCmd(func() error {
+		cmds = append(cmds, m.playerCmd(func(p player.Player) error {
 			if msg.PlaylistID != "" {
-				return m.player.SetPlaylist(msg.PlaylistID, msg.StartIdx)
+				return p.SetPlaylist(msg.PlaylistID, msg.StartIdx)
 			}
-			return m.player.SetQueue(msg.IDs)
+			return p.SetQueue(msg.IDs)
 		}))
 		m.mode = modeNormal
 		m.activePanel = -1
@@ -821,15 +825,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, waitForState(m.stateCh), m.library.Init())
 		if m.cfg.Volume != nil {
 			v := m.cfg.VolumeOrDefault()
-			cmds = append(cmds, m.playerCmd(func() error {
-				return m.player.SetVolume(v)
+			cmds = append(cmds, m.playerCmd(func(p player.Player) error {
+				return p.SetVolume(v)
 			}))
 			m.appendLog(fmt.Sprintf("[vol] restored %.0f%% from config", v*100))
 		}
 		if len(m.cfg.EQBands) > 0 {
 			bands := configEQBandsToPlayer(m.cfg.EQBands)
-			cmds = append(cmds, m.playerCmd(func() error {
-				return m.player.SetEqualizer(bands)
+			cmds = append(cmds, m.playerCmd(func(p player.Player) error {
+				return p.SetEqualizer(bands)
 			}))
 			m.appendLog("[eq] restored from config")
 		}
@@ -864,7 +868,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appendLog(fmt.Sprintf("[quality] config save error: %v", err))
 			break
 		}
-		m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC", msg.kbps)
+		if msg.requiresRestart {
+			m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC (restart audio engine to apply)", msg.kbps)
+		} else {
+			m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC", msg.kbps)
+		}
 		m.errExpiry = time.Now().Add(3 * time.Second)
 
 	case errMsg:
@@ -977,7 +985,7 @@ func (m *Model) handleSearchKey(k string, msg tea.KeyPressMsg) tea.Cmd {
 			m.playerState.Position = 0
 			m.queue.SetTracks(m.queueTracks)
 			m.mode = modeNormal
-			return m.playerCmd(func() error { return m.player.SetQueue(m.queueIDs) })
+			return m.playerCmd(func(p player.Player) error { return p.SetQueue(m.queueIDs) })
 		}
 		// Album: fetch all tracks then play.
 		if a := m.search.SelectedAlbum(); a != nil {
@@ -998,7 +1006,7 @@ func (m *Model) handleSearchKey(k string, msg tea.KeyPressMsg) tea.Cmd {
 			m.queueTracks = append(m.queueTracks, tc)
 			m.queueIDs = append(m.queueIDs, views.PlaybackID(tc))
 			m.queue.SetTracks(m.queueTracks)
-			return m.playerCmd(func() error { return m.player.AppendQueue([]string{views.PlaybackID(tc)}) })
+			return m.playerCmd(func(p player.Player) error { return p.AppendQueue([]string{views.PlaybackID(tc)}) })
 		}
 		// Album: fetch all tracks then add to queue.
 		if a := m.search.SelectedAlbum(); a != nil {
@@ -1203,12 +1211,12 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 			vol := m.preMuteVol
 			m.preMuteVol = -1
 			m.appendLog(fmt.Sprintf("[vol] unmuted → %.0f%%", vol*100))
-			return m.playerCmd(func() error { return m.player.SetVolume(vol) })
+			return m.playerCmd(func(p player.Player) error { return p.SetVolume(vol) })
 		}
 		// Mute: save current volume and set to 0.
 		m.preMuteVol = m.playerState.Volume
 		m.appendLog("[vol] muted")
-		return m.playerCmd(func() error { return m.player.SetVolume(0) })
+		return m.playerCmd(func(p player.Player) error { return p.SetVolume(0) })
 
 	case strings.HasPrefix(cmd, "quality"):
 		name, arg, _ := strings.Cut(cmd, " ")
@@ -1225,11 +1233,15 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 			return nil
 		}
 		m.appendLog(fmt.Sprintf("[quality] → %d kbps AAC", kbps))
+		p := m.player
 		return func() tea.Msg {
-			if m.player == nil {
+			if p == nil {
 				return errMsg{fmt.Errorf("no player")}
 			}
-			if err := m.player.SetAudioBitrate(kbps); err != nil {
+			if err := p.SetAudioBitrate(kbps); err != nil {
+				if errors.Is(err, player.ErrAudioBitrateRequiresRestart) {
+					return saveAudioQualityMsg{kbps: kbps, requiresRestart: true}
+				}
 				return errMsg{err}
 			}
 			return saveAudioQualityMsg{kbps: kbps}
@@ -1272,11 +1284,12 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 		m.preMuteVol = -1 // clear mute state on explicit vol change
 		m.appendLog(fmt.Sprintf("[vol] → %.0f%%", newVol*100))
 		vol := newVol
+		p := m.player
 		return func() tea.Msg {
-			if m.player == nil {
+			if p == nil {
 				return errMsg{fmt.Errorf("no player")}
 			}
-			if err := m.player.SetVolume(vol); err != nil {
+			if err := p.SetVolume(vol); err != nil {
 				return errMsg{err}
 			}
 			return saveVolumeMsg{vol}
@@ -1301,7 +1314,7 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 		}
 		pos := time.Duration(n) * time.Second
 		m.appendLog(fmt.Sprintf("[player] seek → %s", views.FormatDuration(pos)))
-		return m.playerCmd(func() error { return m.player.Seek(pos) })
+		return m.playerCmd(func(p player.Player) error { return p.Seek(pos) })
 
 	case strings.HasPrefix(cmd, "save "), strings.HasPrefix(cmd, "save-playlist "):
 		name := cmd
@@ -1532,7 +1545,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 				m.playerState.Loading = true
 				m.playerState.Playing = false
 				m.playerState.Position = 0
-				return m.playerCmd(func() error { return m.player.SetQueue(ids) })
+				return m.playerCmd(func(p player.Player) error { return p.SetQueue(ids) })
 			}
 		case "d":
 			if idx, t := m.queue.SelectedTrack(); idx >= 0 {
@@ -1545,7 +1558,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 				m.queue.SetTracks(m.queueTracks)
 				m.appendLog(fmt.Sprintf("[queue] removed #%d: %s", idx+1, title))
 				i := idx
-				return m.playerCmd(func() error { return m.player.RemoveFromQueue(i) })
+				return m.playerCmd(func(p player.Player) error { return p.RemoveFromQueue(i) })
 			}
 		case "K":
 			if idx, _ := m.queue.SelectedTrack(); idx > 0 {
@@ -1554,7 +1567,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 				m.queue.SetTracks(m.queueTracks)
 				m.appendLog(fmt.Sprintf("[queue] moved #%d up", idx+1))
 				from, to := idx, idx-1
-				return m.playerCmd(func() error { return m.player.MoveInQueue(from, to) })
+				return m.playerCmd(func(p player.Player) error { return p.MoveInQueue(from, to) })
 			}
 		case "J":
 			if idx, _ := m.queue.SelectedTrack(); idx >= 0 && idx < len(m.queueTracks)-1 {
@@ -1563,14 +1576,14 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 				m.queue.SetTracks(m.queueTracks)
 				m.appendLog(fmt.Sprintf("[queue] moved #%d down", idx+1))
 				from, to := idx, idx+1
-				return m.playerCmd(func() error { return m.player.MoveInQueue(from, to) })
+				return m.playerCmd(func(p player.Player) error { return p.MoveInQueue(from, to) })
 			}
 		case "c":
 			m.appendLog("[queue] cleared")
 			m.queueTracks = nil
 			m.queueIDs = nil
 			m.queue.SetTracks(nil)
-			return m.playerCmd(func() error { return m.player.ClearQueue() })
+			return m.playerCmd(func(p player.Player) error { return p.ClearQueue() })
 		case "s":
 			m.mode = modeCommand
 			m.cmdBuf = "save "
@@ -1595,13 +1608,13 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 		m.lastKey = ""
 		m.appendLog("[player] next")
 		m.playerState.Loading = true
-		return m.playerCmd(func() error { return m.player.Next() })
+		return m.playerCmd(func(p player.Player) error { return p.Next() })
 
 	case "p":
 		m.lastKey = ""
 		m.appendLog("[player] previous")
 		m.playerState.Loading = true
-		return m.playerCmd(func() error { return m.player.Previous() })
+		return m.playerCmd(func(p player.Player) error { return p.Previous() })
 
 	case "+", "=":
 		m.lastKey = ""
@@ -1639,14 +1652,14 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 		}
 		m.playerState.RepeatMode = next
 		m.appendLog(fmt.Sprintf("[player] repeat → %d", next))
-		return m.playerCmd(func() error { return m.player.SetRepeat(next) })
+		return m.playerCmd(func(p player.Player) error { return p.SetRepeat(next) })
 
 	case "s":
 		m.lastKey = ""
 		on := !m.playerState.ShuffleMode
 		m.playerState.ShuffleMode = on
 		m.appendLog(fmt.Sprintf("[player] shuffle → %v", on))
-		return m.playerCmd(func() error { return m.player.SetShuffle(on) })
+		return m.playerCmd(func(p player.Player) error { return p.SetShuffle(on) })
 
 	case "f":
 		m.lastKey = ""
@@ -1692,7 +1705,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 			newPos := max(0, m.playerState.Position-10*time.Second)
 			m.appendLog(fmt.Sprintf("[player] seek ← %s", views.FormatDuration(newPos)))
 			pos := newPos
-			return m.playerCmd(func() error { return m.player.Seek(pos) })
+			return m.playerCmd(func(p player.Player) error { return p.Seek(pos) })
 		}
 
 	case "right":
@@ -1704,7 +1717,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 			}
 			m.appendLog(fmt.Sprintf("[player] seek → %s", views.FormatDuration(newPos)))
 			pos := newPos
-			return m.playerCmd(func() error { return m.player.Seek(pos) })
+			return m.playerCmd(func(p player.Player) error { return p.Seek(pos) })
 		}
 	}
 
@@ -1779,7 +1792,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 			m.playerState.Playing = false
 			m.playerState.Position = 0
 			m.queue.SetTracks(m.queueTracks)
-			return m.playerCmd(func() error { return m.player.SetQueue(m.queueIDs) })
+			return m.playerCmd(func(p player.Player) error { return p.SetQueue(m.queueIDs) })
 		}
 
 	case "a":
@@ -1789,7 +1802,7 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 			m.queueTracks = append(m.queueTracks, tc)
 			m.queueIDs = append(m.queueIDs, views.PlaybackID(tc))
 			m.queue.SetTracks(m.queueTracks)
-			return m.playerCmd(func() error { return m.player.AppendQueue([]string{views.PlaybackID(tc)}) })
+			return m.playerCmd(func(p player.Player) error { return p.AppendQueue([]string{views.PlaybackID(tc)}) })
 		}
 
 	default:
@@ -2291,12 +2304,13 @@ func (m *Model) togglePlayPause() tea.Cmd {
 	}
 }
 
-func (m *Model) playerCmd(fn func() error) tea.Cmd {
+func (m *Model) playerCmd(fn func(player.Player) error) tea.Cmd {
+	p := m.player
 	return func() tea.Msg {
-		if m.player == nil {
+		if p == nil {
 			return errMsg{fmt.Errorf("no player")}
 		}
-		if err := fn(); err != nil {
+		if err := fn(p); err != nil {
 			return errMsg{err}
 		}
 		return nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,6 +11,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/simone-vibes/vibez/internal/audioquality"
 	"github.com/simone-vibes/vibez/internal/config"
 	"github.com/simone-vibes/vibez/internal/lyrics"
 	"github.com/simone-vibes/vibez/internal/player"
@@ -143,6 +144,7 @@ type errMsg struct{ err error }
 // saveVolumeMsg is returned by volume-change commands to persist the new
 // volume to the config file.
 type saveVolumeMsg struct{ vol float64 }
+type saveAudioQualityMsg struct{ kbps int }
 type playlistCreatedMsg struct{ name string }
 type SessionExpiredMsg struct{}
 type SessionRestoredMsg struct{}
@@ -853,6 +855,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appendLog(fmt.Sprintf("[vol] config save error: %v", err))
 		}
 
+	case saveAudioQualityMsg:
+		if err := m.cfg.SetAudioBitrate(msg.kbps); err != nil {
+			m.appendLog(fmt.Sprintf("[quality] config error: %v", err))
+			break
+		}
+		if err := m.cfg.Save(""); err != nil {
+			m.appendLog(fmt.Sprintf("[quality] config save error: %v", err))
+			break
+		}
+		m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC", msg.kbps)
+		m.errExpiry = time.Now().Add(3 * time.Second)
+
 	case errMsg:
 		m.appendLog("[error] " + msg.err.Error())
 		m.errMsg = msg.err.Error()
@@ -1090,6 +1104,8 @@ var allCommands = []cmdEntry{
 	{"seek", "seek <seconds>", "Jump to a position in the current song"},
 	{"discover", "discover <n>|auto", "Queue n discovered songs now, or auto-discover indefinitely"},
 	{"vol", "vol <0-100|+n|-n>", "Set, raise, or lower volume (e.g. vol 80, vol +10, vol -5)"},
+	{"quality", "quality <high|standard|256|64>", "Set Apple Music AAC bitrate"},
+	{"bitrate", "bitrate <high|standard|256|64>", "Set Apple Music AAC bitrate"},
 	{"mute", "mute", "Toggle mute"},
 	{"debug-logs", "debug-logs", "Toggle debug log panel"},
 	{"q", "q", "Quit vibez"},
@@ -1194,6 +1210,31 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 		m.preMuteVol = m.playerState.Volume
 		m.appendLog("[vol] muted")
 		return m.playerCmd(func() error { return m.player.SetVolume(0) })
+
+	case strings.HasPrefix(cmd, "quality") || strings.HasPrefix(cmd, "bitrate"):
+		name, arg, _ := strings.Cut(cmd, " ")
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			m.errMsg = ":" + name + " requires high, standard, 256, or 64"
+			m.errExpiry = time.Now().Add(3 * time.Second)
+			return nil
+		}
+		kbps, err := audioquality.Parse(arg)
+		if err != nil {
+			m.errMsg = err.Error()
+			m.errExpiry = time.Now().Add(4 * time.Second)
+			return nil
+		}
+		m.appendLog(fmt.Sprintf("[quality] → %d kbps AAC", kbps))
+		return func() tea.Msg {
+			if m.player == nil {
+				return errMsg{fmt.Errorf("no player")}
+			}
+			if err := m.player.SetAudioBitrate(kbps); err != nil {
+				return errMsg{err}
+			}
+			return saveAudioQualityMsg{kbps: kbps}
+		}
 
 	case strings.HasPrefix(cmd, "vol"):
 		arg := strings.TrimSpace(strings.TrimPrefix(cmd, "vol"))
@@ -2832,7 +2873,7 @@ func (m *Model) statusPlayContent(_ int) string {
 }
 
 // commandLines renders the command palette in the panel area when CMD mode is active.
-func (m *Model) commandLines(w, h int) []string {
+func (m *Model) commandLines(_ int, h int) []string {
 	muted := styles.QueueItemMuted
 	accent := styles.KeyName
 	header := accent.Render("Commands")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -146,8 +146,8 @@ type errMsg struct{ err error }
 // volume to the config file.
 type saveVolumeMsg struct{ vol float64 }
 type saveAudioQualityMsg struct {
-	kbps            int
-	requiresRestart bool
+	kbps      int
+	savedOnly bool
 }
 type playlistCreatedMsg struct{ name string }
 type SessionExpiredMsg struct{}
@@ -868,8 +868,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appendLog(fmt.Sprintf("[quality] config save error: %v", err))
 			break
 		}
-		if msg.requiresRestart {
-			m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC (restart audio engine to apply)", msg.kbps)
+		if msg.savedOnly {
+			m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC (used next launch; current backend cannot switch live)", msg.kbps)
 		} else {
 			m.errMsg = fmt.Sprintf("✓ Audio quality saved: %d kbps AAC", msg.kbps)
 		}
@@ -1239,8 +1239,8 @@ func (m *Model) executeCommand(cmd string) tea.Cmd {
 				return errMsg{fmt.Errorf("no player")}
 			}
 			if err := p.SetAudioBitrate(kbps); err != nil {
-				if errors.Is(err, player.ErrAudioBitrateRequiresRestart) {
-					return saveAudioQualityMsg{kbps: kbps, requiresRestart: true}
+				if errors.Is(err, player.ErrAudioBitrateSavedPreferenceOnly) {
+					return saveAudioQualityMsg{kbps: kbps, savedOnly: true}
 				}
 				return errMsg{err}
 			}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -376,7 +376,7 @@ func TestTogglePlayPause_PlayerError(t *testing.T) {
 
 func TestPlayerCmd_NilPlayer(t *testing.T) {
 	m := newModel(nil)
-	cmd := m.playerCmd(func() error { return nil })
+	cmd := m.playerCmd(func(player.Player) error { return nil })
 	msg := cmd()
 	if _, ok := msg.(errMsg); !ok {
 		t.Errorf("playerCmd with nil player should return errMsg, got %T", msg)
@@ -386,7 +386,7 @@ func TestPlayerCmd_NilPlayer(t *testing.T) {
 func TestPlayerCmd_Next(t *testing.T) {
 	mp := newMockPlayer()
 	m := newModel(mp)
-	cmd := m.playerCmd(func() error { return mp.Next() })
+	cmd := m.playerCmd(func(p player.Player) error { return p.Next() })
 	msg := cmd()
 	if msg != nil {
 		t.Errorf("playerCmd success should return nil msg, got %v", msg)
@@ -399,10 +399,24 @@ func TestPlayerCmd_Next(t *testing.T) {
 func TestPlayerCmd_Previous(t *testing.T) {
 	mp := newMockPlayer()
 	m := newModel(mp)
-	cmd := m.playerCmd(func() error { return mp.Previous() })
+	cmd := m.playerCmd(func(p player.Player) error { return p.Previous() })
 	cmd()
 	if !mp.prevCalled {
 		t.Error("Previous() should have been called")
+	}
+}
+
+func TestPlayerCmdUsesCapturedPlayer(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	cmd := m.playerCmd(func(p player.Player) error { return p.Next() })
+	m.player = nil
+	msg := cmd()
+	if msg != nil {
+		t.Fatalf("playerCmd with captured player returned %v", msg)
+	}
+	if !mp.nextCalled {
+		t.Fatal("captured player Next() was not called")
 	}
 }
 
@@ -2735,6 +2749,27 @@ func TestExecuteCommandQualitySetsPlayerAndPersists(t *testing.T) {
 	m = updated.(*Model)
 	if got, err := m.cfg.AudioBitrateKbps(); err != nil || got != 64 {
 		t.Fatalf("config bitrate = %d, %v; want 64, nil", got, err)
+	}
+}
+
+func TestExecuteCommandQualityPersistsWhenPlayerRequiresRestart(t *testing.T) {
+	p := newMockPlayer()
+	p.err = player.ErrAudioBitrateRequiresRestart
+	m := newModel(p)
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := m.executeCommand("quality 64")
+	if cmd == nil {
+		t.Fatal("quality command returned nil cmd")
+	}
+	msg := cmd()
+	updated, _ := m.Update(msg)
+	m = updated.(*Model)
+	if got, err := m.cfg.AudioBitrateKbps(); err != nil || got != 64 {
+		t.Fatalf("config bitrate = %d, %v; want 64, nil", got, err)
+	}
+	if !strings.Contains(m.errMsg, "restart audio engine to apply") {
+		t.Fatalf("errMsg = %q", m.errMsg)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -26,6 +26,7 @@ type mockPlayer struct {
 	closeCalled    bool
 	seekCalled     bool
 	seekPos        time.Duration
+	bitrateKbps    int
 	setQueueIDs    []string   // last IDs passed to SetQueue
 	appendQueueIDs [][]string // all calls to AppendQueue (each call appended)
 	err            error
@@ -46,7 +47,11 @@ func (m *mockPlayer) Seek(pos time.Duration) error {
 	m.seekPos = pos
 	return m.err
 }
-func (m *mockPlayer) SetVolume(_ float64) error            { return m.err }
+func (m *mockPlayer) SetVolume(_ float64) error { return m.err }
+func (m *mockPlayer) SetAudioBitrate(kbps int) error {
+	m.bitrateKbps = kbps
+	return m.err
+}
 func (m *mockPlayer) SetRepeat(_ int) error                { return m.err }
 func (m *mockPlayer) SetShuffle(_ bool) error              { return m.err }
 func (m *mockPlayer) SetEqualizer(_ []player.EQBand) error { return m.err }
@@ -2711,4 +2716,53 @@ func (p *captureProvider) AddToPlaylist(_ context.Context, playlistID, trackID s
 		return p.addToPlaylistFn(playlistID, trackID)
 	}
 	return nil
+}
+
+func TestExecuteCommandQualitySetsPlayerAndPersists(t *testing.T) {
+	p := newMockPlayer()
+	m := newModel(p)
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := m.executeCommand("quality 64")
+	if cmd == nil {
+		t.Fatal("quality command returned nil cmd")
+	}
+	msg := cmd()
+	if p.bitrateKbps != 64 {
+		t.Fatalf("player bitrate = %d, want 64", p.bitrateKbps)
+	}
+	updated, _ := m.Update(msg)
+	m = updated.(*Model)
+	if got, err := m.cfg.AudioBitrateKbps(); err != nil || got != 64 {
+		t.Fatalf("config bitrate = %d, %v; want 64, nil", got, err)
+	}
+}
+
+func TestExecuteCommandQualityRejectsLossless(t *testing.T) {
+	p := newMockPlayer()
+	m := newModel(p)
+	cmd := m.executeCommand("quality lossless")
+	if cmd != nil {
+		t.Fatal("lossless quality returned command")
+	}
+	if p.bitrateKbps != 0 {
+		t.Fatalf("player bitrate changed to %d", p.bitrateKbps)
+	}
+	if !strings.Contains(m.errMsg, "MusicKit JS/web playback max is 256 kbps AAC") {
+		t.Fatalf("errMsg = %q", m.errMsg)
+	}
+}
+
+func TestCommandSuggestionsIncludeQuality(t *testing.T) {
+	m := newModel(newMockPlayer())
+	m.cmdBuf = "qual"
+	got := m.commandSuggestions()
+	if len(got) == 0 || got[0].trigger != "quality" {
+		t.Fatalf("quality suggestions = %#v", got)
+	}
+	m.cmdBuf = "bit"
+	got = m.commandSuggestions()
+	if len(got) == 0 || got[0].trigger != "bitrate" {
+		t.Fatalf("bitrate suggestions = %#v", got)
+	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2752,9 +2752,9 @@ func TestExecuteCommandQualitySetsPlayerAndPersists(t *testing.T) {
 	}
 }
 
-func TestExecuteCommandQualityPersistsWhenPlayerRequiresRestart(t *testing.T) {
+func TestExecuteCommandQualityPersistsWhenBackendCannotSwitchLive(t *testing.T) {
 	p := newMockPlayer()
-	p.err = player.ErrAudioBitrateRequiresRestart
+	p.err = player.ErrAudioBitrateSavedPreferenceOnly
 	m := newModel(p)
 	t.Setenv("HOME", t.TempDir())
 
@@ -2768,7 +2768,7 @@ func TestExecuteCommandQualityPersistsWhenPlayerRequiresRestart(t *testing.T) {
 	if got, err := m.cfg.AudioBitrateKbps(); err != nil || got != 64 {
 		t.Fatalf("config bitrate = %d, %v; want 64, nil", got, err)
 	}
-	if !strings.Contains(m.errMsg, "restart audio engine to apply") {
+	if !strings.Contains(m.errMsg, "used next launch; current backend cannot switch live") {
 		t.Fatalf("errMsg = %q", m.errMsg)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2760,9 +2760,4 @@ func TestCommandSuggestionsIncludeQuality(t *testing.T) {
 	if len(got) == 0 || got[0].trigger != "quality" {
 		t.Fatalf("quality suggestions = %#v", got)
 	}
-	m.cmdBuf = "bit"
-	got = m.commandSuggestions()
-	if len(got) == 0 || got[0].trigger != "bitrate" {
-		t.Fatalf("bitrate suggestions = %#v", got)
-	}
 }


### PR DESCRIPTION
## Summary
- add `audio_quality` config with high/standard options
- add `:quality` command for 256/64 kbps AAC
- clearly reject lossless/unsupported values for MusicKit web backend

## Tests
- `PKG_CONFIG_PATH=$PWD/pkg-config go test ./...`
- `PKG_CONFIG_PATH=$PWD/pkg-config go build ./...`
- `node internal/player/web/musickit_test.mjs`