### PR TITLE
Add library sections for songs albums artists playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AudioServiceOutOfProcess` is added to `--disable-features` (prevents distortion
   caused by PulseAudio and Windows running at mismatched sample rates). Disabled by
   default so native Linux users are unaffected.
+- **Library sections** — the library panel now opens to Songs, Albums, Artists,
+  and Playlists. Songs play directly from the selected track onward, Albums and
+  Artists are grouped from saved library songs, and Playlists keep the existing
+  playlist drill-down and playback flow.
+
 - **10-band parametric equalizer** — press `e` to open the equalizer panel. Each of the 10
   ISO bands (32 Hz, 64 Hz, 125 Hz, 250 Hz, 500 Hz, 1 kHz, 2 kHz, 4 kHz, 8 kHz, 16 kHz)
   exposes independent frequency, Q factor, and gain (±12 dB, in 0.5 dB steps). Changes apply

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -911,7 +911,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appendLog("[library] playlist tracks error: " + err.Error())
 		}
 		if err := updated.LoadErr(); err != nil && m.library.m.LoadErr() == nil {
-			m.appendLog("[library] playlists load error: " + err.Error())
+			m.appendLog("[library] load error: " + err.Error())
 		}
 		m.library.m = updated
 		cmds = append(cmds, libCmd)
@@ -2832,7 +2832,7 @@ func (m *Model) statusPlayContent(_ int) string {
 }
 
 // commandLines renders the command palette in the panel area when CMD mode is active.
-func (m *Model) commandLines(w, h int) []string {
+func (m *Model) commandLines(_ int, h int) []string {
 	muted := styles.QueueItemMuted
 	accent := styles.KeyName
 	header := accent.Render("Commands")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -905,12 +905,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 
 	default:
-		// Forward library background loads
+		// Forward library background loads.
+		prevDrillErr := m.library.m.DrillErr()
+		prevLoadErr := m.library.m.LoadErr()
 		updated, libCmd := m.library.m.Update(msg)
-		if err := updated.DrillErr(); err != nil && m.library.m.DrillErr() == nil {
+		if err := updated.DrillErr(); err != nil && prevDrillErr == nil {
 			m.appendLog("[library] playlist tracks error: " + err.Error())
 		}
-		if err := updated.LoadErr(); err != nil && m.library.m.LoadErr() == nil {
+		if err := updated.LoadErr(); err != nil && prevLoadErr == nil {
 			m.appendLog("[library] load error: " + err.Error())
 		}
 		m.library.m = updated

--- a/internal/tui/views/helpers_test.go
+++ b/internal/tui/views/helpers_test.go
@@ -8,11 +8,17 @@ import (
 
 // mockProvider is a no-op provider for unit tests.
 type mockProvider struct {
-	searchResult   *provider.SearchResult
-	searchErr      error
-	libraryTracks  []provider.Track
-	playlists      []provider.Playlist
-	playlistTracks map[string][]provider.Track
+	searchResult       *provider.SearchResult
+	searchErr          error
+	libraryTracks      []provider.Track
+	playlists          []provider.Playlist
+	playlistTracks     map[string][]provider.Track
+	libraryTrackCalls  int
+	libraryTrackCtx    context.Context
+	playlistCalls      int
+	playlistCtx        context.Context
+	playlistTrackCalls int
+	playlistTrackCtx   context.Context
 }
 
 func (m *mockProvider) Name() string { return "mock" }
@@ -27,15 +33,21 @@ func (m *mockProvider) Search(_ context.Context, _ string) (*provider.SearchResu
 	return &provider.SearchResult{}, nil
 }
 
-func (m *mockProvider) GetLibraryTracks(_ context.Context) ([]provider.Track, error) {
+func (m *mockProvider) GetLibraryTracks(ctx context.Context) ([]provider.Track, error) {
+	m.libraryTrackCalls++
+	m.libraryTrackCtx = ctx
 	return m.libraryTracks, nil
 }
 
-func (m *mockProvider) GetLibraryPlaylists(_ context.Context) ([]provider.Playlist, error) {
+func (m *mockProvider) GetLibraryPlaylists(ctx context.Context) ([]provider.Playlist, error) {
+	m.playlistCalls++
+	m.playlistCtx = ctx
 	return m.playlists, nil
 }
 
-func (m *mockProvider) GetPlaylistTracks(_ context.Context, id string) ([]provider.Track, error) {
+func (m *mockProvider) GetPlaylistTracks(ctx context.Context, id string) ([]provider.Track, error) {
+	m.playlistTrackCalls++
+	m.playlistTrackCtx = ctx
 	if m.playlistTracks == nil {
 		return nil, nil
 	}

--- a/internal/tui/views/helpers_test.go
+++ b/internal/tui/views/helpers_test.go
@@ -8,10 +8,11 @@ import (
 
 // mockProvider is a no-op provider for unit tests.
 type mockProvider struct {
-	searchResult  *provider.SearchResult
-	searchErr     error
-	libraryTracks []provider.Track
-	playlists     []provider.Playlist
+	searchResult   *provider.SearchResult
+	searchErr      error
+	libraryTracks  []provider.Track
+	playlists      []provider.Playlist
+	playlistTracks map[string][]provider.Track
 }
 
 func (m *mockProvider) Name() string { return "mock" }
@@ -34,8 +35,11 @@ func (m *mockProvider) GetLibraryPlaylists(_ context.Context) ([]provider.Playli
 	return m.playlists, nil
 }
 
-func (m *mockProvider) GetPlaylistTracks(_ context.Context, _ string) ([]provider.Track, error) {
-	return nil, nil
+func (m *mockProvider) GetPlaylistTracks(_ context.Context, id string) ([]provider.Track, error) {
+	if m.playlistTracks == nil {
+		return nil, nil
+	}
+	return m.playlistTracks[id], nil
 }
 
 func (m *mockProvider) GetAlbumTracks(_ context.Context, _ string) ([]provider.Track, error) {

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -13,12 +13,22 @@ import (
 	"github.com/simone-vibes/vibez/internal/tui/styles"
 )
 
-// libraryPane controls which level of the drill-down is visible.
 type libraryPane int
 
 const (
-	paneList   libraryPane = iota // top-level tab list
-	paneTracks                    // tracks inside a selected playlist
+	paneSections libraryPane = iota
+	paneItems
+	paneTracks
+	paneList = paneItems
+)
+
+type librarySection int
+
+const (
+	sectionSongs librarySection = iota
+	sectionAlbums
+	sectionArtists
+	sectionPlaylists
 )
 
 type libraryLoadedMsg struct {
@@ -26,10 +36,21 @@ type libraryLoadedMsg struct {
 	err       error
 }
 
+type libraryTracksLoadedMsg struct {
+	tracks []provider.Track
+	err    error
+}
+
 type playlistTracksMsg struct {
 	playlist provider.Playlist
 	tracks   []provider.Track
 	err      error
+}
+
+type trackGroup struct {
+	title  string
+	desc   string
+	tracks []provider.Track
 }
 
 type LibraryModel struct {
@@ -39,15 +60,22 @@ type LibraryModel struct {
 	list     list.Model
 	spinner  spinner.Model
 
-	playlists []provider.Playlist
+	pane            libraryPane
+	selectedSection librarySection
+	libraryTracks   []provider.Track
+	tracksLoaded    bool
+	playlists       []provider.Playlist
+	playlistsLoaded bool
+	albums          []trackGroup
+	artists         []trackGroup
 
-	// Drill-down into a playlist's tracks.
-	pane          libraryPane
-	drillPlaylist provider.Playlist
-	drillTracks   []provider.Track
-	drillLoading  bool
-	drillErr      error
-	drillList     list.Model
+	drillTitle     string
+	drillPlaylist  provider.Playlist
+	drillTracks    []provider.Track
+	drillLoading   bool
+	drillErr       error
+	drillList      list.Model
+	tracksBackPane libraryPane
 
 	width  int
 	height int
@@ -57,31 +85,21 @@ func NewLibrary(prov provider.Provider) *LibraryModel {
 	delegate := list.NewDefaultDelegate()
 	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.Foreground(styles.ColorPrimary)
 	delegate.Styles.SelectedDesc = delegate.Styles.SelectedDesc.Foreground(styles.ColorSubtle)
-
 	l := list.New(nil, delegate, 0, 0)
 	l.SetShowTitle(false)
 	l.SetFilteringEnabled(false)
-
 	drill := list.New(nil, delegate, 0, 0)
 	drill.SetShowTitle(false)
 	drill.SetFilteringEnabled(false)
-
 	sp := spinner.New()
 	sp.Style = styles.Spinner
 	sp.Spinner = spinner.Dot
-
-	return &LibraryModel{
-		provider:  prov,
-		list:      l,
-		drillList: drill,
-		spinner:   sp,
-	}
+	m := &LibraryModel{provider: prov, list: l, drillList: drill, spinner: sp, pane: paneSections}
+	m.showSections()
+	return m
 }
 
-func (m *LibraryModel) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, m.loadPlaylists())
-}
-
+func (m *LibraryModel) Init() tea.Cmd   { return m.spinner.Tick }
 func (m *LibraryModel) Width() int      { return m.width }
 func (m *LibraryModel) Height() int     { return m.height }
 func (m *LibraryModel) DrillErr() error { return m.drillErr }
@@ -93,6 +111,15 @@ func (m *LibraryModel) SetSize(w, h int) {
 	listH := max(0, h-3)
 	m.list.SetSize(w, listH)
 	m.drillList.SetSize(w, listH)
+}
+
+func (m *LibraryModel) loadLibraryTracks() tea.Cmd {
+	m.loading = true
+	prov := m.provider
+	return func() tea.Msg {
+		tracks, err := prov.GetLibraryTracks(context.Background())
+		return libraryTracksLoadedMsg{tracks: tracks, err: err}
+	}
 }
 
 func (m *LibraryModel) loadPlaylists() tea.Cmd {
@@ -115,105 +142,206 @@ func (m *LibraryModel) loadPlaylistTracks(pl provider.Playlist) tea.Cmd {
 
 func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 	switch msg := msg.(type) {
+	case libraryTracksLoadedMsg:
+		m.loading = false
+		m.loadErr = msg.err
+		if msg.err == nil {
+			m.libraryTracks = append([]provider.Track{}, msg.tracks...)
+			m.tracksLoaded = true
+			m.routeLoadedLibraryTracks()
+		}
+		return m, nil
 	case libraryLoadedMsg:
 		m.loading = false
 		m.loadErr = msg.err
 		if msg.err == nil {
-			m.playlists = msg.playlists
-			m.refreshList()
+			m.playlists = append([]provider.Playlist{}, msg.playlists...)
+			m.playlistsLoaded = true
+			m.showPlaylists()
 		}
 		return m, nil
-
 	case playlistTracksMsg:
 		m.drillLoading = false
 		m.drillErr = msg.err
+		m.drillPlaylist = msg.playlist
 		if msg.err == nil {
-			m.drillTracks = msg.tracks
-			items := make([]list.Item, len(msg.tracks))
-			for i, t := range msg.tracks {
-				items[i] = trackListItem{t}
-			}
-			m.drillList.SetItems(items)
+			m.showTrackPane(msg.playlist.Name, msg.tracks, paneItems)
 		}
 		return m, nil
-
 	case spinner.TickMsg:
 		if m.loading || m.drillLoading {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
 		}
-
 	case tea.KeyPressMsg:
-		// Drill-down pane handles its own keys.
-		if m.pane == paneTracks {
-			switch msg.String() {
-			case "esc", "backspace":
-				m.pane = paneList
-				return m, nil
-			case "enter":
-				if selected := m.drillList.SelectedItem(); selected != nil {
-					if _, ok := selected.(trackListItem); ok {
-						// Play from the selected track to end of playlist.
-						idx := m.drillList.Index()
-						allTracks := m.drillTracks[idx:]
-						ids := make([]string, len(allTracks))
-						for i, t := range allTracks {
-							ids[i] = PlaybackID(t)
-						}
-						first := allTracks[0]
-						tracks := append([]provider.Track{}, allTracks...)
-						return m, func() tea.Msg {
-							return PlayTracksMsg{IDs: ids, Tracks: tracks, Track: &first}
-						}
-					}
-				}
-				return m, nil
-			default:
-				var cmd tea.Cmd
-				m.drillList, cmd = m.drillList.Update(msg)
-				return m, cmd
-			}
-		}
+		return m.handleKey(msg)
+	}
+	return m.updateActiveList(msg)
+}
 
-		// Top-level pane.
-		switch msg.String() {
-		case "enter":
-			if selected := m.list.SelectedItem(); selected != nil {
-				if item, ok := selected.(playlistItem); ok {
-					pl := provider.Playlist(item)
-					m.drillPlaylist = pl
-					m.pane = paneTracks
-					m.drillTracks = nil
-					m.drillErr = nil
-					m.drillList.SetItems(nil)
-					return m, tea.Batch(m.spinner.Tick, m.loadPlaylistTracks(pl))
-				}
+func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
+	switch m.pane {
+	case paneSections:
+		if msg.String() == "enter" {
+			if item, ok := m.list.SelectedItem().(sectionItem); ok {
+				m.selectedSection = item.section
+				return m.openSelectedSection()
 			}
 			return m, nil
-		default:
-			var cmd tea.Cmd
-			m.list, cmd = m.list.Update(msg)
-			return m, cmd
+		}
+	case paneItems:
+		switch msg.String() {
+		case "esc", "backspace":
+			m.pane = paneSections
+			m.showSections()
+			return m, nil
+		case "enter":
+			return m.openSelectedItem()
+		}
+	case paneTracks:
+		switch msg.String() {
+		case "esc", "backspace":
+			if m.tracksBackPane == paneSections && m.drillTitle == "" {
+				m.pane = paneList
+			} else {
+				m.pane = m.tracksBackPane
+			}
+			return m, nil
+		case "enter":
+			return m, m.playTracksFromSelection()
 		}
 	}
+	return m.updateActiveList(msg)
+}
 
+func (m *LibraryModel) updateActiveList(msg tea.Msg) (*LibraryModel, tea.Cmd) {
+	var cmd tea.Cmd
 	if m.pane == paneTracks {
-		var cmd tea.Cmd
 		m.drillList, cmd = m.drillList.Update(msg)
 		return m, cmd
 	}
-	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
 	return m, cmd
 }
 
-func (m *LibraryModel) refreshList() {
-	var items []list.Item
-	for _, pl := range m.playlists {
-		items = append(items, playlistItem(pl))
+func (m *LibraryModel) openSelectedSection() (*LibraryModel, tea.Cmd) {
+	switch m.selectedSection {
+	case sectionSongs, sectionAlbums, sectionArtists:
+		if !m.tracksLoaded {
+			m.loading = true
+			return m, tea.Batch(m.spinner.Tick, m.loadLibraryTracks())
+		}
+		m.routeLoadedLibraryTracks()
+		return m, nil
+	case sectionPlaylists:
+		if !m.playlistsLoaded {
+			m.loading = true
+			return m, tea.Batch(m.spinner.Tick, m.loadPlaylists())
+		}
+		m.showPlaylists()
+		return m, nil
+	default:
+		panic("unknown library section")
+	}
+}
+
+func (m *LibraryModel) routeLoadedLibraryTracks() {
+	switch m.selectedSection {
+	case sectionSongs:
+		m.showTrackPane("Songs", m.libraryTracks, paneSections)
+	case sectionAlbums:
+		m.albums = buildLibraryAlbums(m.libraryTracks)
+		m.showGroups(m.albums)
+	case sectionArtists:
+		m.artists = buildLibraryArtists(m.libraryTracks)
+		m.showGroups(m.artists)
+	case sectionPlaylists:
+		m.showPlaylists()
+	default:
+		panic("unknown library section")
+	}
+}
+
+func (m *LibraryModel) openSelectedItem() (*LibraryModel, tea.Cmd) {
+	switch item := m.list.SelectedItem().(type) {
+	case albumItem:
+		m.showTrackPane(item.group.title, item.group.tracks, paneItems)
+	case artistItem:
+		m.showTrackPane(item.group.title, item.group.tracks, paneItems)
+	case playlistItem:
+		pl := provider.Playlist(item)
+		m.drillPlaylist = pl
+		m.drillTitle = pl.Name
+		m.pane = paneTracks
+		m.tracksBackPane = paneItems
+		m.drillTracks = nil
+		m.drillErr = nil
+		m.drillList.SetItems(nil)
+		return m, tea.Batch(m.spinner.Tick, m.loadPlaylistTracks(pl))
+	}
+	return m, nil
+}
+
+func (m *LibraryModel) playTracksFromSelection() tea.Cmd {
+	if selected := m.drillList.SelectedItem(); selected == nil {
+		return nil
+	}
+	idx := m.drillList.Index()
+	if idx < 0 || idx >= len(m.drillTracks) {
+		return nil
+	}
+	allTracks := m.drillTracks[idx:]
+	ids := make([]string, len(allTracks))
+	for i, t := range allTracks {
+		ids[i] = PlaybackID(t)
+	}
+	first := allTracks[0]
+	tracks := append([]provider.Track{}, allTracks...)
+	return func() tea.Msg { return PlayTracksMsg{IDs: ids, Tracks: tracks, Track: &first} }
+}
+
+func (m *LibraryModel) showSections() {
+	items := []list.Item{sectionItem{sectionSongs}, sectionItem{sectionAlbums}, sectionItem{sectionArtists}, sectionItem{sectionPlaylists}}
+	m.list.SetItems(items)
+	m.list.Select(0)
+}
+
+func (m *LibraryModel) showPlaylists() {
+	m.pane = paneItems
+	items := make([]list.Item, len(m.playlists))
+	for i, pl := range m.playlists {
+		items[i] = playlistItem(pl)
 	}
 	m.list.SetItems(items)
+	m.list.Select(0)
+}
+
+func (m *LibraryModel) showGroups(groups []trackGroup) {
+	m.pane = paneItems
+	items := make([]list.Item, len(groups))
+	for i, group := range groups {
+		if m.selectedSection == sectionAlbums {
+			items[i] = albumItem{group}
+		} else {
+			items[i] = artistItem{group}
+		}
+	}
+	m.list.SetItems(items)
+	m.list.Select(0)
+}
+
+func (m *LibraryModel) showTrackPane(title string, tracks []provider.Track, back libraryPane) {
+	m.pane = paneTracks
+	m.tracksBackPane = back
+	m.drillTitle = title
+	m.drillTracks = append([]provider.Track{}, tracks...)
+	items := make([]list.Item, len(tracks))
+	for i, t := range tracks {
+		items[i] = trackListItem{t}
+	}
+	m.drillList.SetItems(items)
+	m.drillList.Select(0)
 }
 
 func (m *LibraryModel) View() string {
@@ -222,37 +350,141 @@ func (m *LibraryModel) View() string {
 	}
 	header := m.renderHeader()
 	if m.loading {
-		return header + "\n\n  " + m.spinner.View() + " Loading…"
+		return header + "\n\n  " + m.spinner.View() + " " + m.loadingText()
 	}
-	if len(m.playlists) == 0 {
-		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render("No playlists found"), m.width)
+	if len(m.list.Items()) == 0 {
+		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render(m.emptyText()), m.width)
 	}
 	return header + "\n" + m.list.View()
 }
 
 func (m *LibraryModel) renderDrillView() string {
-	name := styles.SidebarActive.Render(m.drillPlaylist.Name)
+	name := styles.SidebarActive.Render(m.drillTitle)
+	if m.drillTitle == "" {
+		name = styles.SidebarActive.Render("Tracks")
+	}
 	hint := styles.QueueItemMuted.Render("  ← esc · enter play")
-	header := name + hint + "\n" +
-		lipgloss.NewStyle().Foreground(styles.ColorMuted).Render(strings.Repeat("─", m.width))
+	header := name + hint + "\n" + lipgloss.NewStyle().Foreground(styles.ColorMuted).Render(strings.Repeat("─", m.width))
 	if m.drillLoading {
 		return header + "\n\n  " + m.spinner.View() + " Loading tracks…"
 	}
 	if len(m.drillTracks) == 0 {
 		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render("No tracks found"), m.width)
 	}
-	listH := max(0, m.height-3)
-	m.drillList.SetSize(m.width, listH)
+	m.drillList.SetSize(m.width, max(0, m.height-3))
 	return header + "\n" + m.drillList.View()
 }
 
 func (m *LibraryModel) renderHeader() string {
-	title := styles.TabActive.Render("Playlists")
-	return title +
-		"\n" + lipgloss.NewStyle().Foreground(styles.ColorMuted).Render("─────────────────────────")
+	title := "Library"
+	if m.pane == paneItems {
+		title = sectionTitle(m.selectedSection)
+	}
+	return styles.TabActive.Render(title) + "\n" + lipgloss.NewStyle().Foreground(styles.ColorMuted).Render(strings.Repeat("─", max(1, m.width)))
 }
 
-// --- list.Item adapters ---
+func (m *LibraryModel) loadingText() string {
+	switch m.selectedSection {
+	case sectionSongs:
+		return "Loading songs…"
+	case sectionAlbums:
+		return "Loading albums…"
+	case sectionArtists:
+		return "Loading artists…"
+	case sectionPlaylists:
+		return "Loading playlists…"
+	default:
+		return "Loading…"
+	}
+}
+
+func (m *LibraryModel) emptyText() string {
+	switch m.selectedSection {
+	case sectionSongs:
+		return "No songs found"
+	case sectionAlbums:
+		return "No albums found"
+	case sectionArtists:
+		return "No artists found"
+	case sectionPlaylists:
+		return "No playlists found"
+	default:
+		return "No items found"
+	}
+}
+
+func sectionTitle(section librarySection) string {
+	switch section {
+	case sectionSongs:
+		return "Songs"
+	case sectionAlbums:
+		return "Albums"
+	case sectionArtists:
+		return "Artists"
+	case sectionPlaylists:
+		return "Playlists"
+	default:
+		panic("unknown library section")
+	}
+}
+
+func buildLibraryAlbums(tracks []provider.Track) []trackGroup {
+	groups := make([]trackGroup, 0)
+	index := make(map[string]int, len(tracks))
+	for _, track := range tracks {
+		title := track.Album
+		if title == "" {
+			title = "Unknown Album"
+		}
+		key := track.Artist + "\x00" + title
+		if i, ok := index[key]; ok {
+			groups[i].tracks = append(groups[i].tracks, track)
+			continue
+		}
+		index[key] = len(groups)
+		groups = append(groups, trackGroup{title: title, desc: track.Artist, tracks: []provider.Track{track}})
+	}
+	return groups
+}
+
+func buildLibraryArtists(tracks []provider.Track) []trackGroup {
+	groups := make([]trackGroup, 0)
+	index := make(map[string]int, len(tracks))
+	for _, track := range tracks {
+		title := track.Artist
+		if title == "" {
+			title = "Unknown Artist"
+		}
+		if i, ok := index[title]; ok {
+			groups[i].tracks = append(groups[i].tracks, track)
+			continue
+		}
+		index[title] = len(groups)
+		groups = append(groups, trackGroup{title: title, desc: fmt.Sprintf("%d tracks", 1), tracks: []provider.Track{track}})
+	}
+	for i := range groups {
+		groups[i].desc = fmt.Sprintf("%d tracks", len(groups[i].tracks))
+	}
+	return groups
+}
+
+type sectionItem struct{ section librarySection }
+
+func (s sectionItem) Title() string       { return sectionTitle(s.section) }
+func (s sectionItem) Description() string { return "enter to browse" }
+func (s sectionItem) FilterValue() string { return s.Title() }
+
+type albumItem struct{ group trackGroup }
+
+func (a albumItem) Title() string       { return a.group.title }
+func (a albumItem) Description() string { return a.group.desc }
+func (a albumItem) FilterValue() string { return a.group.title + " " + a.group.desc }
+
+type artistItem struct{ group trackGroup }
+
+func (a artistItem) Title() string       { return a.group.title }
+func (a artistItem) Description() string { return a.group.desc }
+func (a artistItem) FilterValue() string { return a.group.title }
 
 type playlistItem provider.Playlist
 

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -46,10 +46,19 @@ type libraryTracksLoadedMsg struct {
 	err    error
 }
 
+type playlistRequestKind int
+
+const (
+	playlistRequestNone playlistRequestKind = iota
+	playlistRequestTracks
+)
+
 type playlistTracksMsg struct {
-	playlist provider.Playlist
-	tracks   []provider.Track
-	err      error
+	playlist   provider.Playlist
+	generation uint64
+	kind       playlistRequestKind
+	tracks     []provider.Track
+	err        error
 }
 
 type trackGroup struct {
@@ -75,13 +84,15 @@ type LibraryModel struct {
 	albums            []trackGroup
 	artists           []trackGroup
 
-	drillTitle     string
-	drillPlaylist  provider.Playlist
-	drillTracks    []provider.Track
-	drillLoading   bool
-	drillErr       error
-	drillList      list.Model
-	tracksBackPane libraryPane
+	drillTitle             string
+	drillPlaylist          provider.Playlist
+	drillTracks            []provider.Track
+	drillLoading           bool
+	drillErr               error
+	drillList              list.Model
+	drillRequestGeneration uint64
+	drillRequestKind       playlistRequestKind
+	tracksBackPane         libraryPane
 
 	width  int
 	height int
@@ -142,13 +153,17 @@ func (m *LibraryModel) loadPlaylists() tea.Cmd {
 }
 
 func (m *LibraryModel) loadPlaylistTracks(pl provider.Playlist) tea.Cmd {
+	m.drillRequestGeneration++
+	m.drillRequestKind = playlistRequestTracks
+	generation := m.drillRequestGeneration
+	kind := m.drillRequestKind
 	m.drillLoading = true
 	prov := m.provider
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), libraryLoadTimeout)
 		defer cancel()
 		tracks, err := prov.GetPlaylistTracks(ctx, pl.ID)
-		return playlistTracksMsg{playlist: pl, tracks: tracks, err: err}
+		return playlistTracksMsg{playlist: pl, generation: generation, kind: kind, tracks: tracks, err: err}
 	}
 }
 
@@ -174,13 +189,13 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 		}
 		return m, nil
 	case playlistTracksMsg:
-		if m.pane != paneTracks || m.drillPlaylist.ID != msg.playlist.ID {
+		if m.pane != paneTracks || m.drillPlaylist.ID != msg.playlist.ID || m.drillRequestGeneration != msg.generation || m.drillRequestKind != msg.kind || msg.kind != playlistRequestTracks {
 			return m, nil
 		}
 		m.drillLoading = false
 		m.drillErr = msg.err
 		if msg.err == nil {
-			m.showTrackPane(msg.playlist.Name, msg.tracks, paneItems)
+			m.showPlaylistTrackPane(msg.playlist.Name, msg.tracks, paneItems)
 		}
 		return m, nil
 	case spinner.TickMsg:
@@ -208,6 +223,7 @@ func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 	case paneItems:
 		switch msg.String() {
 		case "esc", "backspace":
+			m.invalidatePlaylistRequest()
 			m.pane = paneSections
 			m.showSections()
 			return m, nil
@@ -217,6 +233,7 @@ func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 	case paneTracks:
 		switch msg.String() {
 		case "esc", "backspace":
+			m.invalidatePlaylistRequest()
 			if m.tracksBackPane == paneSections && m.drillTitle == "" {
 				m.pane = paneItems
 			} else {
@@ -361,7 +378,20 @@ func (m *LibraryModel) showGroups(groups []trackGroup) {
 	m.list.Select(0)
 }
 
+func (m *LibraryModel) invalidatePlaylistRequest() {
+	m.drillRequestGeneration++
+	m.drillRequestKind = playlistRequestNone
+	m.drillPlaylist = provider.Playlist{}
+	m.drillLoading = false
+	m.drillErr = nil
+}
+
 func (m *LibraryModel) showTrackPane(title string, tracks []provider.Track, back libraryPane) {
+	m.invalidatePlaylistRequest()
+	m.showPlaylistTrackPane(title, tracks, back)
+}
+
+func (m *LibraryModel) showPlaylistTrackPane(title string, tracks []provider.Track, back libraryPane) {
 	m.pane = paneTracks
 	m.tracksBackPane = back
 	m.drillTitle = title

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -174,9 +174,11 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 		}
 		return m, nil
 	case playlistTracksMsg:
+		if m.pane != paneTracks || m.drillPlaylist.ID != msg.playlist.ID {
+			return m, nil
+		}
 		m.drillLoading = false
 		m.drillErr = msg.err
-		m.drillPlaylist = msg.playlist
 		if msg.err == nil {
 			m.showTrackPane(msg.playlist.Name, msg.tracks, paneItems)
 		}

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -36,14 +36,28 @@ const (
 	sectionPlaylists
 )
 
+type libraryRequestKind int
+
+const (
+	libraryRequestNone libraryRequestKind = iota
+	libraryRequestTracks
+	libraryRequestPlaylists
+)
+
 type libraryLoadedMsg struct {
-	playlists []provider.Playlist
-	err       error
+	generation uint64
+	section    librarySection
+	kind       libraryRequestKind
+	playlists  []provider.Playlist
+	err        error
 }
 
 type libraryTracksLoadedMsg struct {
-	tracks []provider.Track
-	err    error
+	generation uint64
+	section    librarySection
+	kind       libraryRequestKind
+	tracks     []provider.Track
+	err        error
 }
 
 type playlistRequestKind int
@@ -83,6 +97,10 @@ type LibraryModel struct {
 	playlistsLoaded   bool
 	albums            []trackGroup
 	artists           []trackGroup
+
+	libraryRequestGeneration uint64
+	libraryRequestSection    librarySection
+	libraryRequestKind       libraryRequestKind
 
 	drillTitle             string
 	drillPlaylist          provider.Playlist
@@ -131,24 +149,36 @@ func (m *LibraryModel) SetSize(w, h int) {
 }
 
 func (m *LibraryModel) loadLibraryTracks() tea.Cmd {
+	m.libraryRequestGeneration++
+	m.libraryRequestSection = m.selectedSection
+	m.libraryRequestKind = libraryRequestTracks
+	generation := m.libraryRequestGeneration
+	section := m.libraryRequestSection
+	kind := m.libraryRequestKind
 	m.loading = true
 	prov := m.provider
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), libraryLoadTimeout)
 		defer cancel()
 		tracks, err := prov.GetLibraryTracks(ctx)
-		return libraryTracksLoadedMsg{tracks: tracks, err: err}
+		return libraryTracksLoadedMsg{generation: generation, section: section, kind: kind, tracks: tracks, err: err}
 	}
 }
 
 func (m *LibraryModel) loadPlaylists() tea.Cmd {
+	m.libraryRequestGeneration++
+	m.libraryRequestSection = m.selectedSection
+	m.libraryRequestKind = libraryRequestPlaylists
+	generation := m.libraryRequestGeneration
+	section := m.libraryRequestSection
+	kind := m.libraryRequestKind
 	m.loading = true
 	prov := m.provider
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), libraryLoadTimeout)
 		defer cancel()
 		playlists, err := prov.GetLibraryPlaylists(ctx)
-		return libraryLoadedMsg{playlists: playlists, err: err}
+		return libraryLoadedMsg{generation: generation, section: section, kind: kind, playlists: playlists, err: err}
 	}
 }
 
@@ -170,6 +200,9 @@ func (m *LibraryModel) loadPlaylistTracks(pl provider.Playlist) tea.Cmd {
 func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case libraryTracksLoadedMsg:
+		if !m.currentLibraryRequest(msg.generation, msg.section, msg.kind) || msg.kind != libraryRequestTracks {
+			return m, nil
+		}
 		m.loading = false
 		m.loadErr = msg.err
 		if msg.err == nil {
@@ -180,6 +213,9 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 		}
 		return m, nil
 	case libraryLoadedMsg:
+		if !m.currentLibraryRequest(msg.generation, msg.section, msg.kind) || msg.kind != libraryRequestPlaylists {
+			return m, nil
+		}
 		m.loading = false
 		m.loadErr = msg.err
 		if msg.err == nil {
@@ -258,6 +294,7 @@ func (m *LibraryModel) updateActiveList(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 }
 
 func (m *LibraryModel) openSelectedSection() (*LibraryModel, tea.Cmd) {
+	m.invalidateLibraryRequest()
 	switch m.selectedSection {
 	case sectionSongs, sectionAlbums, sectionArtists:
 		if !m.tracksLoaded || m.libraryTracksExpired(time.Now()) {
@@ -279,6 +316,17 @@ func (m *LibraryModel) openSelectedSection() (*LibraryModel, tea.Cmd) {
 		m.showSections()
 		return m, nil
 	}
+}
+
+func (m *LibraryModel) currentLibraryRequest(generation uint64, section librarySection, kind libraryRequestKind) bool {
+	return m.libraryRequestGeneration == generation && m.libraryRequestSection == section && m.libraryRequestKind == kind && m.selectedSection == section
+}
+
+func (m *LibraryModel) invalidateLibraryRequest() {
+	m.libraryRequestGeneration++
+	m.libraryRequestSection = m.selectedSection
+	m.libraryRequestKind = libraryRequestNone
+	m.loading = false
 }
 
 func (m *LibraryModel) libraryTracksExpired(now time.Time) bool {

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/spinner"
@@ -19,7 +20,11 @@ const (
 	paneSections libraryPane = iota
 	paneItems
 	paneTracks
-	paneList = paneItems
+)
+
+const (
+	libraryLoadTimeout = 20 * time.Second
+	libraryTracksTTL   = 5 * time.Minute
 )
 
 type librarySection int
@@ -60,14 +65,15 @@ type LibraryModel struct {
 	list     list.Model
 	spinner  spinner.Model
 
-	pane            libraryPane
-	selectedSection librarySection
-	libraryTracks   []provider.Track
-	tracksLoaded    bool
-	playlists       []provider.Playlist
-	playlistsLoaded bool
-	albums          []trackGroup
-	artists         []trackGroup
+	pane              libraryPane
+	selectedSection   librarySection
+	libraryTracks     []provider.Track
+	tracksLoaded      bool
+	libraryTracksTime time.Time
+	playlists         []provider.Playlist
+	playlistsLoaded   bool
+	albums            []trackGroup
+	artists           []trackGroup
 
 	drillTitle     string
 	drillPlaylist  provider.Playlist
@@ -117,7 +123,9 @@ func (m *LibraryModel) loadLibraryTracks() tea.Cmd {
 	m.loading = true
 	prov := m.provider
 	return func() tea.Msg {
-		tracks, err := prov.GetLibraryTracks(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), libraryLoadTimeout)
+		defer cancel()
+		tracks, err := prov.GetLibraryTracks(ctx)
 		return libraryTracksLoadedMsg{tracks: tracks, err: err}
 	}
 }
@@ -126,7 +134,9 @@ func (m *LibraryModel) loadPlaylists() tea.Cmd {
 	m.loading = true
 	prov := m.provider
 	return func() tea.Msg {
-		playlists, err := prov.GetLibraryPlaylists(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), libraryLoadTimeout)
+		defer cancel()
+		playlists, err := prov.GetLibraryPlaylists(ctx)
 		return libraryLoadedMsg{playlists: playlists, err: err}
 	}
 }
@@ -135,7 +145,9 @@ func (m *LibraryModel) loadPlaylistTracks(pl provider.Playlist) tea.Cmd {
 	m.drillLoading = true
 	prov := m.provider
 	return func() tea.Msg {
-		tracks, err := prov.GetPlaylistTracks(context.Background(), pl.ID)
+		ctx, cancel := context.WithTimeout(context.Background(), libraryLoadTimeout)
+		defer cancel()
+		tracks, err := prov.GetPlaylistTracks(ctx, pl.ID)
 		return playlistTracksMsg{playlist: pl, tracks: tracks, err: err}
 	}
 }
@@ -148,6 +160,7 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 		if msg.err == nil {
 			m.libraryTracks = append([]provider.Track{}, msg.tracks...)
 			m.tracksLoaded = true
+			m.libraryTracksTime = time.Now()
 			m.routeLoadedLibraryTracks()
 		}
 		return m, nil
@@ -203,7 +216,7 @@ func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 		switch msg.String() {
 		case "esc", "backspace":
 			if m.tracksBackPane == paneSections && m.drillTitle == "" {
-				m.pane = paneList
+				m.pane = paneItems
 			} else {
 				m.pane = m.tracksBackPane
 			}
@@ -228,7 +241,7 @@ func (m *LibraryModel) updateActiveList(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 func (m *LibraryModel) openSelectedSection() (*LibraryModel, tea.Cmd) {
 	switch m.selectedSection {
 	case sectionSongs, sectionAlbums, sectionArtists:
-		if !m.tracksLoaded {
+		if !m.tracksLoaded || m.libraryTracksExpired(time.Now()) {
 			m.loading = true
 			return m, tea.Batch(m.spinner.Tick, m.loadLibraryTracks())
 		}
@@ -242,8 +255,21 @@ func (m *LibraryModel) openSelectedSection() (*LibraryModel, tea.Cmd) {
 		m.showPlaylists()
 		return m, nil
 	default:
-		panic("unknown library section")
+		m.loadErr = fmt.Errorf("unknown library section: %d", m.selectedSection)
+		m.pane = paneSections
+		m.showSections()
+		return m, nil
 	}
+}
+
+func (m *LibraryModel) libraryTracksExpired(now time.Time) bool {
+	if !m.tracksLoaded {
+		return true
+	}
+	if m.libraryTracksTime.IsZero() {
+		return true
+	}
+	return now.Sub(m.libraryTracksTime) >= libraryTracksTTL
 }
 
 func (m *LibraryModel) routeLoadedLibraryTracks() {
@@ -259,7 +285,9 @@ func (m *LibraryModel) routeLoadedLibraryTracks() {
 	case sectionPlaylists:
 		m.showPlaylists()
 	default:
-		panic("unknown library section")
+		m.loadErr = fmt.Errorf("unknown library section: %d", m.selectedSection)
+		m.pane = paneSections
+		m.showSections()
 	}
 }
 
@@ -424,7 +452,7 @@ func sectionTitle(section librarySection) string {
 	case sectionPlaylists:
 		return "Playlists"
 	default:
-		panic("unknown library section")
+		return "Library"
 	}
 }
 

--- a/internal/tui/views/library_behavior_test.go
+++ b/internal/tui/views/library_behavior_test.go
@@ -1,0 +1,116 @@
+package views
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/simone-vibes/vibez/internal/provider"
+)
+
+func TestLibrary_InitialViewShowsLibrarySections(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 24)
+	view := lib.View()
+	for _, want := range []string{"Songs", "Albums", "Artists", "Playlists"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("View() missing %q: %q", want, view)
+		}
+	}
+}
+
+func TestLibrary_SongsSectionLoadsAndPlaysSongs(t *testing.T) {
+	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A", Album: "X"}, {ID: "i.2", Title: "Two", Artist: "B", Album: "Y"}}
+	lib := NewLibrary(&mockProvider{libraryTracks: tracks})
+	lib.SetSize(80, 24)
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !strings.Contains(lib.View(), "Loading songs") {
+		t.Fatalf("loading view missing songs copy: %q", lib.View())
+	}
+	lib, _ = lib.Update(libraryTracksLoadedMsg{tracks: tracks})
+	view := lib.View()
+	if !strings.Contains(view, "One") || !strings.Contains(view, "Two") {
+		t.Fatalf("songs not rendered: %q", view)
+	}
+	_, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assertPlayTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks)
+}
+
+func TestLibrary_AlbumsSectionGroupsSongsAndPlaysAlbumTracks(t *testing.T) {
+	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A", Album: "Alpha"}, {ID: "i.2", Title: "Two", Artist: "A", Album: "Alpha"}, {ID: "i.3", Title: "Three", Artist: "B", Album: "Beta"}}
+	lib := NewLibrary(&mockProvider{libraryTracks: tracks})
+	lib.SetSize(80, 24)
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{tracks: tracks})
+	if view := lib.View(); !strings.Contains(view, "Alpha") || !strings.Contains(view, "Beta") {
+		t.Fatalf("albums not rendered: %q", view)
+	}
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if view := lib.View(); !strings.Contains(view, "One") || !strings.Contains(view, "Two") || strings.Contains(view, "Three") {
+		t.Fatalf("album tracks wrong: %q", view)
+	}
+	_, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assertPlayTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks[:2])
+}
+
+func TestLibrary_ArtistsSectionGroupsSongsAndPlaysArtistTracks(t *testing.T) {
+	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A", Album: "Alpha"}, {ID: "i.2", Title: "Two", Artist: "A", Album: "Beta"}, {ID: "i.3", Title: "Three", Artist: "B", Album: "Beta"}}
+	lib := NewLibrary(&mockProvider{libraryTracks: tracks})
+	lib.SetSize(80, 24)
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{tracks: tracks})
+	if view := lib.View(); !strings.Contains(view, "A") || !strings.Contains(view, "B") {
+		t.Fatalf("artists not rendered: %q", view)
+	}
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if view := lib.View(); !strings.Contains(view, "One") || !strings.Contains(view, "Two") || strings.Contains(view, "Three") {
+		t.Fatalf("artist tracks wrong: %q", view)
+	}
+	_, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assertPlayTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks[:2])
+}
+
+func TestLibrary_PlaylistsSectionLoadsPlaylistThenPlaysTracks(t *testing.T) {
+	playlists := []provider.Playlist{{ID: "p.1", Name: "Mix", TrackCount: 2}}
+	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A"}, {ID: "i.2", Title: "Two", Artist: "B"}}
+	lib := NewLibrary(&mockProvider{playlists: playlists, playlistTracks: map[string][]provider.Track{"p.1": tracks}})
+	lib.SetSize(80, 24)
+	for range 3 {
+		lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	lib, _ = lib.Update(libraryLoadedMsg{playlists: playlists})
+	if view := lib.View(); !strings.Contains(view, "Mix") {
+		t.Fatalf("playlists not rendered: %q", view)
+	}
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	lib, _ = lib.Update(playlistTracksMsg{playlist: playlists[0], tracks: tracks})
+	if view := lib.View(); !strings.Contains(view, "One") || !strings.Contains(view, "Two") {
+		t.Fatalf("playlist tracks not rendered: %q", view)
+	}
+	_, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assertPlayTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks)
+}
+
+func assertPlayTracksMsg(t *testing.T, cmd tea.Cmd, ids []string, tracks []provider.Track) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected play command")
+	}
+	msg, ok := cmd().(PlayTracksMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want PlayTracksMsg", cmd())
+	}
+	if strings.Join(msg.IDs, ",") != strings.Join(ids, ",") {
+		t.Fatalf("IDs = %#v, want %#v", msg.IDs, ids)
+	}
+	if len(msg.Tracks) != len(tracks) {
+		t.Fatalf("Tracks len = %d, want %d", len(msg.Tracks), len(tracks))
+	}
+	if msg.Track == nil || msg.Track.ID != tracks[0].ID {
+		t.Fatalf("Track = %#v, want first %#v", msg.Track, tracks[0])
+	}
+}

--- a/internal/tui/views/library_behavior_test.go
+++ b/internal/tui/views/library_behavior_test.go
@@ -27,7 +27,7 @@ func TestLibrary_SongsSectionLoadsAndPlaysSongs(t *testing.T) {
 	if !strings.Contains(lib.View(), "Loading songs") {
 		t.Fatalf("loading view missing songs copy: %q", lib.View())
 	}
-	lib, _ = lib.Update(libraryTracksLoadedMsg{tracks: tracks})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: lib.libraryRequestGeneration, section: lib.libraryRequestSection, kind: lib.libraryRequestKind, tracks: tracks})
 	view := lib.View()
 	if !strings.Contains(view, "One") || !strings.Contains(view, "Two") {
 		t.Fatalf("songs not rendered: %q", view)
@@ -42,7 +42,7 @@ func TestLibrary_AlbumsSectionGroupsSongsAndPlaysAlbumTracks(t *testing.T) {
 	lib.SetSize(80, 24)
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	lib, _ = lib.Update(libraryTracksLoadedMsg{tracks: tracks})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: lib.libraryRequestGeneration, section: lib.libraryRequestSection, kind: lib.libraryRequestKind, tracks: tracks})
 	if view := lib.View(); !strings.Contains(view, "Alpha") || !strings.Contains(view, "Beta") {
 		t.Fatalf("albums not rendered: %q", view)
 	}
@@ -61,7 +61,7 @@ func TestLibrary_ArtistsSectionGroupsSongsAndPlaysArtistTracks(t *testing.T) {
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	lib, _ = lib.Update(libraryTracksLoadedMsg{tracks: tracks})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: lib.libraryRequestGeneration, section: lib.libraryRequestSection, kind: lib.libraryRequestKind, tracks: tracks})
 	if view := lib.View(); !strings.Contains(view, "A") || !strings.Contains(view, "B") {
 		t.Fatalf("artists not rendered: %q", view)
 	}
@@ -82,7 +82,7 @@ func TestLibrary_PlaylistsSectionLoadsPlaylistThenPlaysTracks(t *testing.T) {
 		lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	lib, _ = lib.Update(libraryLoadedMsg{playlists: playlists})
+	lib, _ = lib.Update(libraryLoadedMsg{generation: lib.libraryRequestGeneration, section: lib.libraryRequestSection, kind: lib.libraryRequestKind, playlists: playlists})
 	if view := lib.View(); !strings.Contains(view, "Mix") {
 		t.Fatalf("playlists not rendered: %q", view)
 	}

--- a/internal/tui/views/library_behavior_test.go
+++ b/internal/tui/views/library_behavior_test.go
@@ -87,7 +87,7 @@ func TestLibrary_PlaylistsSectionLoadsPlaylistThenPlaysTracks(t *testing.T) {
 		t.Fatalf("playlists not rendered: %q", view)
 	}
 	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	lib, _ = lib.Update(playlistTracksMsg{playlist: playlists[0], tracks: tracks})
+	lib, _ = lib.Update(playlistTracksMsg{playlist: playlists[0], generation: lib.drillRequestGeneration, kind: lib.drillRequestKind, tracks: tracks})
 	if view := lib.View(); !strings.Contains(view, "One") || !strings.Contains(view, "Two") {
 		t.Fatalf("playlist tracks not rendered: %q", view)
 	}

--- a/internal/tui/views/library_test.go
+++ b/internal/tui/views/library_test.go
@@ -110,7 +110,14 @@ func TestLibrary_View_NotLoading(t *testing.T) {
 func TestLibrary_Update_LibraryLoadedMsg_Playlists(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 24)
+	lib.libraryRequestGeneration = 1
+	lib.libraryRequestSection = sectionPlaylists
+	lib.libraryRequestKind = libraryRequestPlaylists
+	lib.selectedSection = sectionPlaylists
 	msg := libraryLoadedMsg{
+		generation: 1,
+		section:    sectionPlaylists,
+		kind:       libraryRequestPlaylists,
 		playlists: []provider.Playlist{
 			{ID: "p1", Name: "Playlist One", TrackCount: 10},
 			{ID: "p2", Name: "Playlist Two", TrackCount: 20},
@@ -126,7 +133,11 @@ func TestLibrary_Update_LibraryLoadedMsg_Error(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 24)
 	lib.loading = true
-	msg := libraryLoadedMsg{err: errors.New("load failed")}
+	lib.libraryRequestGeneration = 1
+	lib.libraryRequestSection = sectionPlaylists
+	lib.libraryRequestKind = libraryRequestPlaylists
+	lib.selectedSection = sectionPlaylists
+	msg := libraryLoadedMsg{generation: 1, section: sectionPlaylists, kind: libraryRequestPlaylists, err: errors.New("load failed")}
 	lib, _ = lib.Update(msg)
 	// loading should be cleared even on error
 	if lib.loading {
@@ -154,8 +165,15 @@ func TestLibrary_RefreshList_Indirect(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 24)
 	// Load playlists and verify no panic.
+	lib.libraryRequestGeneration = 1
+	lib.libraryRequestSection = sectionPlaylists
+	lib.libraryRequestKind = libraryRequestPlaylists
+	lib.selectedSection = sectionPlaylists
 	lib, _ = lib.Update(libraryLoadedMsg{
-		playlists: []provider.Playlist{{Name: "PL", TrackCount: 5}},
+		generation: 1,
+		section:    sectionPlaylists,
+		kind:       libraryRequestPlaylists,
+		playlists:  []provider.Playlist{{Name: "PL", TrackCount: 5}},
 	})
 	if lib.list.Items() == nil {
 		t.Error("expected non-nil items after loading playlists")
@@ -177,6 +195,7 @@ func TestLibrary_LoadPlaylists_Executes(t *testing.T) {
 		},
 	}
 	lib := NewLibrary(prov)
+	lib.selectedSection = sectionPlaylists
 	cmd := lib.loadPlaylists()
 	if cmd == nil {
 		t.Fatal("loadPlaylists() should return non-nil cmd")
@@ -188,6 +207,15 @@ func TestLibrary_LoadPlaylists_Executes(t *testing.T) {
 	}
 	if len(loaded.playlists) != 1 {
 		t.Errorf("got %d playlists, want 1", len(loaded.playlists))
+	}
+	if loaded.generation == 0 {
+		t.Fatal("libraryLoadedMsg.generation = 0, want non-zero")
+	}
+	if loaded.section != sectionPlaylists {
+		t.Fatalf("libraryLoadedMsg.section = %d, want %d", loaded.section, sectionPlaylists)
+	}
+	if loaded.kind != libraryRequestPlaylists {
+		t.Fatalf("libraryLoadedMsg.kind = %d, want %d", loaded.kind, libraryRequestPlaylists)
 	}
 }
 
@@ -415,6 +443,82 @@ func TestLibrary_CurrentPlaylistResponseAccepted(t *testing.T) {
 	}
 	if len(lib.drillTracks) != 1 || lib.drillTracks[0].ID != "t.1" {
 		t.Fatalf("drillTracks = %+v, want current playlist tracks", lib.drillTracks)
+	}
+}
+
+func TestLibrary_StalePlaylistsResponseAfterNavigatingSongsDoesNotReplaceSongs(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	playlists := []provider.Playlist{{ID: "p.1", Name: "Slow Playlist"}}
+	songs := []provider.Track{{ID: "s.1", Title: "Current Song"}}
+
+	lib.selectedSection = sectionPlaylists
+	playlistsCmd := lib.loadPlaylists()
+	playlistsMsg := playlistsCmd().(libraryLoadedMsg)
+
+	lib.selectedSection = sectionSongs
+	songsCmd := lib.loadLibraryTracks()
+	songsMsg := songsCmd().(libraryTracksLoadedMsg)
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: songsMsg.generation, section: songsMsg.section, kind: songsMsg.kind, tracks: songs})
+	lib, _ = lib.Update(libraryLoadedMsg{generation: playlistsMsg.generation, section: playlistsMsg.section, kind: playlistsMsg.kind, playlists: playlists})
+
+	if lib.pane != paneTracks {
+		t.Fatalf("pane = %d, want %d", lib.pane, paneTracks)
+	}
+	if len(lib.drillTracks) != 1 || lib.drillTracks[0].ID != "s.1" {
+		t.Fatalf("drillTracks = %+v, want current songs", lib.drillTracks)
+	}
+	if lib.loading {
+		t.Fatal("stale playlists response cleared/changed current loading state")
+	}
+}
+
+func TestLibrary_StaleSongsResponseAfterNavigatingPlaylistsDoesNotOverwritePlaylists(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	songs := []provider.Track{{ID: "s.1", Title: "Slow Song"}}
+	playlists := []provider.Playlist{{ID: "p.1", Name: "Current Playlist"}}
+
+	lib.selectedSection = sectionSongs
+	songsCmd := lib.loadLibraryTracks()
+	songsMsg := songsCmd().(libraryTracksLoadedMsg)
+
+	lib.selectedSection = sectionPlaylists
+	playlistsCmd := lib.loadPlaylists()
+	playlistsMsg := playlistsCmd().(libraryLoadedMsg)
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: songsMsg.generation, section: songsMsg.section, kind: songsMsg.kind, tracks: songs})
+
+	if !lib.loading {
+		t.Fatal("stale songs response cleared current playlists loading")
+	}
+	if lib.pane != paneSections {
+		t.Fatalf("pane = %d, want sections while playlists load", lib.pane)
+	}
+
+	lib, _ = lib.Update(libraryLoadedMsg{generation: playlistsMsg.generation, section: playlistsMsg.section, kind: playlistsMsg.kind, playlists: playlists})
+	if lib.loading {
+		t.Fatal("valid playlists response should clear loading")
+	}
+	if lib.pane != paneItems || len(lib.playlists) != 1 || lib.playlists[0].ID != "p.1" {
+		t.Fatalf("playlists pane = %d playlists = %+v, want current playlists", lib.pane, lib.playlists)
+	}
+}
+
+func TestLibrary_CurrentTopLevelResponseAccepted(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	tracks := []provider.Track{{ID: "s.1", Title: "Accepted Song"}}
+
+	lib.selectedSection = sectionSongs
+	cmd := lib.loadLibraryTracks()
+	msg := cmd().(libraryTracksLoadedMsg)
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: msg.generation, section: msg.section, kind: msg.kind, tracks: tracks})
+
+	if lib.loading {
+		t.Fatal("valid tracks response should clear loading")
+	}
+	if lib.pane != paneTracks || len(lib.drillTracks) != 1 || lib.drillTracks[0].ID != "s.1" {
+		t.Fatalf("tracks pane = %d drillTracks = %+v, want accepted songs", lib.pane, lib.drillTracks)
 	}
 }
 

--- a/internal/tui/views/library_test.go
+++ b/internal/tui/views/library_test.go
@@ -277,6 +277,8 @@ func TestLibrary_Update_PlaylistTracksMsg_Success(t *testing.T) {
 	lib.SetSize(80, 20)
 	pl := provider.Playlist{ID: "pl1", Name: "Playlist"}
 	tracks := []provider.Track{{Title: "Song", Artist: "Artist"}}
+	lib.pane = paneTracks
+	lib.drillPlaylist = pl
 	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, tracks: tracks})
 	if len(updated.drillTracks) != 1 {
 		t.Errorf("drillTracks after playlistTracksMsg = %d, want 1", len(updated.drillTracks))
@@ -286,9 +288,34 @@ func TestLibrary_Update_PlaylistTracksMsg_Success(t *testing.T) {
 func TestLibrary_Update_PlaylistTracksMsg_Error(t *testing.T) {
 	lib := NewLibrary(&mockProvider{})
 	lib.SetSize(80, 20)
-	updated, _ := lib.Update(playlistTracksMsg{err: errors.New("load error")})
+	pl := provider.Playlist{ID: "pl1", Name: "Playlist"}
+	lib.pane = paneTracks
+	lib.drillPlaylist = pl
+	lib.drillLoading = true
+	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, err: errors.New("load error")})
 	if updated.drillLoading {
 		t.Error("drillLoading should be false after error")
+	}
+}
+
+func TestLibrary_Update_PlaylistTracksMsg_DropsStaleResponse(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	pl := provider.Playlist{ID: "pl1", Name: "Playlist"}
+	tracks := []provider.Track{{Title: "Song", Artist: "Artist"}}
+	lib.pane = paneItems
+	lib.drillPlaylist = pl
+	lib.drillLoading = true
+
+	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, tracks: tracks})
+	if updated.pane != paneItems {
+		t.Fatalf("stale playlist response changed pane = %d, want %d", updated.pane, paneItems)
+	}
+	if len(updated.drillTracks) != 0 {
+		t.Fatalf("stale playlist response set %d drill tracks, want 0", len(updated.drillTracks))
+	}
+	if !updated.drillLoading {
+		t.Fatal("stale playlist response should not clear current drill loading state")
 	}
 }
 

--- a/internal/tui/views/library_test.go
+++ b/internal/tui/views/library_test.go
@@ -301,8 +301,57 @@ func TestLibrary_Update_DrillPane_Esc_ReturnsToList(t *testing.T) {
 	lib.drillTracks = []provider.Track{{Title: "T1"}}
 
 	updated, _ := lib.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
-	if updated.pane != paneList {
+	if updated.pane != paneItems {
 		t.Error("esc in drill pane should return to list pane")
+	}
+}
+
+func TestLibrary_LoadCommandsUseTimeoutContexts(t *testing.T) {
+	prov := &mockProvider{}
+	lib := NewLibrary(prov)
+
+	lib.loadLibraryTracks()()
+	if _, ok := prov.libraryTrackCtx.Deadline(); !ok {
+		t.Fatal("GetLibraryTracks context missing deadline")
+	}
+
+	lib.loadPlaylists()()
+	if _, ok := prov.playlistCtx.Deadline(); !ok {
+		t.Fatal("GetLibraryPlaylists context missing deadline")
+	}
+
+	lib.loadPlaylistTracks(provider.Playlist{ID: "p1"})()
+	if _, ok := prov.playlistTrackCtx.Deadline(); !ok {
+		t.Fatal("GetPlaylistTracks context missing deadline")
+	}
+}
+
+func TestLibrary_OpenSelectedSectionRefreshesExpiredTracks(t *testing.T) {
+	prov := &mockProvider{libraryTracks: []provider.Track{{ID: "i.1", Title: "One"}}}
+	lib := NewLibrary(prov)
+	lib.selectedSection = sectionSongs
+	lib.tracksLoaded = true
+	lib.libraryTracksTime = time.Now().Add(-libraryTracksTTL)
+
+	_, cmd := lib.openSelectedSection()
+	if cmd == nil {
+		t.Fatal("expired library tracks should trigger reload")
+	}
+}
+
+func TestLibrary_UnknownSectionDoesNotPanic(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.selectedSection = librarySection(99)
+
+	updated, cmd := lib.openSelectedSection()
+	if cmd != nil {
+		t.Fatal("unknown section should not return load command")
+	}
+	if updated.LoadErr() == nil {
+		t.Fatal("unknown section should record load error")
+	}
+	if got := sectionTitle(librarySection(99)); got != "Library" {
+		t.Fatalf("sectionTitle(unknown) = %q, want Library", got)
 	}
 }
 

--- a/internal/tui/views/library_test.go
+++ b/internal/tui/views/library_test.go
@@ -207,6 +207,12 @@ func TestLibrary_LoadPlaylistTracks_Executes(t *testing.T) {
 	if ptm.playlist.ID != "pl-123" {
 		t.Errorf("playlistTracksMsg.playlist.ID = %q, want %q", ptm.playlist.ID, "pl-123")
 	}
+	if ptm.generation == 0 {
+		t.Fatal("playlistTracksMsg.generation = 0, want non-zero")
+	}
+	if ptm.kind != playlistRequestTracks {
+		t.Fatalf("playlistTracksMsg.kind = %d, want %d", ptm.kind, playlistRequestTracks)
+	}
 }
 
 // --- renderDrillView ---
@@ -247,9 +253,13 @@ func TestLibrary_RenderDrillView_WithTracks(t *testing.T) {
 		{Title: "Track 2", Artist: "Artist 2"},
 	}
 	// Set drill list items.
+	lib.drillRequestGeneration = 1
+	lib.drillRequestKind = playlistRequestTracks
 	lib.Update(playlistTracksMsg{
-		playlist: lib.drillPlaylist,
-		tracks:   lib.drillTracks,
+		playlist:   lib.drillPlaylist,
+		generation: 1,
+		kind:       playlistRequestTracks,
+		tracks:     lib.drillTracks,
 	})
 	view := lib.renderDrillView()
 	if view == "" {
@@ -279,7 +289,9 @@ func TestLibrary_Update_PlaylistTracksMsg_Success(t *testing.T) {
 	tracks := []provider.Track{{Title: "Song", Artist: "Artist"}}
 	lib.pane = paneTracks
 	lib.drillPlaylist = pl
-	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, tracks: tracks})
+	lib.drillRequestGeneration = 1
+	lib.drillRequestKind = playlistRequestTracks
+	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, generation: 1, kind: playlistRequestTracks, tracks: tracks})
 	if len(updated.drillTracks) != 1 {
 		t.Errorf("drillTracks after playlistTracksMsg = %d, want 1", len(updated.drillTracks))
 	}
@@ -292,7 +304,9 @@ func TestLibrary_Update_PlaylistTracksMsg_Error(t *testing.T) {
 	lib.pane = paneTracks
 	lib.drillPlaylist = pl
 	lib.drillLoading = true
-	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, err: errors.New("load error")})
+	lib.drillRequestGeneration = 1
+	lib.drillRequestKind = playlistRequestTracks
+	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, generation: 1, kind: playlistRequestTracks, err: errors.New("load error")})
 	if updated.drillLoading {
 		t.Error("drillLoading should be false after error")
 	}
@@ -306,8 +320,10 @@ func TestLibrary_Update_PlaylistTracksMsg_DropsStaleResponse(t *testing.T) {
 	lib.pane = paneItems
 	lib.drillPlaylist = pl
 	lib.drillLoading = true
+	lib.drillRequestGeneration = 1
+	lib.drillRequestKind = playlistRequestTracks
 
-	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, tracks: tracks})
+	updated, _ := lib.Update(playlistTracksMsg{playlist: pl, generation: 1, kind: playlistRequestTracks, tracks: tracks})
 	if updated.pane != paneItems {
 		t.Fatalf("stale playlist response changed pane = %d, want %d", updated.pane, paneItems)
 	}
@@ -316,6 +332,89 @@ func TestLibrary_Update_PlaylistTracksMsg_DropsStaleResponse(t *testing.T) {
 	}
 	if !updated.drillLoading {
 		t.Fatal("stale playlist response should not clear current drill loading state")
+	}
+}
+
+func TestLibrary_PlaylistResponseAfterBackAndSongsDoesNotOverwriteSongs(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	playlist := provider.Playlist{ID: "pl1", Name: "Playlist"}
+	playlistTracks := []provider.Track{{ID: "p.1", Title: "Playlist Song"}}
+	songTracks := []provider.Track{{ID: "s.1", Title: "Song Pane Track"}}
+
+	cmd := lib.loadPlaylistTracks(playlist)
+	msg := cmd().(playlistTracksMsg)
+	lib.pane = paneTracks
+	lib.drillPlaylist = playlist
+	lib.drillTitle = playlist.Name
+	lib.tracksBackPane = paneItems
+
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	lib.showTrackPane("Songs", songTracks, paneSections)
+	lib, _ = lib.Update(playlistTracksMsg{playlist: playlist, generation: msg.generation, kind: msg.kind, tracks: playlistTracks})
+
+	if lib.pane != paneTracks {
+		t.Fatalf("pane = %d, want %d", lib.pane, paneTracks)
+	}
+	if lib.drillLoading {
+		t.Fatal("stale playlist response left drill loading stuck")
+	}
+	if len(lib.drillTracks) != 1 || lib.drillTracks[0].ID != "s.1" {
+		t.Fatalf("drillTracks = %+v, want songs pane tracks", lib.drillTracks)
+	}
+}
+
+func TestLibrary_PlaylistAResponseIgnoredAfterOpeningPlaylistB(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	playlistA := provider.Playlist{ID: "a", Name: "Playlist A"}
+	playlistB := provider.Playlist{ID: "b", Name: "Playlist B"}
+	tracksA := []provider.Track{{ID: "a.1", Title: "A"}}
+	tracksB := []provider.Track{{ID: "b.1", Title: "B"}}
+
+	cmdA := lib.loadPlaylistTracks(playlistA)
+	msgA := cmdA().(playlistTracksMsg)
+	lib.pane = paneTracks
+	lib.drillPlaylist = playlistA
+
+	cmdB := lib.loadPlaylistTracks(playlistB)
+	msgB := cmdB().(playlistTracksMsg)
+	lib.drillPlaylist = playlistB
+
+	lib, _ = lib.Update(playlistTracksMsg{playlist: playlistA, generation: msgA.generation, kind: msgA.kind, tracks: tracksA})
+	if len(lib.drillTracks) != 0 {
+		t.Fatalf("stale playlist A set tracks: %+v", lib.drillTracks)
+	}
+	if !lib.drillLoading {
+		t.Fatal("stale playlist A cleared playlist B loading")
+	}
+
+	lib, _ = lib.Update(playlistTracksMsg{playlist: playlistB, generation: msgB.generation, kind: msgB.kind, tracks: tracksB})
+	if lib.drillLoading {
+		t.Fatal("valid playlist B response should clear loading")
+	}
+	if len(lib.drillTracks) != 1 || lib.drillTracks[0].ID != "b.1" {
+		t.Fatalf("drillTracks = %+v, want playlist B tracks", lib.drillTracks)
+	}
+}
+
+func TestLibrary_CurrentPlaylistResponseAccepted(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.SetSize(80, 20)
+	playlist := provider.Playlist{ID: "pl1", Name: "Playlist"}
+	tracks := []provider.Track{{ID: "t.1", Title: "Track"}}
+
+	cmd := lib.loadPlaylistTracks(playlist)
+	msg := cmd().(playlistTracksMsg)
+	lib.pane = paneTracks
+	lib.drillPlaylist = playlist
+
+	lib, _ = lib.Update(playlistTracksMsg{playlist: playlist, generation: msg.generation, kind: msg.kind, tracks: tracks})
+	if lib.drillLoading {
+		t.Fatal("valid playlist response should clear loading")
+	}
+	if len(lib.drillTracks) != 1 || lib.drillTracks[0].ID != "t.1" {
+		t.Fatalf("drillTracks = %+v, want current playlist tracks", lib.drillTracks)
 	}
 }
 


### PR DESCRIPTION
## Summary
- show Songs, Albums, Artists, Playlists when opening Library
- add drill-down/playback for songs, album groups, artist groups, playlists
- preserve playlist behavior with back navigation

## Tests
- `go test ./internal/tui/views ./internal/tui`
- `go test ./...`