### PR TITLE
feat(tui): render album art in the now-playing panel (closes #33)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/lipgloss/v2 v2.0.3
+	github.com/charmbracelet/colorprofile v0.4.3
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/playwright-community/playwright-go v0.6000.0
@@ -15,9 +17,7 @@ require (
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/playwright-community/playwright-go v0.6000.0
 	github.com/spf13/cobra v1.10.2
 	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
+	golang.org/x/sys v0.43.0
 )
 
 require (
@@ -35,5 +36,4 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// WSL enables audio tuning workarounds for WSL2 environments where Hyper-V
 	// scheduler jitter causes audio underruns with default Chrome buffer sizes.
 	WSL bool `json:"wsl,omitempty"`
+	// AlbumArt toggles the half-block album artwork shown in the now-playing
+	// panel. Absent (nil) means enabled; set it to false to hide the artwork.
+	AlbumArt *bool `json:"album_art,omitempty"`
 }
 
 type EQBand struct {
@@ -52,6 +55,12 @@ func (c *Config) VolumeOrDefault() float64 {
 // SetVolume updates the in-memory volume field. Call Save to persist it.
 func (c *Config) SetVolume(v float64) {
 	c.Volume = &v
+}
+
+// AlbumArtEnabled reports whether the now-playing panel should render album
+// artwork. It defaults to true when the config field is unset.
+func (c *Config) AlbumArtEnabled() bool {
+	return c.AlbumArt == nil || *c.AlbumArt
 }
 
 func defaults() *Config {

--- a/internal/tui/art/art.go
+++ b/internal/tui/art/art.go
@@ -52,13 +52,36 @@ func Render(img image.Image, cols, rows int) []string {
 
 	pxW, pxH := cols, rows*2
 
-	// sample returns the 8-bit RGB of the source pixel nearest to grid cell
-	// (px, py) in the pxW × pxH target grid.
+	// sample returns the average 8-bit RGB of every source pixel that maps to
+	// grid cell (px, py) in the pxW × pxH target grid. Area-averaging (a box
+	// filter) is what keeps a heavily downscaled cover smooth and recognisable;
+	// picking a single nearest pixel per cell instead produces a harsh, aliased
+	// result at this size.
 	sample := func(px, py int) (uint8, uint8, uint8) {
-		sx := b.Min.X + px*srcW/pxW
-		sy := b.Min.Y + py*srcH/pxH
-		r, g, bl, _ := img.At(sx, sy).RGBA()
-		return uint8(r >> 8), uint8(g >> 8), uint8(bl >> 8) //nolint:gosec // 16-bit → 8-bit
+		x0 := b.Min.X + px*srcW/pxW
+		x1 := b.Min.X + (px+1)*srcW/pxW
+		y0 := b.Min.Y + py*srcH/pxH
+		y1 := b.Min.Y + (py+1)*srcH/pxH
+		if x1 <= x0 {
+			x1 = x0 + 1
+		}
+		if y1 <= y0 {
+			y1 = y0 + 1
+		}
+		var rs, gs, bs, n uint64
+		for y := y0; y < y1; y++ {
+			for x := x0; x < x1; x++ {
+				r, g, bl, _ := img.At(x, y).RGBA()
+				rs += uint64(r >> 8)
+				gs += uint64(g >> 8)
+				bs += uint64(bl >> 8)
+				n++
+			}
+		}
+		if n == 0 {
+			n = 1
+		}
+		return uint8(rs / n), uint8(gs / n), uint8(bs / n) //nolint:gosec // averaged 8-bit channels
 	}
 
 	lines := make([]string, rows)

--- a/internal/tui/art/art.go
+++ b/internal/tui/art/art.go
@@ -1,0 +1,83 @@
+// Package art renders album artwork as coloured Unicode half-block art for the
+// now-playing panel.
+//
+// Each character cell is drawn as an upper-half block "▀" whose foreground
+// colour is the top pixel and whose background colour is the bottom pixel, so a
+// single cell encodes two vertically-stacked image pixels. Because a typical
+// terminal cell is about twice as tall as it is wide, this yields roughly
+// square pixels — a square cover looks square when rendered with cols == rows*2.
+package art
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+
+	// Register the decoders for the formats Apple Music serves artwork in.
+	_ "image/jpeg"
+	_ "image/png"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// upperHalfBlock fills the top half of a cell; the bottom half shows through as
+// the cell's background colour.
+const upperHalfBlock = "▀"
+
+// Decode decodes JPEG or PNG image bytes into an image.Image.
+func Decode(data []byte) (image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	return img, err
+}
+
+// Render converts img into exactly rows strings, each of visual width cols,
+// drawn with 24-bit colour half-blocks. The image is nearest-neighbour scaled
+// to fill a cols × (rows*2) pixel grid, so callers should size cols/rows to the
+// image's aspect ratio (for a square cover, cols == rows*2).
+//
+// Colours are emitted through lipgloss, so the active renderer down-samples them
+// to the terminal's colour profile automatically. Render returns nil for a nil
+// image or non-positive dimensions.
+func Render(img image.Image, cols, rows int) []string {
+	if img == nil || cols <= 0 || rows <= 0 {
+		return nil
+	}
+
+	b := img.Bounds()
+	srcW, srcH := b.Dx(), b.Dy()
+	if srcW == 0 || srcH == 0 {
+		return nil
+	}
+
+	pxW, pxH := cols, rows*2
+
+	// sample returns the 8-bit RGB of the source pixel nearest to grid cell
+	// (px, py) in the pxW × pxH target grid.
+	sample := func(px, py int) (uint8, uint8, uint8) {
+		sx := b.Min.X + px*srcW/pxW
+		sy := b.Min.Y + py*srcH/pxH
+		r, g, bl, _ := img.At(sx, sy).RGBA()
+		return uint8(r >> 8), uint8(g >> 8), uint8(bl >> 8) //nolint:gosec // 16-bit → 8-bit
+	}
+
+	lines := make([]string, rows)
+	for row := range rows {
+		var sb strings.Builder
+		for col := range cols {
+			tr, tg, tb := sample(col, row*2)   // top pixel → foreground
+			br, bg, bb := sample(col, row*2+1) // bottom pixel → background
+			cell := lipgloss.NewStyle().
+				Foreground(lipgloss.Color(hexColor(tr, tg, tb))).
+				Background(lipgloss.Color(hexColor(br, bg, bb))).
+				Render(upperHalfBlock)
+			sb.WriteString(cell)
+		}
+		lines[row] = sb.String()
+	}
+	return lines
+}
+
+func hexColor(r, g, b uint8) string {
+	return fmt.Sprintf("#%02x%02x%02x", r, g, b)
+}

--- a/internal/tui/art/art.go
+++ b/internal/tui/art/art.go
@@ -32,9 +32,11 @@ func Decode(data []byte) (image.Image, error) {
 }
 
 // Render converts img into exactly rows strings, each of visual width cols,
-// drawn with 24-bit colour half-blocks. The image is nearest-neighbour scaled
-// to fill a cols × (rows*2) pixel grid, so callers should size cols/rows to the
-// image's aspect ratio (for a square cover, cols == rows*2).
+// drawn with 24-bit colour half-blocks. The image is scaled to fill a
+// cols × (rows*2) pixel grid, so callers pick cols/rows to match the image's
+// aspect ratio and the terminal's cell proportions (for a square cover, set
+// cols = round(rows * cellHeight/cellWidth); the source is stretched into the
+// grid and the cell shape stretches it back, netting a square).
 //
 // Colours are emitted through lipgloss, so the active renderer down-samples them
 // to the terminal's colour profile automatically. Render returns nil for a nil

--- a/internal/tui/art/art_test.go
+++ b/internal/tui/art/art_test.go
@@ -1,0 +1,111 @@
+package art
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// makePNG builds a src.png-encoded image of size w×h filled by fn(x, y).
+func makePNG(t *testing.T, w, h int, fn func(x, y int) color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, fn(x, y))
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestDecodeRoundTrip(t *testing.T) {
+	data := makePNG(t, 4, 4, func(_, _ int) color.Color { return color.White })
+	img, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got := img.Bounds().Dx(); got != 4 {
+		t.Fatalf("width = %d, want 4", got)
+	}
+}
+
+func TestDecodeInvalid(t *testing.T) {
+	if _, err := Decode([]byte("not an image")); err == nil {
+		t.Fatal("expected error decoding garbage, got nil")
+	}
+}
+
+func TestRenderDimensions(t *testing.T) {
+	data := makePNG(t, 16, 16, func(x, y int) color.Color {
+		//nolint:gosec // x,y ∈ [0,16) so x*16 ∈ [0,240] — fits in uint8.
+		return color.RGBA{R: uint8(x * 16), G: uint8(y * 16), B: 128, A: 255}
+	})
+	img, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	const cols, rows = 12, 6
+	lines := Render(img, cols, rows)
+	if len(lines) != rows {
+		t.Fatalf("got %d lines, want %d", len(lines), rows)
+	}
+	for i, ln := range lines {
+		if w := lipgloss.Width(ln); w != cols {
+			t.Errorf("line %d visual width = %d, want %d", i, w, cols)
+		}
+		// Stripped of colour, each line is exactly `cols` half-block runes.
+		if stripped := ansi.Strip(ln); stripped != strings.Repeat(upperHalfBlock, cols) {
+			t.Errorf("line %d stripped = %q, want %d half-blocks", i, stripped, cols)
+		}
+	}
+}
+
+func TestRenderGuards(t *testing.T) {
+	data := makePNG(t, 4, 4, func(_, _ int) color.Color { return color.Black })
+	img, _ := Decode(data)
+	if lines := Render(nil, 4, 4); lines != nil {
+		t.Error("Render(nil image) should return nil")
+	}
+	if lines := Render(img, 0, 4); lines != nil {
+		t.Error("Render(cols=0) should return nil")
+	}
+	if lines := Render(img, 4, 0); lines != nil {
+		t.Error("Render(rows=0) should return nil")
+	}
+}
+
+// TestRenderColors checks that the top pixel drives the foreground and the
+// bottom pixel drives the background: a cover split red (top) over blue (bottom)
+// should emit both colours in the single rendered row.
+func TestRenderColors(t *testing.T) {
+	// 2px tall: row 0 red, row 1 blue → one output row.
+	data := makePNG(t, 2, 2, func(_, y int) color.Color {
+		if y == 0 {
+			return color.RGBA{R: 255, A: 255}
+		}
+		return color.RGBA{B: 255, A: 255}
+	})
+	img, _ := Decode(data)
+	lines := Render(img, 2, 1)
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1", len(lines))
+	}
+	// Foreground (top) red = 38;2;255;0;0, background (bottom) blue = 48;2;0;0;255.
+	if !strings.Contains(lines[0], "255;0;0") {
+		t.Errorf("expected red foreground in %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "0;0;255") {
+		t.Errorf("expected blue background in %q", lines[0])
+	}
+}

--- a/internal/tui/cellaspect_other.go
+++ b/internal/tui/cellaspect_other.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin
+
+package tui
+
+// cellAspect returns the conventional cell height/width ratio on platforms
+// without a TIOCGWINSZ query. See the unix build for details.
+func cellAspect() float64 { return 2.0 }

--- a/internal/tui/cellaspect_unix.go
+++ b/internal/tui/cellaspect_unix.go
@@ -1,0 +1,41 @@
+//go:build linux || darwin
+
+package tui
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// cellAspect returns the terminal's cell height/width ratio. Album art is sized
+// to this ratio so a square cover renders as a true square regardless of the
+// font's cell proportions (a wide monospace font like JetBrains Mono has cells
+// noticeably less than twice as tall as wide).
+//
+// It queries the terminal's pixel geometry via TIOCGWINSZ. When that is
+// unavailable — e.g. inside tmux or a terminal that reports zero pixels — it
+// falls back to the conventional 2.0 (cells roughly twice as tall as wide).
+func cellAspect() float64 {
+	const fallback = 2.0
+	//nolint:gosec // a file descriptor fits an int; os.Stdout.Fd is 1.
+	ws, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
+	if err != nil || ws.Xpixel == 0 || ws.Ypixel == 0 || ws.Col == 0 || ws.Row == 0 {
+		return fallback
+	}
+	cw := float64(ws.Xpixel) / float64(ws.Col)
+	ch := float64(ws.Ypixel) / float64(ws.Row)
+	if cw <= 0 || ch <= 0 {
+		return fallback
+	}
+	r := ch / cw
+	// Clamp to a sane range so a bogus report can't distort the layout.
+	switch {
+	case r < 1.5:
+		return 1.5
+	case r > 2.6:
+		return 2.6
+	default:
+		return r
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2838,8 +2838,8 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 	showArt := m.artColorOK && m.cfg.AlbumArtEnabled() && m.artworkImg != nil &&
 		m.artworkURL != "" && t.ArtworkURL == m.artworkURL
 	if showArt {
-		artRows = min(10, h-2) // one-row margin top and bottom
-		artCols = artRows * 2  // square cover: terminal cells are ~2:1 tall:wide
+		artRows = h           // fill the panel height for maximum resolution
+		artCols = artRows * 2 // square cover: terminal cells are ~2:1 tall:wide
 		gap = 2
 		// Shrink to fit: the cover takes at most ~45% of the width and must
 		// leave at least 24 columns for the track info, else we fall back to

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"image"
+	"io"
 	"math/rand"
+	"net/http"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -12,12 +16,15 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/simone-vibes/vibez/internal/audioquality"
 	"github.com/simone-vibes/vibez/internal/config"
 	"github.com/simone-vibes/vibez/internal/lyrics"
 	"github.com/simone-vibes/vibez/internal/openurl"
 	"github.com/simone-vibes/vibez/internal/player"
 	"github.com/simone-vibes/vibez/internal/provider"
+	"github.com/simone-vibes/vibez/internal/tui/art"
 	"github.com/simone-vibes/vibez/internal/tui/styles"
 	"github.com/simone-vibes/vibez/internal/tui/views"
 	"github.com/simone-vibes/vibez/internal/vibe"
@@ -180,6 +187,15 @@ type lyricsResultMsg struct {
 	result  *lyrics.Result
 	err     error
 }
+
+// artworkResultMsg carries a decoded album cover back to the model. url is the
+// ArtworkURL the fetch was issued for, used to discard results that arrive after
+// the user has already skipped to a different track.
+type artworkResultMsg struct {
+	url string
+	img image.Image
+	err error
+}
 type feedResultMsg struct {
 	groups []provider.RecommendationGroup
 	err    error
@@ -274,6 +290,16 @@ type Model struct {
 	// Vibe panel (always visible, right split)
 	vibe *views.VibeModel
 
+	// Album art (now-playing panel). artColorOK is detected once at startup;
+	// artwork is fetched per track and the rendered half-block lines are cached
+	// (keyed by artLinesKey = "url|cols|rows") so they only re-render on a track
+	// change or a resize.
+	artColorOK  bool
+	artworkURL  string      // ArtworkURL of the cover currently loaded/loading
+	artworkImg  image.Image // decoded cover, nil until the fetch completes
+	artLines    []string    // cached rendered half-block lines
+	artLinesKey string      // cache key for artLines
+
 	// Search popup (not a panel)
 	search *views.SearchModel
 
@@ -335,6 +361,9 @@ func New(cfg *config.Config, prov provider.Provider, plyr player.Player, opts Op
 		activePanel:  -1,
 		memProfiling: opts.MemProfiling,
 		preMuteVol:   -1,
+		// Album art needs at least a 256-colour terminal to look reasonable;
+		// on 16-colour/ASCII terminals we skip it (and its download) entirely.
+		artColorOK: colorprofile.Detect(os.Stdout, os.Environ()) >= colorprofile.ANSI256,
 	}
 	if plyr != nil {
 		m.stateCh = plyr.Subscribe()
@@ -544,6 +573,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		// Album art: fetch a fresh cover whenever the artwork URL changes.
+		if m.cfg.AlbumArtEnabled() && m.artColorOK &&
+			s.Track != nil && s.Track.ArtworkURL != "" && s.Track.ArtworkURL != m.artworkURL {
+			m.artworkURL = s.Track.ArtworkURL
+			m.artworkImg = nil
+			m.artLines = nil
+			m.artLinesKey = ""
+			cmds = append(cmds, m.fetchArtworkCmd(s.Track.ArtworkURL))
+		}
 		// Always sync playback position so the current lyrics line stays highlighted.
 		if s.Track != nil {
 			m.lyricsP.m.SetPosition(s.Position)
@@ -587,6 +625,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.appendLog(fmt.Sprintf("[lyrics] not found: %v", msg.err))
 			} else {
 				m.appendLog("[lyrics] loaded")
+			}
+		}
+
+	case artworkResultMsg:
+		// Discard stale covers if the track changed while the fetch was in flight.
+		if msg.url == m.artworkURL {
+			if msg.err != nil {
+				m.appendLog("[artwork] " + msg.err.Error())
+			} else {
+				m.artworkImg = msg.img
+				m.artLines = nil
+				m.artLinesKey = ""
 			}
 		}
 
@@ -1446,6 +1496,39 @@ func (m *Model) fetchLyricsCmd(t *provider.Track) tea.Cmd {
 		defer cancel()
 		res, err := client.Fetch(ctx, artist, title, album, dur)
 		return lyricsResultMsg{trackID: trackID, result: res, err: err}
+	}
+}
+
+// fetchArtworkCmd downloads and decodes the album cover at url asynchronously.
+// The decoded image is returned via artworkResultMsg; failures are reported the
+// same way and surfaced only in the debug log (missing art is not an error the
+// user needs to see).
+func (m *Model) fetchArtworkCmd(url string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return artworkResultMsg{url: url, err: err}
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return artworkResultMsg{url: url, err: err}
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return artworkResultMsg{url: url, err: fmt.Errorf("artwork fetch: HTTP %d", resp.StatusCode)}
+		}
+		// Cap the read at 8 MiB — Apple covers at 300px are well under this.
+		data, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+		if err != nil {
+			return artworkResultMsg{url: url, err: err}
+		}
+		img, err := art.Decode(data)
+		if err != nil {
+			return artworkResultMsg{url: url, err: err}
+		}
+		return artworkResultMsg{url: url, img: img}
 	}
 }
 
@@ -2746,6 +2829,33 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 		return lines
 	}
 
+	// Reserve a left column for the album cover when one is available and the
+	// terminal is wide enough. w is the width remaining for the centred track
+	// info to the right; without art it stays the full content width, so the
+	// no-art layout is unchanged.
+	w := contentW
+	artCols, artRows, gap := 0, 0, 0
+	showArt := m.artColorOK && m.cfg.AlbumArtEnabled() && m.artworkImg != nil &&
+		m.artworkURL != "" && t.ArtworkURL == m.artworkURL
+	if showArt {
+		artRows = min(10, h-2) // one-row margin top and bottom
+		artCols = artRows * 2  // square cover: terminal cells are ~2:1 tall:wide
+		gap = 2
+		// Shrink to fit: the cover takes at most ~45% of the width and must
+		// leave at least 24 columns for the track info, else we fall back to
+		// the plain centred layout.
+		for artRows >= 4 && (artCols > contentW*9/20 || contentW-artCols-gap < 24) {
+			artRows--
+			artCols = artRows * 2
+		}
+		if artRows < 4 || contentW-artCols-gap < 24 {
+			showArt = false
+			artCols, artRows, gap = 0, 0, 0
+		} else {
+			w = contentW - artCols - gap
+		}
+	}
+
 	// Title: bright lavender while playing, softer gray while paused.
 	var titleStr string
 	if m.playerState.Playing || m.playerState.Loading {
@@ -2757,7 +2867,7 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 	// "Artist — Title" — centred
 	trackLine := centerStr(
 		styles.NowPlayingArtist.Render(t.Artist)+muted.Render(" — ")+titleStr,
-		contentW,
+		w,
 	)
 
 	// "Album • elapsed / total" — centred
@@ -2765,12 +2875,12 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 	total := views.FormatDuration(t.Duration)
 	albumLine := centerStr(
 		styles.NowPlayingAlbum.Render(t.Album+" • ")+styles.TimeStyle.Render(elapsed+" / "+total),
-		contentW,
+		w,
 	)
 
 	// Progress bar — centred, slightly narrower than full width
-	barW := max(10, contentW-8)
-	progressLine := centerStr(views.RenderProgressBar(m.playerState.Position, t.Duration, barW), contentW)
+	barW := max(10, w-8)
+	progressLine := centerStr(views.RenderProgressBar(m.playerState.Position, t.Duration, barW), w)
 
 	// Controls: ↺  ⇄  ▶/⏸  ♡/♥
 	var playIcon string
@@ -2810,7 +2920,7 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 			shuffleStyle.Render("⇄")+"   "+
 			playStyle.Render(playIcon)+"   "+
 			heartStyle.Render(heartIcon),
-		contentW,
+		w,
 	)
 
 	// Error / status line — centred, or blank.
@@ -2820,20 +2930,20 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 	if m.errMsg != "" {
 		var rendered string
 		if strings.HasPrefix(m.errMsg, "✓") {
-			text := truncateStr(m.errMsg, max(10, contentW))
-			rendered = centerStr(styles.ControlActive.Render(text), contentW)
+			text := truncateStr(m.errMsg, max(10, w))
+			rendered = centerStr(styles.ControlActive.Render(text), w)
 		} else {
 			const prefix = "⚠  "
-			errText := truncateStr(m.errMsg, max(10, contentW-len([]rune(prefix))))
-			rendered = centerStr(styles.ErrorStyle.Render(prefix+errText), contentW)
+			errText := truncateStr(m.errMsg, max(10, w-len([]rune(prefix))))
+			rendered = centerStr(styles.ErrorStyle.Render(prefix+errText), w)
 		}
 		errLine = rendered
 	}
 
 	lines := []string{
 		"",
-		centerStr(styles.NowPlayingLabel.Render("Now Playing"), contentW),
-		centerStr(muted.Render(strings.Repeat("─", 11)), contentW),
+		centerStr(styles.NowPlayingLabel.Render("Now Playing"), w),
+		centerStr(muted.Render(strings.Repeat("─", 11)), w),
 		trackLine,
 		albumLine,
 		"",
@@ -2848,7 +2958,41 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 	for len(lines) < h {
 		lines = append(lines, "")
 	}
-	return lines[:h]
+	lines = lines[:h]
+
+	if showArt {
+		lines = m.overlayArt(lines, artCols, artRows, gap, h, w)
+	}
+	return lines
+}
+
+// overlayArt prepends the cached album-cover column to each text line. The
+// cover is artCols wide and artRows tall, vertically centred within h rows and
+// separated from the text by gap spaces; each text line is truncated (ANSI-
+// aware) to textW so no composed row can overflow the panel and break the box
+// border. The rendered half-blocks are cached (keyed by URL + dimensions) so
+// they are recomputed only on a track change or a resize. text must already be
+// exactly h lines.
+func (m *Model) overlayArt(text []string, artCols, artRows, gap, h, textW int) []string {
+	key := fmt.Sprintf("%s|%d|%d", m.artworkURL, artCols, artRows)
+	if m.artLinesKey != key || m.artLines == nil {
+		m.artLines = art.Render(m.artworkImg, artCols, artRows)
+		m.artLinesKey = key
+	}
+
+	blank := strings.Repeat(" ", artCols)
+	pad := strings.Repeat(" ", gap)
+	top := max(0, (h-artRows)/2)
+
+	out := make([]string, h)
+	for i := range out {
+		cell := blank
+		if ai := i - top; ai >= 0 && ai < len(m.artLines) {
+			cell = m.artLines[ai]
+		}
+		out[i] = cell + pad + ansi.Truncate(safeIdx(text, i), textW, "…")
+	}
+	return out
 }
 
 // queuePanelLines returns the Queue panel lines for the left split.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"image"
 	"io"
+	"math"
 	"math/rand"
 	"net/http"
 	"os"
@@ -295,6 +296,7 @@ type Model struct {
 	// (keyed by artLinesKey = "url|cols|rows") so they only re-render on a track
 	// change or a resize.
 	artColorOK  bool
+	artCellAsp  float64     // terminal cell height/width ratio, for square art
 	artworkURL  string      // ArtworkURL of the cover currently loaded/loading
 	artworkImg  image.Image // decoded cover, nil until the fetch completes
 	artLines    []string    // cached rendered half-block lines
@@ -364,6 +366,8 @@ func New(cfg *config.Config, prov provider.Provider, plyr player.Player, opts Op
 		// Album art needs at least a 256-colour terminal to look reasonable;
 		// on 16-colour/ASCII terminals we skip it (and its download) entirely.
 		artColorOK: colorprofile.Detect(os.Stdout, os.Environ()) >= colorprofile.ANSI256,
+		// Measured cell height/width ratio, so album art renders as a true square.
+		artCellAsp: cellAspect(),
 	}
 	if plyr != nil {
 		m.stateCh = plyr.Subscribe()
@@ -2838,15 +2842,23 @@ func (m *Model) nowPlayingLines(contentW, h int) []string {
 	showArt := m.artColorOK && m.cfg.AlbumArtEnabled() && m.artworkImg != nil &&
 		m.artworkURL != "" && t.ArtworkURL == m.artworkURL
 	if showArt {
-		artRows = h           // fill the panel height for maximum resolution
-		artCols = artRows * 2 // square cover: terminal cells are ~2:1 tall:wide
+		// artCols is derived from the measured cell aspect (height/width) so a
+		// square cover renders square: physical width artCols*cellW equals
+		// physical height artRows*cellH when artCols = artRows*(cellH/cellW).
+		aspect := m.artCellAsp
+		if aspect <= 0 {
+			aspect = 2.0
+		}
+		artColsFor := func(rows int) int { return int(math.Round(float64(rows) * aspect)) }
+		artRows = h // fill the panel height for maximum resolution
+		artCols = artColsFor(artRows)
 		gap = 2
 		// Shrink to fit: the cover takes at most ~45% of the width and must
 		// leave at least 24 columns for the track info, else we fall back to
 		// the plain centred layout.
 		for artRows >= 4 && (artCols > contentW*9/20 || contentW-artCols-gap < 24) {
 			artRows--
-			artCols = artRows * 2
+			artCols = artColsFor(artRows)
 		}
 		if artRows < 4 || contentW-artCols-gap < 24 {
 			showArt = false

--- a/internal/tui/nowplaying_art_test.go
+++ b/internal/tui/nowplaying_art_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"image"
 	"image/color"
+	"math"
 	"strings"
 	"testing"
 
@@ -102,6 +103,30 @@ func TestNowPlayingLines_NoArtWhenNarrow(t *testing.T) {
 	// Too narrow to fit the cover plus a usable text column.
 	if got := strings.Join(m.nowPlayingLines(30, 12), "\n"); strings.Contains(got, "▀") {
 		t.Error("art should not render when the panel is too narrow")
+	}
+}
+
+// TestNowPlayingLines_ArtWidthMatchesCellAspect verifies the cover column width
+// tracks the measured cell aspect ratio, so the art renders as a true square on
+// terminals whose cells aren't exactly 2:1.
+func TestNowPlayingLines_ArtWidthMatchesCellAspect(t *testing.T) {
+	m := newArtModel(t)
+	m.artCellAsp = 1.7
+	const contentW, h = 96, 12
+	lines := m.nowPlayingLines(contentW, h)
+
+	// The cover fills the panel height (h rows), so its width should be
+	// round(h * aspect) half-block columns at the start of a middle row.
+	want := int(math.Round(float64(h) * 1.7))
+	got := 0
+	for _, r := range ansi.Strip(lines[h/2]) {
+		if r != '▀' {
+			break
+		}
+		got++
+	}
+	if got != want {
+		t.Errorf("art column width = %d, want %d (h=%d, aspect=1.7)", got, want, h)
 	}
 }
 

--- a/internal/tui/nowplaying_art_test.go
+++ b/internal/tui/nowplaying_art_test.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"image"
+	"image/color"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/simone-vibes/vibez/internal/player"
+	"github.com/simone-vibes/vibez/internal/provider"
+)
+
+const testArtURL = "https://example.test/cover/300x300bb.jpg"
+
+// newArtModel returns a model primed to render album art: a decoded four-colour
+// test cover, matching artwork URL, a playing track, and truecolor enabled.
+func newArtModel(t *testing.T) *Model {
+	t.Helper()
+	m := newModel(nil)
+	m.width, m.height = 100, 30
+	m.artColorOK = true
+
+	img := image.NewRGBA(image.Rect(0, 0, 32, 32))
+	for y := range 32 {
+		for x := range 32 {
+			var c color.RGBA
+			switch {
+			case x < 16 && y < 16:
+				c = color.RGBA{R: 255, A: 255}
+			case x >= 16 && y < 16:
+				c = color.RGBA{G: 255, A: 255}
+			case x < 16 && y >= 16:
+				c = color.RGBA{B: 255, A: 255}
+			default:
+				c = color.RGBA{R: 255, G: 255, A: 255}
+			}
+			img.Set(x, y, c)
+		}
+	}
+	m.artworkImg = img
+	m.artworkURL = testArtURL
+	m.playerState = player.State{
+		Playing: true,
+		Track: &provider.Track{
+			Title:      "Test Title",
+			Artist:     "Test Artist",
+			Album:      "Test Album",
+			ArtworkURL: testArtURL,
+		},
+	}
+	return m
+}
+
+func TestNowPlayingLines_RendersArt(t *testing.T) {
+	m := newArtModel(t)
+	const contentW, h = 96, 12
+	lines := m.nowPlayingLines(contentW, h)
+
+	if len(lines) != h {
+		t.Fatalf("got %d lines, want %d", len(lines), h)
+	}
+	// No composed row may exceed the content width, or the box border breaks.
+	for i, ln := range lines {
+		if w := lipgloss.Width(ln); w > contentW {
+			t.Errorf("line %d width %d exceeds contentW %d", i, w, contentW)
+		}
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "▀") {
+		t.Fatal("expected half-block art in now-playing lines")
+	}
+	if !strings.Contains(ansi.Strip(joined), "Test Artist") {
+		t.Error("expected the artist name alongside the art")
+	}
+	// A middle row is within the art band, so it must start with the art column.
+	if mid := ansi.Strip(lines[h/2]); !strings.HasPrefix(mid, "▀") {
+		t.Errorf("expected art column on the left; mid line = %q", mid)
+	}
+}
+
+func TestNowPlayingLines_NoArtWhenDisabled(t *testing.T) {
+	m := newArtModel(t)
+	disabled := false
+	m.cfg.AlbumArt = &disabled
+	if got := strings.Join(m.nowPlayingLines(96, 12), "\n"); strings.Contains(got, "▀") {
+		t.Error("art should not render when AlbumArt is disabled in config")
+	}
+}
+
+func TestNowPlayingLines_NoArtWithoutTrueColor(t *testing.T) {
+	m := newArtModel(t)
+	m.artColorOK = false
+	if got := strings.Join(m.nowPlayingLines(96, 12), "\n"); strings.Contains(got, "▀") {
+		t.Error("art should not render without 256-colour/truecolor support")
+	}
+}
+
+func TestNowPlayingLines_NoArtWhenNarrow(t *testing.T) {
+	m := newArtModel(t)
+	// Too narrow to fit the cover plus a usable text column.
+	if got := strings.Join(m.nowPlayingLines(30, 12), "\n"); strings.Contains(got, "▀") {
+		t.Error("art should not render when the panel is too narrow")
+	}
+}
+
+// TestNowPlayingLines_StaleCoverIgnored verifies the current track's ArtworkURL
+// must match the loaded cover, so a cover left over from the previous track is
+// not shown against a new one.
+func TestNowPlayingLines_StaleCoverIgnored(t *testing.T) {
+	m := newArtModel(t)
+	m.playerState.Track.ArtworkURL = "https://example.test/cover/different.jpg"
+	if got := strings.Join(m.nowPlayingLines(96, 12), "\n"); strings.Contains(got, "▀") {
+		t.Error("art should not render when the loaded cover is for a different track")
+	}
+}


### PR DESCRIPTION
## What

Implements the album art request from #33: the current track's cover now renders as coloured Unicode half-block art on the left of the **Now Playing** panel, with the track info centred to its right.

Each character cell is an upper-half block `▀` whose **foreground is the top pixel** and **background is the bottom pixel**, so one cell encodes two vertically-stacked image pixels. Because a terminal cell is ~twice as tall as it is wide, this yields roughly square pixels — a square cover reads as square when drawn with `cols == rows*2`.

## Why

The now-playing panel was text-only; a cover makes it feel like a real player. This is the enhancement filed in #33.

## How

- **`internal/tui/art`** — a small, pure-Go converter (`Decode` + `Render`) using only stdlib `image/jpeg` + `image/png`. Colours are emitted through `lipgloss`, so the active renderer down-samples them to the terminal's colour profile automatically.
- The cover is fetched **asynchronously** (a `tea.Cmd`) whenever the artwork URL changes; the `ArtworkURL` already present on `player.State.Track` is reused, so no provider changes were needed.
- Rendered half-block lines are **cached** (keyed by URL + dimensions) so they only re-render on a track change or a resize — not every frame.
- Layout **adapts to width** and falls back to the existing centred layout when the panel is too narrow. Text lines are ANSI-aware truncated so a long title can't overflow and break the box border.
- Art (and its download) are **skipped entirely** on terminals without at least 256-colour support, per the graceful-fallback note in the issue.
- New config option **`album_art`** (default `true`) to turn it off.

The no-art code path is unchanged (the width variable simply stays the full content width), so existing behaviour is byte-identical when art isn't shown.

## Tests

- `internal/tui/art`: decode round-trip, invalid input, output dimensions/width, colour mapping (top→fg, bottom→bg), and guard cases.
- `internal/tui`: `nowPlayingLines` renders art on the left with track text on the right, respects the config toggle, skips art without truecolor / when too narrow, and ignores a stale cover whose URL doesn't match the current track.
- Verified the full fetch → decode → render pipeline against a **real Apple Music cover** end-to-end and confirmed the reconstructed output is a faithful cover.
- `go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint` (v2.11.4, matching CI) all pass clean.

Happy to adjust the default cover size, the colour-profile threshold, or the config surface to taste.
