### PR TITLE
fix: enable macOS Google Chrome Widevine DRM playback by removing --disable-component-update flag

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -64,16 +64,53 @@ jobs:
           PKG_CONFIG_PATH: ${{ github.workspace }}/pkg-config
           GOTOOLCHAIN: local
         run: |
-          go build -o vibez \
+          go build -o vibez-linux-amd64 \
             -ldflags "-s -w -X 'github.com/simone-vibes/vibez/internal/version.Version=dev-pr${{ inputs.pr_number }}-$(echo ${{ steps.pr.outputs.sha }} | cut -c1-7)' -X 'github.com/simone-vibes/vibez/internal/auth.devToken=${{ env.APPLE_DEV_TOKEN }}'" \
             .
 
-      - name: Upload artifact
-        id: upload
+      - name: Build (darwin/amd64)
+        env:
+          APPLE_DEV_TOKEN: ${{ steps.devtoken.outputs.token }}
+          CGO_ENABLED: "0"
+          GOTOOLCHAIN: local
+          GOOS: darwin
+          GOARCH: amd64
+        run: |
+          go build -o vibez-darwin-amd64 \
+            -ldflags "-s -w -X 'github.com/simone-vibes/vibez/internal/version.Version=dev-pr${{ inputs.pr_number }}-$(echo ${{ steps.pr.outputs.sha }} | cut -c1-7)' -X 'github.com/simone-vibes/vibez/internal/auth.devToken=${{ env.APPLE_DEV_TOKEN }}'" \
+            .
+
+      - name: Build (darwin/arm64)
+        env:
+          APPLE_DEV_TOKEN: ${{ steps.devtoken.outputs.token }}
+          CGO_ENABLED: "0"
+          GOTOOLCHAIN: local
+          GOOS: darwin
+          GOARCH: arm64
+        run: |
+          go build -o vibez-darwin-arm64 \
+            -ldflags "-s -w -X 'github.com/simone-vibes/vibez/internal/version.Version=dev-pr${{ inputs.pr_number }}-$(echo ${{ steps.pr.outputs.sha }} | cut -c1-7)' -X 'github.com/simone-vibes/vibez/internal/auth.devToken=${{ env.APPLE_DEV_TOKEN }}'" \
+            .
+
+      - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
           name: vibez-dev-pr${{ inputs.pr_number }}-linux-amd64
-          path: vibez
+          path: vibez-linux-amd64
+          retention-days: 14
+
+      - name: Upload Darwin AMD64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibez-dev-pr${{ inputs.pr_number }}-darwin-amd64
+          path: vibez-darwin-amd64
+          retention-days: 14
+
+      - name: Upload Darwin ARM64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibez-dev-pr${{ inputs.pr_number }}-darwin-arm64
+          path: vibez-darwin-arm64
           retention-days: 14
 
       - name: Comment on PR
@@ -81,8 +118,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh pr comment ${{ inputs.pr_number }} --body "🎵 **Dev build ready** — [\`dev-pr${{ inputs.pr_number }}-$(echo ${{ steps.pr.outputs.sha }} | cut -c1-7)\`]($RUN_URL)
+          gh pr comment ${{ inputs.pr_number }} --body "🎵 **Dev builds ready** — [\`dev-pr${{ inputs.pr_number }}-$(echo ${{ steps.pr.outputs.sha }} | cut -c1-7)\`]($RUN_URL)
 
-          **Download:** Go to the [workflow run]($RUN_URL) → Artifacts → \`vibez-dev-pr${{ inputs.pr_number }}-linux-amd64\`
+          **Download:** Go to the [workflow run]($RUN_URL) → Artifacts:
+          - \`vibez-dev-pr${{ inputs.pr_number }}-linux-amd64\`
+          - \`vibez-dev-pr${{ inputs.pr_number }}-darwin-amd64\`
+          - \`vibez-dev-pr${{ inputs.pr_number }}-darwin-arm64\` (for Apple Silicon Macs)
 
           <sub>Built from ${{ steps.pr.outputs.sha }} • expires in 14 days</sub>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation for keyboard shortcuts** — documented `Tab` (add to queue), `Shift+Tab` (play next), and `Shift+Up/Down` (move in queue) shortcuts in the README and inline TUI help hints.
 
 ### Fixed
+- **macOS Apple Music playback** — Enable Google Chrome component updates on macOS by removing the `--disable-component-update` launch flag, allowing Chrome to correctly load and initialize the Widevine Content Decryption Module (CDM) for DRM playback. Closes #54.
 - **Empty library 404 error handling** — Handle `404 Not Found` API errors gracefully when fetching tracks or playlists from an empty Apple Music library (or when opening Favorites), returning empty collections instead of failing.
 - **Equalizer key conflicts** — Intercept equalizer-specific key presses (arrow keys, `h`/`j`/`k`/`l`, `0`, `r`) when the equalizer panel is open, resolving a conflict where arrow keys would seek playback and `r` would toggle repeat mode. Closes #64.
 

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -112,7 +112,6 @@ func chromeLaunchArgs(_ bool) []string {
 		"--autoplay-policy=no-user-gesture-required",
 		"--enable-features=MediaCapabilities,WidevineCdm",
 		"--disable-blink-features=AutomationControlled",
-		"--disable-component-update",
 		"--disable-background-networking",
 		"--js-flags=--max-old-space-size=256",
 	}

--- a/internal/player/cdp/browser_darwin_test.go
+++ b/internal/player/cdp/browser_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -63,11 +64,9 @@ func TestFindChromePathRejectsMissingOverride(t *testing.T) {
 
 func TestChromeLaunchArgsDoNotUseLinuxOnlyOrUnsafeFlags(t *testing.T) {
 	args := chromeLaunchArgs(false)
-	for _, forbidden := range []string{"--no-sandbox", "--disable-setuid-sandbox", "--no-zygote", "--single-process", "--ignore-certificate-errors"} {
-		for _, arg := range args {
-			if arg == forbidden {
-				t.Fatalf("chromeLaunchArgs contains forbidden flag %q", forbidden)
-			}
+	for _, forbidden := range []string{"--no-sandbox", "--disable-setuid-sandbox", "--no-zygote", "--single-process", "--ignore-certificate-errors", "--disable-component-update"} {
+		if slices.Contains(args, forbidden) {
+			t.Fatalf("chromeLaunchArgs contains forbidden flag %q", forbidden)
 		}
 	}
 }

--- a/internal/player/cdp/browser_test.go
+++ b/internal/player/cdp/browser_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -327,5 +328,12 @@ func TestExtractDeb_TruncatedArHeader(t *testing.T) {
 	// extractDeb should return an error (missing data.tar.*), not panic.
 	if err := extractDeb(path, t.TempDir()); err == nil {
 		t.Error("expected error for truncated ar, got nil")
+	}
+}
+
+func TestChromeLaunchArgs_HasDisableComponentUpdate(t *testing.T) {
+	args := chromeLaunchArgs(false)
+	if !slices.Contains(args, "--disable-component-update") {
+		t.Error("chromeLaunchArgs does not contain --disable-component-update, which is expected on Linux for network isolation")
 	}
 }


### PR DESCRIPTION
Enables macOS Google Chrome to correctly load and initialize the Widevine CDM component for DRM playback.