### PR TITLE
Add top-level library nav and queue hotkey

### DIFF
--- a/internal/player/demo/player.go
+++ b/internal/player/demo/player.go
@@ -260,12 +260,36 @@ func (p *Player) RemoveFromQueue(idx int) error {
 	p.mu.Lock()
 	if idx >= 0 && idx < len(p.queue) {
 		p.queue = append(p.queue[:idx], p.queue[idx+1:]...)
-		if p.idx >= len(p.queue) {
-			p.idx = len(p.queue) - 1
-		}
+		p.syncTrackAfterQueueMutation()
 	}
+	st := p.state
 	p.mu.Unlock()
+	p.broadcast(st)
 	return nil
+}
+
+// syncTrackAfterQueueMutation preserves the invariant that idx and state.Track
+// are valid for queue, or playback is stopped when queue is empty. Must be
+// called with mu held.
+func (p *Player) syncTrackAfterQueueMutation() {
+	if len(p.queue) == 0 {
+		p.idx = 0
+		p.state.Track = nil
+		p.state.Position = 0
+		p.state.Playing = false
+		return
+	}
+	if p.idx >= len(p.queue) {
+		p.idx = len(p.queue) - 1
+	}
+	if p.idx < 0 {
+		p.idx = 0
+	}
+	t := p.queue[p.idx]
+	p.state.Track = &t
+	if p.state.Position > t.Duration {
+		p.state.Position = 0
+	}
 }
 
 func (p *Player) MoveInQueue(from, to int) error {

--- a/internal/player/demo/player_test.go
+++ b/internal/player/demo/player_test.go
@@ -444,6 +444,23 @@ func TestRemoveFromQueue_NegativeIsNoop(t *testing.T) {
 	}
 }
 
+func TestRemoveFromQueue_LastTrackStopsPlayback(t *testing.T) {
+	p := newPlayer(t)
+	if err := p.SetQueue([]string{demodp.Tracks[0].ID}); err != nil {
+		t.Fatalf("SetQueue: %v", err)
+	}
+	if err := p.RemoveFromQueue(0); err != nil {
+		t.Fatalf("RemoveFromQueue: %v", err)
+	}
+	st := state(t, p)
+	if st.Track != nil {
+		t.Fatalf("Track = %+v, want nil", st.Track)
+	}
+	if st.Playing {
+		t.Fatal("Playing = true, want false")
+	}
+}
+
 // --- MoveInQueue ---
 
 func TestMoveInQueue_ValidIndices(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -788,6 +788,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.appendLog(fmt.Sprintf("[search] queued %q (%d tracks)", msg.label, len(ids)))
 		return m, m.playerCmd(func(p player.Player) error { return p.AppendQueue(ids) })
 
+	case views.QueueTracksMsg:
+		if len(msg.Tracks) == 0 || len(msg.IDs) == 0 {
+			break
+		}
+		m.queueTracks = append(m.queueTracks, msg.Tracks...)
+		m.queueIDs = append(m.queueIDs, msg.IDs...)
+		m.queue.SetTracks(m.queueTracks)
+		m.appendLog(fmt.Sprintf("[library] queued %q (%d tracks)", msg.Label, len(msg.IDs)))
+		return m, m.playerCmd(func(p player.Player) error { return p.AppendQueue(msg.IDs) })
+
 	case views.PlayTracksMsg:
 		if msg.Track != nil {
 			m.playerState.Track = msg.Track
@@ -1503,6 +1513,17 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 	// When vibe panel has text-input focus or picker is open, route all keys to it.
 	if m.vibe.IsFocused() || m.vibe.PickerActive() {
 		return m.vibe.Update(msg)
+	}
+
+	if k == "L" {
+		m.library.m.ResetTopLevel()
+		for i, p := range m.panels {
+			if p == m.library {
+				m.activePanel = i
+				m.lastKey = ""
+				return nil
+			}
+		}
 	}
 
 	// Panel nav keys toggle their panel (always checked first).

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -773,6 +773,48 @@ func TestHandleSearchKey_Tab_MultipleTabsAccumulate(t *testing.T) {
 	}
 }
 
+func TestModel_QueueTracksMsg_AppendsWithoutLeavingLibrary(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.activePanel = 0
+	tracks := []provider.Track{{ID: "i.1", Title: "One"}, {ID: "i.2", Title: "Two"}}
+
+	_, cmd := m.Update(views.QueueTracksMsg{IDs: []string{"i.1", "i.2"}, Tracks: tracks, Label: "Artist"})
+	if cmd == nil {
+		t.Fatal("QueueTracksMsg returned nil cmd")
+	}
+	cmd()
+	if len(mp.appendQueueIDs) != 1 || strings.Join(mp.appendQueueIDs[0], ",") != "i.1,i.2" {
+		t.Fatalf("AppendQueue calls = %#v, want [[i.1 i.2]]", mp.appendQueueIDs)
+	}
+	if m.activePanel != 0 {
+		t.Fatalf("activePanel = %d, want library still active", m.activePanel)
+	}
+	if len(m.queueTracks) != 2 {
+		t.Fatalf("queueTracks len = %d, want 2", len(m.queueTracks))
+	}
+}
+
+func TestHandleNormalKey_CapitalLOpensTopLevelLibrary(t *testing.T) {
+	m := newModel(nil)
+	m.activePanel = -1
+	m.library.SetSize(80, 24)
+
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Text: "L"}, "L")
+	if cmd != nil {
+		t.Fatal("capital L should not return a command")
+	}
+	if m.activePanel < 0 || m.panels[m.activePanel] != m.library {
+		t.Fatalf("activePanel = %d, want library", m.activePanel)
+	}
+	view := m.library.View()
+	for _, want := range []string{"Songs", "Albums", "Artists", "Playlists"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("library view missing %q: %q", want, view)
+		}
+	}
+}
+
 func TestHandleSearchKey_Esc_ResetsMode(t *testing.T) {
 	m := newModel(nil)
 	m.mode = modeSearch

--- a/internal/tui/views/library.go
+++ b/internal/tui/views/library.go
@@ -140,6 +140,13 @@ func (m *LibraryModel) Height() int     { return m.height }
 func (m *LibraryModel) DrillErr() error { return m.drillErr }
 func (m *LibraryModel) LoadErr() error  { return m.loadErr }
 
+func (m *LibraryModel) ResetTopLevel() {
+	m.invalidateLibraryRequest()
+	m.invalidatePlaylistRequest()
+	m.pane = paneSections
+	m.showSections()
+}
+
 func (m *LibraryModel) Back() bool {
 	switch m.pane {
 	case paneSections:
@@ -280,6 +287,9 @@ func (m *LibraryModel) Update(msg tea.Msg) (*LibraryModel, tea.Cmd) {
 func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 	switch m.pane {
 	case paneSections:
+		if msg.String() == "tab" {
+			return m, nil
+		}
 		if msg.String() == "enter" {
 			if item, ok := m.list.SelectedItem().(sectionItem); ok {
 				m.selectedSection = item.section
@@ -298,6 +308,8 @@ func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 			return m, nil
 		case "enter":
 			return m.openSelectedItem()
+		case "tab":
+			return m.queueSelectedItem()
 		}
 	case paneTracks:
 		switch msg.String() {
@@ -306,6 +318,8 @@ func (m *LibraryModel) handleKey(msg tea.KeyPressMsg) (*LibraryModel, tea.Cmd) {
 			return m, nil
 		case "enter":
 			return m, m.playTracksFromSelection()
+		case "tab":
+			return m, m.queueTracksFromSelection()
 		}
 	}
 	return m.updateActiveList(msg)
@@ -406,6 +420,27 @@ func (m *LibraryModel) openSelectedItem() (*LibraryModel, tea.Cmd) {
 	return m, nil
 }
 
+func (m *LibraryModel) queueSelectedItem() (*LibraryModel, tea.Cmd) {
+	switch item := m.list.SelectedItem().(type) {
+	case albumItem:
+		return m, queueTracksCmd(item.group.title, item.group.tracks)
+	case artistItem:
+		return m, queueTracksCmd(item.group.title, item.group.tracks)
+	case playlistItem:
+		pl := provider.Playlist(item)
+		m.drillPlaylist = pl
+		m.drillTitle = pl.Name
+		m.pane = paneTracks
+		m.tracksBackPane = paneItems
+		m.drillTracks = nil
+		m.drillErr = nil
+		m.drillList.SetItems(nil)
+		return m, tea.Batch(m.spinner.Tick, m.loadPlaylistTracks(pl))
+	default:
+		return m, nil
+	}
+}
+
 func (m *LibraryModel) playTracksFromSelection() tea.Cmd {
 	if selected := m.drillList.SelectedItem(); selected == nil {
 		return nil
@@ -422,6 +457,32 @@ func (m *LibraryModel) playTracksFromSelection() tea.Cmd {
 	first := allTracks[0]
 	tracks := append([]provider.Track{}, allTracks...)
 	return func() tea.Msg { return PlayTracksMsg{IDs: ids, Tracks: tracks, Track: &first} }
+}
+
+func (m *LibraryModel) queueTracksFromSelection() tea.Cmd {
+	if selected := m.drillList.SelectedItem(); selected == nil {
+		return nil
+	}
+	idx := m.drillList.Index()
+	if idx < 0 || idx >= len(m.drillTracks) {
+		return nil
+	}
+	if m.tracksBackPane == paneSections && m.drillTitle == "Songs" {
+		return queueTracksCmd(m.drillTracks[idx].Title, m.drillTracks[idx:idx+1])
+	}
+	return queueTracksCmd(m.drillTitle, m.drillTracks[idx:])
+}
+
+func queueTracksCmd(label string, tracks []provider.Track) tea.Cmd {
+	if len(tracks) == 0 {
+		return nil
+	}
+	queued := append([]provider.Track{}, tracks...)
+	ids := make([]string, len(queued))
+	for i, track := range queued {
+		ids[i] = PlaybackID(track)
+	}
+	return func() tea.Msg { return QueueTracksMsg{IDs: ids, Tracks: queued, Label: label} }
 }
 
 func (m *LibraryModel) showSections() {
@@ -502,7 +563,7 @@ func (m *LibraryModel) renderDrillView() string {
 	if m.drillTitle == "" {
 		name = styles.SidebarActive.Render("Tracks")
 	}
-	hint := styles.QueueItemMuted.Render("  ←/h/esc back · enter play")
+	hint := styles.QueueItemMuted.Render("  ←/h/esc back · enter play · tab queue")
 	header := name + hint + "\n" + lipgloss.NewStyle().Foreground(styles.ColorMuted).Render(strings.Repeat("─", m.width))
 	if m.drillLoading {
 		return header + "\n\n  " + m.spinner.View() + " Loading tracks…"

--- a/internal/tui/views/library_behavior_test.go
+++ b/internal/tui/views/library_behavior_test.go
@@ -73,6 +73,56 @@ func TestLibrary_ArtistsSectionGroupsSongsAndPlaysArtistTracks(t *testing.T) {
 	assertPlayTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks[:2])
 }
 
+func TestLibrary_AlbumsSectionTabQueuesAlbumTracksWithoutLeavingMenu(t *testing.T) {
+	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A", Album: "Alpha"}, {ID: "i.2", Title: "Two", Artist: "A", Album: "Alpha"}}
+	lib := NewLibrary(&mockProvider{libraryTracks: tracks})
+	lib.SetSize(80, 24)
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: lib.libraryRequestGeneration, section: lib.libraryRequestSection, kind: lib.libraryRequestKind, tracks: tracks})
+
+	updated, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if updated.pane != paneItems {
+		t.Fatalf("pane = %v, want paneItems", updated.pane)
+	}
+	assertQueueTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks)
+}
+
+func TestLibrary_SongsSectionTabQueuesSelectedSongWithoutLeavingMenu(t *testing.T) {
+	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A"}, {ID: "i.2", Title: "Two", Artist: "B"}}
+	lib := NewLibrary(&mockProvider{libraryTracks: tracks})
+	lib.SetSize(80, 24)
+	lib, _ = lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	lib, _ = lib.Update(libraryTracksLoadedMsg{generation: lib.libraryRequestGeneration, section: lib.libraryRequestSection, kind: lib.libraryRequestKind, tracks: tracks})
+
+	updated, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if updated.pane != paneTracks {
+		t.Fatalf("pane = %v, want paneTracks", updated.pane)
+	}
+	assertQueueTracksMsg(t, cmd, []string{"i.1"}, tracks[:1])
+}
+
+func TestLibrary_ResetTopLevelShowsSections(t *testing.T) {
+	lib := NewLibrary(&mockProvider{})
+	lib.showGroups([]trackGroup{{title: "Artist", desc: "1 track"}})
+	lib.ResetTopLevel()
+	if lib.pane != paneSections {
+		t.Fatalf("pane = %v, want paneSections", lib.pane)
+	}
+	if len(lib.list.Items()) != 4 {
+		t.Fatalf("section item count = %d, want 4", len(lib.list.Items()))
+	}
+	for i, want := range []string{"Songs", "Albums", "Artists", "Playlists"} {
+		item, ok := lib.list.Items()[i].(sectionItem)
+		if !ok {
+			t.Fatalf("item %d = %T, want sectionItem", i, lib.list.Items()[i])
+		}
+		if item.Title() != want {
+			t.Fatalf("item %d title = %q, want %q", i, item.Title(), want)
+		}
+	}
+}
+
 func TestLibrary_PlaylistsSectionLoadsPlaylistThenPlaysTracks(t *testing.T) {
 	playlists := []provider.Playlist{{ID: "p.1", Name: "Mix", TrackCount: 2}}
 	tracks := []provider.Track{{ID: "i.1", Title: "One", Artist: "A"}, {ID: "i.2", Title: "Two", Artist: "B"}}
@@ -93,6 +143,23 @@ func TestLibrary_PlaylistsSectionLoadsPlaylistThenPlaysTracks(t *testing.T) {
 	}
 	_, cmd := lib.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	assertPlayTracksMsg(t, cmd, []string{"i.1", "i.2"}, tracks)
+}
+
+func assertQueueTracksMsg(t *testing.T, cmd tea.Cmd, ids []string, tracks []provider.Track) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected queue command")
+	}
+	msg, ok := cmd().(QueueTracksMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want QueueTracksMsg", cmd())
+	}
+	if strings.Join(msg.IDs, ",") != strings.Join(ids, ",") {
+		t.Fatalf("IDs = %#v, want %#v", msg.IDs, ids)
+	}
+	if len(msg.Tracks) != len(tracks) {
+		t.Fatalf("Tracks len = %d, want %d", len(msg.Tracks), len(tracks))
+	}
 }
 
 func assertPlayTracksMsg(t *testing.T, cmd tea.Cmd, ids []string, tracks []provider.Track) {

--- a/internal/tui/views/search.go
+++ b/internal/tui/views/search.go
@@ -26,6 +26,14 @@ type PlayTracksMsg struct {
 	StartIdx   int              // start position within the playlist
 }
 
+// QueueTracksMsg is emitted when the user appends library tracks without
+// interrupting playback.
+type QueueTracksMsg struct {
+	IDs    []string
+	Tracks []provider.Track
+	Label  string
+}
+
 // PlaybackID returns the best ID to use for MusicKit queue descriptors.
 // Library tracks (IDs prefixed with "i.") must use their library ID directly
 // so MusicKit never encounters a CONTENT_RESTRICTED error — the catalog copy


### PR DESCRIPTION
## Summary
- Add capital L to open Library at the top-level sections menu
- Add Tab queueing inside library nav for songs, albums, and artists without leaving the menu
- Fix demo player queue removal state when removing the final track

## Test plan
- go test ./internal/player/demo -run TestRemoveFromQueue_LastTrackStopsPlayback -count=1
- go test ./...