### PR TITLE
fix: upgrade playwright-go to v0.6100.0 to resolve driver CDN 404 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Playwright driver installation (404 error)** — Upgraded `playwright-go` dependency to `v0.6100.0` and migrated the module import path to `github.com/mxschmitt/playwright-go`. This resolves `404 Not Found` errors when fetching the driver because Microsoft deprecated pre-packaged driver zips on the old CDN, switching to npm and Node.js-based assembly. Closes #84.
+
 ## [0.4.1] — 2026-07-08
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/playwright-community/playwright-go v0.6000.0
+	github.com/mxschmitt/playwright-go v0.6100.0
 	github.com/spf13/cobra v1.10.2
 	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3Ry
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/playwright-community/playwright-go v0.6000.0 h1:R7sENcRI6n0Zd5ZoW8EKdVF1ZVJgvTubfJeqKHNGvsw=
-github.com/playwright-community/playwright-go v0.6000.0/go.mod h1:z/YpFVdU4LAi+0f9VPOCkGvmdH6dCrtza9nxnXFXgiE=
+github.com/mxschmitt/playwright-go v0.6100.0 h1:HYNnbGZsTHz8veJyDGe4fU1iPxfvXqzmwKchzuvGCsY=
+github.com/mxschmitt/playwright-go v0.6100.0/go.mod h1:A7VtrS3j/c8ToGnSVUaOfNtQQVxi6JotUS0jeuus6r4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	playwright "github.com/playwright-community/playwright-go"
+	playwright "github.com/mxschmitt/playwright-go"
 )
 
 const chromeDebURL = "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	playwright "github.com/playwright-community/playwright-go"
+	playwright "github.com/mxschmitt/playwright-go"
 )
 
 const chromeInstallHelp = "install Google Chrome from https://www.google.com/chrome/ or set VIBEZ_CHROME_PATH/CHROME_PATH"

--- a/internal/player/cdp/browser_test.go
+++ b/internal/player/cdp/browser_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	playwright "github.com/playwright-community/playwright-go"
+	playwright "github.com/mxschmitt/playwright-go"
 )
 
 // buildAr writes a minimal ar(1) archive from an ordered list of (name, data)

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	playwright "github.com/playwright-community/playwright-go"
+	playwright "github.com/mxschmitt/playwright-go"
 
 	"github.com/simone-vibes/vibez/internal/player"
 	"github.com/simone-vibes/vibez/internal/player/web"


### PR DESCRIPTION
Microsoft/Playwright discontinued hosting pre-packaged standalone driver zip files (such as `playwright-1.60.0-linux.zip`) on their old CDN paths. This caused EnsureBrowser/playwright.Install to fail on startup with a 404 error when fetching the driver.

By upgrading `playwright-go` to `v0.6100.0` (and updating the import paths to `github.com/mxschmitt/playwright-go` as required by the library's name change), the driver is now assembled dynamically by downloading `playwright-core` from the npm registry and Node.js from nodejs.org, resolving the 404 error.

Closes #84