### PR TITLE
fix: handle empty library 404 response on Apple Music tracks/playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation for keyboard shortcuts** — documented `Tab` (add to queue), `Shift+Tab` (play next), and `Shift+Up/Down` (move in queue) shortcuts in the README and inline TUI help hints.
 
 ### Fixed
+- **Empty library 404 error handling** — Handle `404 Not Found` API errors gracefully when fetching tracks or playlists from an empty Apple Music library (or when opening Favorites), returning empty collections instead of failing.
 - **Equalizer key conflicts** — Intercept equalizer-specific key presses (arrow keys, `h`/`j`/`k`/`l`, `0`, `r`) when the equalizer panel is open, resolving a conflict where arrow keys would seek playback and `r` would toggle repeat mode. Closes #64.
 
 ---

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -511,6 +511,9 @@ func (a *AppleProvider) GetLibraryTracks(ctx context.Context) ([]provider.Track,
 		}
 		var page paginatedSongs
 		if err := a.do(req, &page); err != nil {
+			if strings.Contains(err.Error(), "404 Not Found") {
+				return nil, nil
+			}
 			return nil, err
 		}
 		for _, s := range page.Data {
@@ -532,6 +535,9 @@ func (a *AppleProvider) GetLibraryPlaylists(ctx context.Context) ([]provider.Pla
 		}
 		var page paginatedPlaylists
 		if err := a.do(req, &page); err != nil {
+			if strings.Contains(err.Error(), "404 Not Found") {
+				break
+			}
 			return nil, err
 		}
 		for _, r := range page.Data {

--- a/internal/provider/apple/apple_test.go
+++ b/internal/provider/apple/apple_test.go
@@ -621,6 +621,38 @@ func TestGetLibraryTracks_HTTPError(t *testing.T) {
 	}
 }
 
+func TestGetLibraryTracks_EmptyLibrary404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code":404,"message":"HTTP 404 Not Found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	tracks, err := p.GetLibraryTracks(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error on 404 Not Found, got: %v", err)
+	}
+	if len(tracks) != 0 {
+		t.Errorf("expected 0 tracks, got %d", len(tracks))
+	}
+}
+
+func TestGetLibraryPlaylists_EmptyLibrary404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code":404,"message":"HTTP 404 Not Found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	playlists, err := p.GetLibraryPlaylists(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error on 404 Not Found, got: %v", err)
+	}
+	if len(playlists) != 1 || playlists[0].ID != "vibez:favorites" {
+		t.Errorf("expected exactly 1 playlist (Favorites), got: %+v", playlists)
+	}
+}
+
 func TestGetLibraryPlaylists_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)


### PR DESCRIPTION
Handles empty library collections gracefully when loading tracks or playlists.