### PR TITLE
Fix Apple library error handling

### DIFF
--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -123,12 +123,24 @@ func (a *AppleProvider) do(req *http.Request, dst any) error {
 	}()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("apple music api %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		return fmt.Errorf("%s", formatAPIError(resp.StatusCode, resp.Status, body))
 	}
 	if dst == nil || len(body) == 0 {
 		return nil
 	}
 	return json.Unmarshal(body, dst)
+}
+
+func formatAPIError(statusCode int, status string, body []byte) string {
+	msg := fmt.Sprintf("apple music api %s", status)
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed != "" {
+		msg += ": " + trimmed
+	}
+	if statusCode == http.StatusUnauthorized {
+		msg += ". Re-run `vibez login`; if you're using a local build, also refresh apple_developer_token."
+	}
+	return msg
 }
 
 // --- Apple Music API response types ---
@@ -223,6 +235,18 @@ type paginatedSongs struct {
 type paginatedPlaylists struct {
 	Data []playlistResource `json:"data"`
 	Next string             `json:"next"`
+}
+
+type playlistWithTracksResponse struct {
+	Data []struct {
+		ID            string             `json:"id"`
+		Attributes    playlistAttributes `json:"attributes"`
+		Relationships struct {
+			Tracks struct {
+				Data []songResource `json:"data"`
+			} `json:"tracks"`
+		} `json:"relationships"`
+	} `json:"data"`
 }
 
 type searchResponse struct {
@@ -540,7 +564,6 @@ func (a *AppleProvider) GetPlaylistTracks(ctx context.Context, playlistID string
 	}
 	var tracks []provider.Track
 	endpoint := fmt.Sprintf("/me/library/playlists/%s/tracks?limit=100", url.PathEscape(playlistID))
-
 	for endpoint != "" {
 		req, err := a.newRequest(ctx, http.MethodGet, endpoint)
 		if err != nil {
@@ -548,6 +571,23 @@ func (a *AppleProvider) GetPlaylistTracks(ctx context.Context, playlistID string
 		}
 		var page paginatedSongs
 		if err := a.do(req, &page); err != nil {
+			if strings.Contains(err.Error(), "404 Not Found") {
+				fallbackReq, reqErr := a.newRequest(ctx, http.MethodGet, fmt.Sprintf("/me/library/playlists/%s?include=tracks", url.PathEscape(playlistID)))
+				if reqErr != nil {
+					return nil, reqErr
+				}
+				var playlistResp playlistWithTracksResponse
+				if doErr := a.do(fallbackReq, &playlistResp); doErr != nil {
+					return nil, err
+				}
+				if len(playlistResp.Data) == 0 {
+					return nil, err
+				}
+				for _, s := range playlistResp.Data[0].Relationships.Tracks.Data {
+					tracks = append(tracks, toTrack(s))
+				}
+				return tracks, nil
+			}
 			return nil, err
 		}
 		for _, s := range page.Data {

--- a/internal/provider/apple/apple_test.go
+++ b/internal/provider/apple/apple_test.go
@@ -296,6 +296,9 @@ func TestSearch_HTTPError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for HTTP 401, got nil")
 	}
+	if !strings.Contains(err.Error(), "Re-run `vibez login`") {
+		t.Fatalf("expected actionable auth guidance, got %q", err)
+	}
 }
 
 func TestSearch_ContextCancelled(t *testing.T) {
@@ -631,6 +634,22 @@ func TestGetLibraryPlaylists_HTTPError(t *testing.T) {
 	}
 }
 
+func TestGetLibraryTracks_HTTPUnauthorizedHasGuidance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, err := p.GetLibraryTracks(context.Background())
+	if err == nil {
+		t.Fatal("expected error for HTTP 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "refresh apple_developer_token") {
+		t.Fatalf("expected developer token guidance, got %q", err)
+	}
+}
+
 func TestGetPlaylistTracks_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
@@ -641,6 +660,36 @@ func TestGetPlaylistTracks_HTTPError(t *testing.T) {
 	_, err := p.GetPlaylistTracks(context.Background(), "pl-id")
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
+	}
+}
+
+func TestGetPlaylistTracks_FallbackToIncludeTracksOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/me/library/playlists/pl-id/tracks":
+			http.Error(w, "not found", http.StatusNotFound)
+		case "/me/library/playlists/pl-id":
+			if r.URL.Query().Get("include") != "tracks" {
+				t.Fatalf("include query = %q", r.URL.Query().Get("include"))
+			}
+			writeJSON(t, w, map[string]any{"data": []any{map[string]any{
+				"id":            "pl-id",
+				"attributes":    map[string]any{"name": "Mix", "trackCount": 1, "artwork": map[string]any{"url": "", "width": 300, "height": 300}},
+				"relationships": map[string]any{"tracks": map[string]any{"data": []any{songJSON("s1", "Playlist Track", "Some Artist", "Some Album", 240000, "")}}},
+			}}})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	tracks, err := p.GetPlaylistTracks(context.Background(), "pl-id")
+	if err != nil {
+		t.Fatalf("GetPlaylistTracks fallback: %v", err)
+	}
+	if len(tracks) != 1 || tracks[0].Title != "Playlist Track" {
+		t.Fatalf("tracks = %+v", tracks)
 	}
 }
 

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -234,6 +234,9 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 			m.tracksLoaded = true
 			m.libraryTracksTime = time.Now()
 			m.routeLoadedLibraryTracks()
+		} else {
+			m.pane = paneItems
+			m.list.SetItems(nil)
 		}
 		return m, nil
 	case libraryLoadedMsg:
@@ -246,6 +249,9 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 			m.playlists = append([]provider.Playlist{}, msg.playlists...)
 			m.playlistsLoaded = true
 			m.showPlaylists()
+		} else {
+			m.pane = paneItems
+			m.list.SetItems(nil)
 		}
 		return m, nil
 	case playlistTracksMsg:
@@ -286,6 +292,7 @@ func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 		switch msg.String() {
 		case "esc", "backspace":
 			m.invalidatePlaylistRequest()
+			m.loadErr = nil
 			m.pane = paneSections
 			m.showSections()
 			return m, nil
@@ -480,6 +487,9 @@ func (m *LibraryModel) View() string {
 	header := m.renderHeader()
 	if m.loading {
 		return header + "\n\n  " + m.spinner.View() + " " + m.loadingText()
+	}
+	if m.loadErr != nil && m.pane != paneSections {
+		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render("Could not load: "+m.loadErr.Error()), m.width)
 	}
 	if len(m.list.Items()) == 0 {
 		return header + "\n\n" + centerLine(styles.QueueItemMuted.Render(m.emptyText()), m.width)


### PR DESCRIPTION
## Summary
- add a documented fallback for Apple library playlist track loading via `?include=tracks`
- surface library load failures in the TUI instead of silently returning to the section list
- improve 401 Apple auth errors with actionable local-build guidance

## Testing
- go test ./...

Closes #49