### PR TITLE
fix: emit MPRIS Seeked signal so clients resync after a seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Double path duplication in pagination** — Trim duplicate `/v1` prefix from relative endpoint paths during pagination to prevent double `/v1/v1/` routing errors (which caused pagination loops to stop early at exactly 100 tracks).
 - **Graceful timeout/cancellation handling** — Return already-accumulated tracks when a pagination query times out or is cancelled, and display a clean `"request timed out"` error message instead of raw HTTP logs.
 - **Localized Favorites suppression** — Suppress synthetic Favorites playlist generation when localized favorites playlists (e.g. Italian `"Brani preferiti"`, `"Preferiti"`, French `"Morceaux préférés"`, Spanish `"Canciones favoritas"`, Portuguese `"Músicas favoritas"`, or custom `"Favorite/Starred Songs"`, etc.) are already present in the library. Closes #74.
+- **MPRIS `Seeked` signal:** Emit `org.mpris.MediaPlayer2.Player.Seeked` when the playback position jumps within a track, so external MPRIS clients (media panels, presence daemons) resync immediately after a seek instead of drifting on a stale, extrapolated position.
 
 ## [0.3.1] — 2026-07-07
 

--- a/internal/player/mpris/server.go
+++ b/internal/player/mpris/server.go
@@ -53,6 +53,8 @@ type Server struct {
 	pos         time.Duration
 	lastStatus  string
 	lastTrackID string
+	lastPos     time.Duration // position at the previous flush, for seek detection
+	lastPosAt   time.Time     // wall-clock time lastPos was sampled
 	debounce    *time.Timer
 	pending     *player.State
 }
@@ -248,6 +250,31 @@ func (s *Server) Update(st player.State) {
 	s.mu.Unlock()
 }
 
+// seekThreshold is the position jump beyond which a change is treated as a
+// deliberate seek rather than normal playback drift or timing jitter. Position
+// updates arrive roughly once per second and vibez seeks in ±10s steps, so this
+// sits safely between the two.
+const seekThreshold = 2 * time.Second
+
+// isSeek reports whether newPos is a discontinuous jump away from where
+// uninterrupted playback would have reached: lastPos sampled at lastAt, plus
+// the elapsed wall-clock time when playback was advancing. With no prior sample
+// (zero lastAt) it is never a seek.
+func isSeek(playing bool, lastPos time.Duration, lastAt time.Time, newPos time.Duration, now time.Time) bool {
+	if lastAt.IsZero() {
+		return false
+	}
+	expected := lastPos
+	if playing {
+		expected += now.Sub(lastAt)
+	}
+	delta := newPos - expected
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta > seekThreshold
+}
+
 func (s *Server) flush() {
 	s.mu.Lock()
 	st := s.pending
@@ -268,13 +295,32 @@ func (s *Server) flush() {
 
 	statusChanged := status != s.lastStatus
 	trackChanged := trackID != s.lastTrackID
-	if !statusChanged && !trackChanged {
+
+	// A seek within the current track surfaces only as a position jump; without
+	// a Seeked signal, clients extrapolate from a stale Position and desync.
+	now := time.Now()
+	seeked := !trackChanged && isSeek(s.lastStatus == "Playing", s.lastPos, s.lastPosAt, st.Position, now)
+	s.lastPos = st.Position
+	s.lastPosAt = now
+
+	if !statusChanged && !trackChanged && !seeked {
 		s.mu.Unlock()
 		return
 	}
 	s.lastStatus = status
 	s.lastTrackID = trackID
 	s.mu.Unlock()
+
+	// Per the MPRIS spec, discontinuous position changes are announced via the
+	// Seeked signal (the Position property does not emit PropertiesChanged).
+	// Refresh Position first so a client reading it in response gets the new value.
+	if seeked {
+		s.props.SetMust(mprisPlayerIface, "Position", st.Position.Microseconds())
+		_ = s.conn.Emit(mprisObjectPath, mprisPlayerIface+".Seeked", st.Position.Microseconds())
+		if !statusChanged && !trackChanged {
+			return
+		}
+	}
 
 	meta := map[string]dbus.Variant{
 		"mpris:trackid": dbus.MakeVariant(noTrackPath),

--- a/internal/player/mpris/server_test.go
+++ b/internal/player/mpris/server_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package mpris
+
+import (
+	"testing"
+	"time"
+)
+
+// isSeek distinguishes a deliberate seek from normal playback progression.
+
+func TestIsSeek_NoPriorSample(t *testing.T) {
+	// A zero lastAt means we have never sampled a position yet.
+	if isSeek(true, 0, time.Time{}, 30*time.Second, time.Now()) {
+		t.Error("first sample must never be treated as a seek")
+	}
+}
+
+func TestIsSeek_NormalPlaybackDrift(t *testing.T) {
+	base := time.Now()
+	// One second of playback advances position by ~one second: not a seek.
+	if isSeek(true, 10*time.Second, base, 11*time.Second, base.Add(time.Second)) {
+		t.Error("normal ~1s playback advance should not be a seek")
+	}
+}
+
+func TestIsSeek_ForwardSeekWhilePlaying(t *testing.T) {
+	base := time.Now()
+	// ~1s elapsed but position jumped +10s: a forward seek.
+	if !isSeek(true, 10*time.Second, base, 21*time.Second, base.Add(time.Second)) {
+		t.Error("forward seek while playing not detected")
+	}
+}
+
+func TestIsSeek_BackwardSeekWhilePlaying(t *testing.T) {
+	base := time.Now()
+	if !isSeek(true, 60*time.Second, base, 30*time.Second, base.Add(time.Second)) {
+		t.Error("backward seek while playing not detected")
+	}
+}
+
+func TestIsSeek_SeekWhilePaused(t *testing.T) {
+	base := time.Now()
+	// Paused: position should not advance, so any jump is a seek.
+	if !isSeek(false, 10*time.Second, base, 40*time.Second, base.Add(5*time.Second)) {
+		t.Error("seek while paused not detected")
+	}
+}
+
+func TestIsSeek_PausedNoMovement(t *testing.T) {
+	base := time.Now()
+	// Paused with an unchanged position, even after real time passes: not a seek.
+	if isSeek(false, 10*time.Second, base, 10*time.Second, base.Add(5*time.Second)) {
+		t.Error("stationary paused position should not be a seek")
+	}
+}
+
+func TestIsSeek_SubThresholdJitter(t *testing.T) {
+	base := time.Now()
+	// A sub-threshold discrepancy (timing jitter) is not a seek.
+	if isSeek(true, 10*time.Second, base, 11500*time.Millisecond, base.Add(time.Second)) {
+		t.Error("sub-threshold jitter should not be a seek")
+	}
+}


### PR DESCRIPTION
vibez's MPRIS server never emits `org.mpris.MediaPlayer2.Player.Seeked` and only writes `Position` on track/status changes. Per the MPRIS spec, clients resync position only on `Seeked`, so seeking within a track leaves external clients drifting on a stale position until the next track.

`flush()` now detects a position jump within the current track and emits `Seeked` with the new position. The check is a small pure helper (`isSeek`) with unit tests, and the 2s threshold sits between the ~1s update cadence and vibez's ±10s seek step.

I kept this inside the MPRIS server by inferring the seek from a position discontinuity. If you'd rather have the engine signal seeks explicitly, I'm glad to rework it.

Verified locally (cgo build with the repo's pkg-config shim): `go build`, `go vet`, and `go test ./...` all pass including the new tests; gofmt clean, `go mod tidy` a no-op.
