### PR TITLE
fix: validate playwright driver version in cache and update if outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Queue resolution limits** — Batch track resolution requests in parallel blocks of 100 to support playing large lists/queues (like library Songs and large Favorites list) without hitting Apple Music's 300 IDs batch query limit.
+- **Playwright driver upgrade validation** — Ensure the Playwright driver in the local cache is always verified and updated when the dependency version changes, even if Chrome is already cached/installed.
 - **Double path duplication in pagination** — Trim duplicate `/v1` prefix from relative endpoint paths during pagination to prevent double `/v1/v1/` routing errors (which caused pagination loops to stop early at exactly 100 tracks).
 - **Graceful timeout/cancellation handling** — Return already-accumulated tracks when a pagination query times out or is cancelled, and display a clean `"request timed out"` error message instead of raw HTTP logs.
 - **Localized Favorites suppression** — Suppress synthetic Favorites playlist generation when localized favorites playlists (e.g. Italian `"Brani preferiti"`, `"Preferiti"`, French `"Morceaux préférés"`, Spanish `"Canciones favoritas"`, Portuguese `"Músicas favoritas"`, or custom `"Favorite/Starred Songs"`, etc.) are already present in the library. Closes #74.

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -11,6 +11,7 @@
 package cdp
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -64,10 +65,37 @@ func linkHelper() {
 // cache directory if not already present. Never calls apt-get or sudo.
 // onProgress is called with human-readable status strings (e.g. "Downloading
 // Chrome… 42%", "Extracting Chrome…"). Pass func(string){} to silence.
+func isDriverUpToDate() bool {
+	driver, err := playwright.NewDriver(&playwright.RunOptions{
+		DriverDirectory: driverDir(),
+	})
+	if err != nil {
+		return false
+	}
+	pkgJSONPath := filepath.Join(driverDir(), "package", "package.json")
+	data, err := os.ReadFile(pkgJSONPath) //nolint:gosec // path constructed from cache dir
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	return pkg.Version == driver.Version
+}
+
 func EnsureBrowser(onProgress func(string)) error {
+	driverUpToDate := isDriverUpToDate()
+	chromeInstalled := false
 	if _, err := os.Stat(ChromePath()); err == nil {
-		linkHelper() // idempotent — creates vibez-helper link if absent
-		return nil   // already installed
+		chromeInstalled = true
+	}
+
+	if driverUpToDate && chromeInstalled {
+		linkHelper()
+		return nil
 	}
 
 	// Also ensure the playwright driver is available (no browser install via playwright).
@@ -78,6 +106,11 @@ func EnsureBrowser(onProgress func(string)) error {
 		SkipInstallBrowsers: true,
 	}); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
+	}
+
+	if chromeInstalled {
+		linkHelper()
+		return nil
 	}
 
 	debPath := filepath.Join(baseDir(), "chrome.deb")

--- a/internal/player/cdp/browser_test.go
+++ b/internal/player/cdp/browser_test.go
@@ -12,6 +12,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	playwright "github.com/playwright-community/playwright-go"
 )
 
 // buildAr writes a minimal ar(1) archive from an ordered list of (name, data)
@@ -305,8 +307,24 @@ func TestEnsureBrowser_AlreadyInstalled(t *testing.T) {
 		t.Fatalf("write chrome: %v", err)
 	}
 
+	// Mock the playwright driver as also already installed and up-to-date.
+	driver, err := playwright.NewDriver(&playwright.RunOptions{
+		DriverDirectory: driverDir(),
+	})
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	pkgDir := filepath.Join(driverDir(), "package")
+	if err := os.MkdirAll(pkgDir, 0o750); err != nil {
+		t.Fatalf("mkdir driver package: %v", err)
+	}
+	pkgJSON := fmt.Sprintf(`{"version": %q}`, driver.Version)
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(pkgJSON), 0o600); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write driver package.json: %v", err)
+	}
+
 	var progress []string
-	err := EnsureBrowser(func(s string) { progress = append(progress, s) })
+	err = EnsureBrowser(func(s string) { progress = append(progress, s) })
 	if err != nil {
 		t.Errorf("EnsureBrowser when already installed should return nil, got: %v", err)
 	}


### PR DESCRIPTION
This PR fixes a bug in EnsureBrowser where the cached Playwright driver version was never validated. If Google Chrome was already installed/cached, EnsureBrowser exited early without calling playwright.Install, leaving any outdated playwright driver in the cache (which causes failures or 404s when playwright-go is upgraded in go.mod). This PR introduces isDriverUpToDate() to check package.json inside the driver directory and matches it against the required version, ensuring it updates the driver when needed.