### PR TITLE
ci: fix dev build PKG_CONFIG_PATH for webkit2gtk shim

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           APPLE_DEV_TOKEN: ${{ steps.devtoken.outputs.token }}
           CGO_ENABLED: "1"
-          PROJECT_DIR: ${{ github.workspace }}
+          PKG_CONFIG_PATH: ${{ github.workspace }}/pkg-config
           GOTOOLCHAIN: local
         run: |
           go build -o vibez \


### PR DESCRIPTION
The dev build workflow was missing `PKG_CONFIG_PATH` pointing to the repo's `pkg-config/` shim directory, causing `webkit2gtk-4.0` not found errors on Ubuntu runners that only have 4.1 installed.