### PR TITLE
feat: add radio mode seeded from any track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Radio mode had no effect mid-album/playlist** — enabling radio while an album or playlist was already queued did nothing until the very last queued track played, since refills only triggered once the current track became the last item in the queue. Radio now drops the rest of the queued album/playlist as soon as it starts, so its picks actually play next.
+- **Dropped album/playlist tracks came right back on refill** — the tracks dropped when radio started were only removed from the queue, not blacklisted, so the very next refill's dedup (which only checks what's still queued) let the station API hand them straight back — since station results are often from the same album/playlist context as the seed. Radio now blacklists dropped tracks so they can't be re-added.
 
 ## [0.4.1] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Radio mode (`R`)** — press `R` on the currently playing track, a selected queue track, or a selected search result to start an Apple Music radio station seeded from it. Related tracks are appended to the queue and playback continues into them; the queue auto-refills as it runs low, and a `📻 radio` badge shows in the now-playing status bar while active. Press `R` again to stop. Closes #32.
+
 ## [0.4.1] — 2026-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Radio mode (`R`)** — press `R` on the currently playing track, a selected queue track, or a selected search result to start an Apple Music radio station seeded from it. Related tracks are appended to the queue and playback continues into them; the queue auto-refills as it runs low, and a `📻 radio` badge shows in the now-playing status bar while active. Press `R` again to stop. Closes #32.
+- **Radio mode (`R`)** — press `R` on the currently playing track, a selected queue track, or a selected search result to start an Apple Music radio station seeded from it. Starting radio drops anything already queued after the seed track so its picks play next, and the queue auto-refills as it runs low; a `📻 radio` badge shows in the now-playing status bar while active. Press `R` again to stop. Closes #32.
+
+### Fixed
+- **Radio mode had no effect mid-album/playlist** — enabling radio while an album or playlist was already queued did nothing until the very last queued track played, since refills only triggered once the current track became the last item in the queue. Radio now drops the rest of the queued album/playlist as soon as it starts, so its picks actually play next.
 
 ## [0.4.1] — 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Full tracks stream via Chrome with Widevine DRM. On Linux amd64, Chrome is auto-
 - **Seed-aware** — the currently playing track is used as the seed; searches adapt progressively from same artist → same genre → completely random as similarity decreases
 - **Toggle anytime** — press `d` again to stop discovery and return to a manual queue
 
+### 📻 Radio Mode
+
+- **Seed a station from any track** — press `R` on the currently playing track, a highlighted queue track, or `ctrl+r` on a search result to start an endless station built around it
+- **Auto-refills like discovery** — vibez queues up new picks from the seed's station as the queue runs low, so the music never stops
+- **Clears the runway** — starting radio drops any tracks still queued after the seed (e.g. the rest of an album or playlist) so the station takes over immediately instead of waiting for them to finish
+- **Toggle anytime** — press `R` again to stop radio and return to a manual queue
+
 ### ⌨️ Terminal UI
 
 - **Fully keyboard-driven** — every action reachable without touching the mouse
@@ -244,6 +251,7 @@ Then set `"theme": "<name>"` in `config.json` and restart vibez.
 | `v` | Open vibe input (mood-driven search) |
 | `e` | Toggle equalizer panel |
 | `d` | Toggle discovery mode |
+| `R` | Toggle radio mode (seeded by the currently playing track) |
 | `/` | Open search |
 | `l` | Toggle library panel |
 | `q` | Toggle queue panel |
@@ -258,6 +266,7 @@ Then set `"theme": "<name>"` in `config.json` and restart vibez.
 | `enter` | Play now |
 | `tab` | Add to queue |
 | `shift+tab` | Play next (insert after current track) |
+| `ctrl+r` | Start radio seeded by the selected track |
 | `esc` | Close |
 
 ### Library (`l`)
@@ -281,6 +290,7 @@ Then set `"theme": "<name>"` in `config.json` and restart vibez.
 | `J` / `shift+down` | Move track down |
 | `c` | Clear entire queue |
 | `s` | Save queue as playlist (opens command prompt) |
+| `R` | Toggle radio mode (seeded by the highlighted track) |
 | `esc` | Close |
 
 ### Command mode (`:`)

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -1159,6 +1159,38 @@ func (a *AppleProvider) AddToPlaylist(ctx context.Context, playlistID, trackID s
 	return a.do(req, nil)
 }
 
+type stationTracksResponse struct {
+	Data []songResource `json:"data"`
+}
+
+// GetStationTracks fetches a batch of tracks for an Apple Music radio
+// station seeded by the given catalog song ID. "ra.<songID>" is Apple's
+// synthetic per-song radio station ID — POSTing to its next-tracks endpoint
+// starts/continues that station without a separately created station
+// resource. Verified against the live API: next-tracks without an ID only
+// accepts GET, and next-tracks/{id} only accepts POST with a body (an empty
+// object is sufficient — the ID alone carries the seed).
+func (a *AppleProvider) GetStationTracks(ctx context.Context, seedCatalogID string) ([]provider.Track, error) {
+	endpoint := "/me/stations/next-tracks/ra." + url.PathEscape(seedCatalogID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+endpoint, strings.NewReader("{}")) //nolint:gosec // G107: URL is constructed from config, not user input
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.cfg.AppleDeveloperToken)
+	req.Header.Set("Music-User-Token", a.cfg.AppleUserToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	var resp stationTracksResponse
+	if err := a.do(req, &resp); err != nil {
+		return nil, fmt.Errorf("GetStationTracks: %w", err)
+	}
+	tracks := make([]provider.Track, 0, len(resp.Data))
+	for _, s := range resp.Data {
+		tracks = append(tracks, toTrack(s))
+	}
+	return tracks, nil
+}
+
 // ratingRequest is the body for PUT /v1/me/ratings/songs/{id}.
 type ratingRequest struct {
 	Type       string           `json:"type"`

--- a/internal/provider/apple/apple_test.go
+++ b/internal/provider/apple/apple_test.go
@@ -3,6 +3,7 @@ package apple_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -1015,6 +1016,55 @@ func TestCreatePlaylist_ServerError(t *testing.T) {
 	_, err := p.CreatePlaylist(context.Background(), "Failing Playlist", []string{})
 	if err == nil {
 		t.Error("CreatePlaylist: expected error for 500 response, got nil")
+	}
+}
+
+// --- GetStationTracks ---
+
+func TestGetStationTracks_Success(t *testing.T) {
+	resp := map[string]any{
+		"data": []any{
+			songJSON("1001", "Related Song", "Related Artist", "Related Album", 200000, ""),
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "stations/next-tracks/ra.500") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if strings.TrimSpace(string(body)) != "{}" {
+			t.Errorf("unexpected request body: %s", body)
+		}
+		writeJSON(t, w, resp)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	tracks, err := p.GetStationTracks(context.Background(), "500")
+	if err != nil {
+		t.Fatalf("GetStationTracks: %v", err)
+	}
+	if len(tracks) != 1 {
+		t.Fatalf("tracks: got %d, want 1", len(tracks))
+	}
+	if tracks[0].ID != "1001" || tracks[0].Title != "Related Song" {
+		t.Errorf("unexpected track: %+v", tracks[0])
+	}
+}
+
+func TestGetStationTracks_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	_, err := p.GetStationTracks(context.Background(), "500")
+	if err == nil {
+		t.Error("GetStationTracks: expected error for 500 response, got nil")
 	}
 }
 

--- a/internal/provider/demo/provider.go
+++ b/internal/provider/demo/provider.go
@@ -119,6 +119,17 @@ func (Provider) GetSongRating(_ context.Context, _ string) (bool, error) { retur
 
 func (Provider) AddToPlaylist(_ context.Context, _, _ string) error { return nil }
 
+func (Provider) GetStationTracks(_ context.Context, seedCatalogID string) ([]provider.Track, error) {
+	out := make([]provider.Track, 0, len(Tracks))
+	for _, t := range Tracks {
+		if t.ID == seedCatalogID || t.CatalogID == seedCatalogID {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
 func (Provider) GetRecommendations(_ context.Context) ([]provider.RecommendationGroup, error) {
 	return []provider.RecommendationGroup{
 		{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -85,6 +85,9 @@ type Provider interface {
 	// GetRecommendations returns personalised recommendation groups (albums and
 	// playlists) from Apple Music based on the user's library and history.
 	GetRecommendations(ctx context.Context) ([]RecommendationGroup, error)
+	// GetStationTracks fetches a batch of tracks for an Apple Music radio
+	// station seeded by the given catalog song ID.
+	GetStationTracks(ctx context.Context, seedCatalogID string) ([]Track, error)
 	// AddToPlaylist adds a track to an existing library playlist.
 	// playlistID must be a library playlist ID (e.g. "p.XXXXX").
 	// trackID should be a catalog song ID or a library song ID ("i.XXXXX").

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1644,7 +1644,40 @@ func (m *Model) startRadioFrom(seed *provider.Track) tea.Cmd {
 	m.radio.triggeredForID = ""
 	m.radio.retries = 0
 	m.appendLog(fmt.Sprintf("[radio] started from %q", seed.Title))
-	return m.runRadioSearch()
+	return tea.Batch(m.dropQueueAfter(seed), m.runRadioSearch())
+}
+
+// dropQueueAfter removes any tracks queued after seed's position so a
+// freshly started radio session plays next, rather than waiting for
+// whatever was already lined up (e.g. the rest of an album) to finish —
+// the last-track refill trigger otherwise never fires until that happens.
+// Tracks up to and including seed are left alone. If seed isn't in the
+// queue at all (e.g. seeded from a search result), this is a no-op.
+func (m *Model) dropQueueAfter(seed *provider.Track) tea.Cmd {
+	seedID := views.PlaybackID(*seed)
+	seedIdx := -1
+	for i, t := range m.queueTracks {
+		if views.PlaybackID(t) == seedID {
+			seedIdx = i
+			break
+		}
+	}
+	origLen := len(m.queueTracks)
+	if seedIdx < 0 || seedIdx == origLen-1 {
+		return nil
+	}
+	m.queueTracks = m.queueTracks[:seedIdx+1]
+	m.queueIDs = m.queueIDs[:seedIdx+1]
+	m.queue.SetTracks(m.queueTracks)
+	m.appendLog(fmt.Sprintf("[radio] dropped %d queued track(s) ahead of the seed", origLen-seedIdx-1))
+	return m.playerCmd(func(p player.Player) error {
+		for i := origLen - 1; i > seedIdx; i-- {
+			if err := p.RemoveFromQueue(i); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // stopRadio disables radio mode and clears its state.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -149,6 +149,7 @@ type vibeResultMsg struct {
 	tracks    []provider.Track
 	err       error
 	discovery bool // true when result is from a discovery auto-refill
+	radio     bool // true when result is from a radio auto-refill
 }
 type loveSongMsg struct {
 	title string
@@ -239,6 +240,23 @@ const (
 	discoverySimilarityStep = 0.1
 )
 
+// ── Radio mode ──────────────────────────────────────────────────────────────
+
+// radioMode holds state for the continuous radio feature: an Apple Music
+// station seeded from a track, auto-refilled as the queue runs low. Mutually
+// exclusive with discoveryMode — starting one stops the other, since both
+// compete for the same last-track refill trigger.
+type radioMode struct {
+	enabled        bool
+	seed           *provider.Track
+	refilling      bool            // background search in progress
+	triggeredForID string          // ID of track for which we already fired a search
+	skipped        map[string]bool // IDs/keys of tracks skipped due to unavailability
+	retries        int             // consecutive failed refill attempts (circuit breaker)
+}
+
+const radioMaxRetries = 5 // give up re-arming after this many consecutive failures
+
 // ── Model ─────────────────────────────────────────────────────────────────
 
 type Model struct {
@@ -256,6 +274,9 @@ type Model struct {
 
 	// Discovery mode
 	discovery discoveryMode
+
+	// Radio mode
+	radio radioMode
 
 	// Panels
 	panels      []ContentView // registered content panels; add new ones in New()
@@ -494,6 +515,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.discovery.skipped = make(map[string]bool)
 			}
 			m.discovery.skipped[skippedID] = true
+			if m.radio.skipped == nil {
+				m.radio.skipped = make(map[string]bool)
+			}
+			m.radio.skipped[skippedID] = true
 			m.purgeSkippedFromQueue()
 			if m.discovery.enabled && !m.discovery.refilling &&
 				m.discovery.retries < discoveryMaxRetries {
@@ -504,6 +529,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, m.runDiscoverySearch())
 			} else if m.discovery.retries >= discoveryMaxRetries {
 				m.appendLog("[discovery] max retries reached — giving up")
+			}
+			if m.radio.enabled && !m.radio.refilling &&
+				m.radio.retries < radioMaxRetries {
+				m.radio.retries++
+				m.radio.triggeredForID = ""
+				m.radio.refilling = true
+				cmds = append(cmds, m.runRadioSearch())
+			} else if m.radio.retries >= radioMaxRetries {
+				m.appendLog("[radio] max retries reached — giving up")
 			}
 		}
 		if s.Track != nil && (m.playerState.Track == nil || m.playerState.Track.Title != s.Track.Title) {
@@ -561,6 +595,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.discovery.refilling = true
 			m.syncDiscoveryView()
 			cmds = append(cmds, m.runDiscoverySearch())
+		}
+		// Radio: same last-track refill trigger as discovery, but always
+		// continuous (no one-shot mode).
+		if m.radio.enabled && !m.radio.refilling &&
+			isLastQueued &&
+			m.radio.triggeredForID != s.Track.ID {
+			m.radio.triggeredForID = s.Track.ID
+			m.radio.refilling = true
+			cmds = append(cmds, m.runRadioSearch())
 		}
 		m.playerState = s
 		if !wasPlaying && m.playerState.Playing {
@@ -658,6 +701,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case vibeResultMsg:
 		if msg.err != nil {
+			if msg.radio {
+				m.appendLog(fmt.Sprintf("[radio] search error: %v", msg.err))
+				m.radio.refilling = false
+				break
+			}
 			if !msg.discovery {
 				m.vibe.SetResult(0, msg.err)
 			}
@@ -668,17 +716,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			break
 		}
-		// For discovery results, drop any track that arrived in the blacklist
-		// while the search was in flight (race between search goroutine and a
-		// concurrent goSkipped notification), and also drop any track already
-		// present in the queue (dedup by ID and artist||title).
+		// For discovery/radio results, drop any track that arrived in the
+		// blacklist while the search was in flight (race between search
+		// goroutine and a concurrent goSkipped notification), and also drop
+		// any track already present in the queue (dedup by ID and
+		// artist||title).
 		tracks := msg.tracks
-		if msg.discovery {
+		if msg.discovery || msg.radio {
+			skipped := m.discovery.skipped
+			if msg.radio {
+				skipped = m.radio.skipped
+			}
 			filtered := tracks[:0]
 			for _, t := range tracks {
 				id := views.PlaybackID(t)
 				key := strings.ToLower(t.Artist + "||" + t.Title)
-				if m.discovery.skipped[id] {
+				if skipped[id] {
 					continue
 				}
 				dup := slices.Contains(m.queueIDs, id)
@@ -697,18 +750,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tracks = filtered
 		}
 		if len(tracks) == 0 {
-			if msg.discovery && m.discovery.retries < discoveryMaxRetries {
+			switch {
+			case msg.discovery && m.discovery.retries < discoveryMaxRetries:
 				m.discovery.retries++
 				m.discovery.refilling = true
 				m.syncDiscoveryView()
 				cmds = append(cmds, m.runDiscoverySearch())
-			} else {
-				if msg.discovery {
-					m.discovery.refilling = false
-					m.syncDiscoveryView()
-				} else {
-					m.vibe.SetResult(0, fmt.Errorf("no streamable results"))
-				}
+			case msg.radio && m.radio.retries < radioMaxRetries:
+				m.radio.retries++
+				m.radio.refilling = true
+				cmds = append(cmds, m.runRadioSearch())
+			case msg.discovery:
+				m.discovery.refilling = false
+				m.syncDiscoveryView()
+			case msg.radio:
+				m.radio.refilling = false
+			default:
+				m.vibe.SetResult(0, fmt.Errorf("no streamable results"))
 			}
 			break
 		}
@@ -718,7 +776,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.player != nil {
 			if err := m.player.AppendQueue(ids); err != nil {
-				if !msg.discovery {
+				if !msg.discovery && !msg.radio {
 					m.vibe.SetResult(0, err)
 				}
 				break
@@ -727,7 +785,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.queueTracks = append(m.queueTracks, tracks...)
 		m.queueIDs = append(m.queueIDs, ids...)
 		m.queue.SetTracks(m.queueTracks)
-		if msg.discovery {
+		switch {
+		case msg.discovery:
 			m.discovery.refilling = false
 			m.discovery.retries = 0 // successful refill — reset circuit breaker
 			if !m.discovery.autoMode {
@@ -737,7 +796,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.syncDiscoveryView()
 			m.appendLog(fmt.Sprintf("[discovery] refilled %d tracks", len(tracks)))
-		} else {
+		case msg.radio:
+			m.radio.refilling = false
+			m.radio.retries = 0 // successful refill — reset circuit breaker
+			m.appendLog(fmt.Sprintf("[radio] refilled %d tracks", len(tracks)))
+		default:
 			m.vibe.SetResult(len(tracks), nil)
 			m.appendLog(fmt.Sprintf("[vibe] added %d tracks for %q", len(tracks), msg.query))
 		}
@@ -1085,6 +1148,14 @@ func (m *Model) handleSearchKey(k string, msg tea.KeyPressMsg) tea.Cmd {
 		// Playlist: fetch all tracks then play next.
 		if p := m.search.SelectedPlaylist(); p != nil {
 			return m.fetchSearchCollectionCmd(nil, p, false, true)
+		}
+		return nil
+	case "ctrl+r":
+		// Start radio seeded by the selected search track. A bare "r" would
+		// steal a letter from the live search query, so this mirrors ctrl+p
+		// (playlist picker) below.
+		if t := m.search.SelectedTrack(); t != nil {
+			return m.startRadioFrom(t)
 		}
 		return nil
 	case "up", "down", "pgup", "pgdown":
@@ -1536,6 +1607,7 @@ func (m *Model) startDiscovery(autoMode bool, n int) tea.Cmd {
 	if sim == 0 {
 		sim = 0.7 // default if no metric was selected yet
 	}
+	m.stopRadio() // discovery and radio both refill on the last-track trigger — mutually exclusive
 	m.discovery.enabled = true
 	m.discovery.autoMode = autoMode
 	m.discovery.refillCap = n
@@ -1551,6 +1623,84 @@ func (m *Model) startDiscovery(autoMode bool, n int) tea.Cmd {
 	m.appendLog(fmt.Sprintf("[discovery] started from %q (similarity %.0f%%, mode=%s)",
 		m.playerState.Track.Title, sim*100, mode))
 	return m.runDiscoverySearch()
+}
+
+// startRadioFrom activates radio mode seeded by the given track, replacing
+// any radio session already in progress.
+func (m *Model) startRadioFrom(seed *provider.Track) tea.Cmd {
+	if seed == nil {
+		return nil
+	}
+	m.discovery.enabled = false // discovery and radio are mutually exclusive
+	m.radio.enabled = true
+	m.radio.seed = seed
+	m.radio.refilling = true // guard against double-trigger while search is in flight
+	m.radio.triggeredForID = ""
+	m.radio.retries = 0
+	m.appendLog(fmt.Sprintf("[radio] started from %q", seed.Title))
+	return m.runRadioSearch()
+}
+
+// stopRadio disables radio mode and clears its state.
+func (m *Model) stopRadio() {
+	if !m.radio.enabled {
+		return
+	}
+	m.radio.enabled = false
+	m.radio.seed = nil
+	m.radio.refilling = false
+	m.radio.triggeredForID = ""
+	m.appendLog("[radio] stopped")
+}
+
+// runRadioSearch fetches the next batch of tracks for the active radio
+// station and returns a vibeResultMsg tagged as a radio refill, mirroring
+// runDiscoverySearch's dedup/exclude handling.
+func (m *Model) runRadioSearch() tea.Cmd {
+	if !m.radio.enabled || m.radio.seed == nil {
+		return nil
+	}
+	seed := m.radio.seed
+	catalogID := seed.CatalogID
+	if catalogID == "" {
+		catalogID = seed.ID
+	}
+	prov := m.provider
+
+	exclude := make(map[string]bool, len(m.radio.skipped)+len(m.queueIDs))
+	for k := range m.radio.skipped {
+		exclude[k] = true
+	}
+	for _, id := range m.queueIDs {
+		exclude[id] = true
+	}
+	for _, t := range m.queueTracks {
+		exclude[strings.ToLower(t.Artist+"||"+t.Title)] = true
+	}
+
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		res, err := prov.GetStationTracks(ctx, catalogID)
+		if err != nil {
+			return vibeResultMsg{radio: true, err: err}
+		}
+		var merged []provider.Track
+		seen := map[string]bool{}
+		for _, t := range res {
+			id := views.PlaybackID(t)
+			key := strings.ToLower(t.Artist + "||" + t.Title)
+			if exclude[id] || exclude[key] || seen[key] {
+				continue
+			}
+			seen[key] = true
+			merged = append(merged, t)
+		}
+		if len(merged) == 0 {
+			return vibeResultMsg{radio: true, err: fmt.Errorf("no results")}
+		}
+		return vibeResultMsg{radio: true, tracks: merged}
+	}
 }
 
 func (m *Model) forwardToActivePanel(msg tea.KeyPressMsg) tea.Cmd {
@@ -1724,6 +1874,11 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 			if _, t := m.queue.SelectedTrack(); t != nil {
 				return m.openPlaylistPicker(t)
 			}
+		case "R":
+			// Start radio seeded by the highlighted queue track.
+			if _, t := m.queue.SelectedTrack(); t != nil {
+				return m.startRadioFrom(t)
+			}
 		default:
 			return m.queue.Update(msg)
 		}
@@ -1840,6 +1995,14 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 		m.lastKey = ""
 		m.vibe.Focus()
 		return nil
+
+	case "R":
+		m.lastKey = ""
+		if m.radio.enabled {
+			m.stopRadio()
+			return nil
+		}
+		return m.startRadioFrom(m.playerState.Track)
 
 	case "left":
 		m.lastKey = ""
@@ -2091,12 +2254,12 @@ func (m *Model) syncDiscoveryView() {
 // slots so both sides stay in sync. Iterates from the end so index removal
 // doesn't shift the positions of entries not yet processed.
 func (m *Model) purgeSkippedFromQueue() {
-	if len(m.discovery.skipped) == 0 {
+	if len(m.discovery.skipped) == 0 && len(m.radio.skipped) == 0 {
 		return
 	}
 	changed := false
 	for i := len(m.queueIDs) - 1; i >= 0; i-- {
-		if !m.discovery.skipped[m.queueIDs[i]] {
+		if !m.discovery.skipped[m.queueIDs[i]] && !m.radio.skipped[m.queueIDs[i]] {
 			continue
 		}
 		m.appendLog(fmt.Sprintf("[skip] removing from queue: %s — %s",
@@ -3072,6 +3235,11 @@ func (m *Model) statusPlayContent(_ int) string {
 		discoverHint = accent.Render("d") + styles.Playing.Render(" picking…")
 	}
 
+	radioHint := accent.Render("R") + muted.Render(" radio")
+	if m.radio.enabled {
+		radioHint = accent.Render("R") + styles.Playing.Render(" 📻 radio")
+	}
+
 	parts := []string{
 		accent.Render("spc") + muted.Render(" play/pause"),
 		accent.Render("n/p") + muted.Render(" next/prev"),
@@ -3080,6 +3248,7 @@ func (m *Model) statusPlayContent(_ int) string {
 		accent.Render("s") + muted.Render(" shuffle"),
 		accent.Render("r") + muted.Render(" repeat"),
 		discoverHint,
+		radioHint,
 	}
 	return strings.Join(parts, dot)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1666,6 +1666,17 @@ func (m *Model) dropQueueAfter(seed *provider.Track) tea.Cmd {
 	if seedIdx < 0 || seedIdx == origLen-1 {
 		return nil
 	}
+	// Blacklist the dropped tracks so the imminent radio refill can't hand
+	// them right back — station results are often the very same tracks
+	// (same album/playlist context as the seed), and the refill's dedup
+	// only checks what's still in the queue.
+	if m.radio.skipped == nil {
+		m.radio.skipped = make(map[string]bool)
+	}
+	for _, t := range m.queueTracks[seedIdx+1:] {
+		m.radio.skipped[views.PlaybackID(t)] = true
+		m.radio.skipped[strings.ToLower(t.Artist+"||"+t.Title)] = true
+	}
 	m.queueTracks = m.queueTracks[:seedIdx+1]
 	m.queueIDs = m.queueIDs[:seedIdx+1]
 	m.queue.SetTracks(m.queueTracks)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -150,6 +150,7 @@ type vibeResultMsg struct {
 	err       error
 	discovery bool // true when result is from a discovery auto-refill
 	radio     bool // true when result is from a radio auto-refill
+	radioGen  int  // radio generation that produced this result
 }
 type loveSongMsg struct {
 	title string
@@ -253,6 +254,7 @@ type radioMode struct {
 	triggeredForID string          // ID of track for which we already fired a search
 	skipped        map[string]bool // IDs/keys of tracks skipped due to unavailability
 	retries        int             // consecutive failed refill attempts (circuit breaker)
+	generation     int             // increments whenever radio starts/stops to ignore stale results
 }
 
 const radioMaxRetries = 5 // give up re-arming after this many consecutive failures
@@ -700,6 +702,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case vibeResultMsg:
+		if msg.radio && (!m.radio.enabled || msg.radioGen != m.radio.generation) {
+			break
+		}
 		if msg.err != nil {
 			if msg.radio {
 				m.appendLog(fmt.Sprintf("[radio] search error: %v", msg.err))
@@ -1632,6 +1637,7 @@ func (m *Model) startRadioFrom(seed *provider.Track) tea.Cmd {
 		return nil
 	}
 	m.discovery.enabled = false // discovery and radio are mutually exclusive
+	m.radio.generation++
 	m.radio.enabled = true
 	m.radio.seed = seed
 	m.radio.refilling = true // guard against double-trigger while search is in flight
@@ -1650,6 +1656,7 @@ func (m *Model) stopRadio() {
 	m.radio.seed = nil
 	m.radio.refilling = false
 	m.radio.triggeredForID = ""
+	m.radio.generation++
 	m.appendLog("[radio] stopped")
 }
 
@@ -1666,6 +1673,7 @@ func (m *Model) runRadioSearch() tea.Cmd {
 		catalogID = seed.ID
 	}
 	prov := m.provider
+	radioGen := m.radio.generation
 
 	exclude := make(map[string]bool, len(m.radio.skipped)+len(m.queueIDs))
 	for k := range m.radio.skipped {
@@ -1683,7 +1691,7 @@ func (m *Model) runRadioSearch() tea.Cmd {
 		defer cancel()
 		res, err := prov.GetStationTracks(ctx, catalogID)
 		if err != nil {
-			return vibeResultMsg{radio: true, err: err}
+			return vibeResultMsg{radio: true, radioGen: radioGen, err: err}
 		}
 		var merged []provider.Track
 		seen := map[string]bool{}
@@ -1697,9 +1705,9 @@ func (m *Model) runRadioSearch() tea.Cmd {
 			merged = append(merged, t)
 		}
 		if len(merged) == 0 {
-			return vibeResultMsg{radio: true, err: fmt.Errorf("no results")}
+			return vibeResultMsg{radio: true, radioGen: radioGen}
 		}
-		return vibeResultMsg{radio: true, tracks: merged}
+		return vibeResultMsg{radio: true, radioGen: radioGen, tracks: merged}
 	}
 }
 
@@ -1875,6 +1883,10 @@ func (m *Model) handleNormalKey(msg tea.KeyPressMsg, k string) tea.Cmd {
 				return m.openPlaylistPicker(t)
 			}
 		case "R":
+			if m.radio.enabled {
+				m.stopRadio()
+				return nil
+			}
 			// Start radio seeded by the highlighted queue track.
 			if _, t := m.queue.SelectedTrack(); t != nil {
 				return m.startRadioFrom(t)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1640,6 +1640,7 @@ func (m *Model) startRadioFrom(seed *provider.Track) tea.Cmd {
 	m.radio.generation++
 	m.radio.enabled = true
 	m.radio.seed = seed
+	m.radio.skipped = nil
 	m.radio.refilling = true // guard against double-trigger while search is in flight
 	m.radio.triggeredForID = ""
 	m.radio.retries = 0
@@ -1652,7 +1653,8 @@ func (m *Model) startRadioFrom(seed *provider.Track) tea.Cmd {
 // whatever was already lined up (e.g. the rest of an album) to finish —
 // the last-track refill trigger otherwise never fires until that happens.
 // Tracks up to and including seed are left alone. If seed isn't in the
-// queue at all (e.g. seeded from a search result), this is a no-op.
+// queue at all (e.g. seeded from a search result), it's inserted as the
+// next track to play instead.
 func (m *Model) dropQueueAfter(seed *provider.Track) tea.Cmd {
 	seedID := views.PlaybackID(*seed)
 	seedIdx := -1
@@ -1662,8 +1664,11 @@ func (m *Model) dropQueueAfter(seed *provider.Track) tea.Cmd {
 			break
 		}
 	}
+	if seedIdx < 0 {
+		return m.playNextCmd(seed.Artist+" — "+seed.Title, []provider.Track{*seed}, []string{seedID})
+	}
 	origLen := len(m.queueTracks)
-	if seedIdx < 0 || seedIdx == origLen-1 {
+	if seedIdx == origLen-1 {
 		return nil
 	}
 	// Blacklist the dropped tracks so the imminent radio refill can't hand
@@ -1698,6 +1703,7 @@ func (m *Model) stopRadio() {
 	}
 	m.radio.enabled = false
 	m.radio.seed = nil
+	m.radio.skipped = nil
 	m.radio.refilling = false
 	m.radio.triggeredForID = ""
 	m.radio.generation++

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -112,6 +112,9 @@ func (m *mockProvider) AddToPlaylist(_ context.Context, _, _ string) error      
 func (m *mockProvider) GetRecommendations(_ context.Context) ([]provider.RecommendationGroup, error) {
 	return nil, nil
 }
+func (m *mockProvider) GetStationTracks(_ context.Context, _ string) ([]provider.Track, error) {
+	return nil, nil
+}
 
 // --- helpers ---
 
@@ -1080,6 +1083,51 @@ func TestModel_Update_VibeResultMsg_Discovery(t *testing.T) {
 	_ = cmd
 }
 
+func TestModel_Update_VibeResultMsg_Radio(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.refilling = true
+	tracks := []provider.Track{{Title: "Radio Song", ID: "888", CatalogID: "cat888"}}
+	_, cmd := m.Update(vibeResultMsg{tracks: tracks, radio: true})
+	_ = cmd
+	if m.radio.refilling {
+		t.Error("radio.refilling should be cleared after a successful refill")
+	}
+	if len(m.queueTracks) != 1 || m.queueTracks[0].Title != "Radio Song" {
+		t.Errorf("queueTracks = %+v, want the radio track appended", m.queueTracks)
+	}
+}
+
+func TestModel_Update_VibeResultMsg_Radio_EmptyAfterFilterRetries(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.refilling = true
+	m.radio.seed = &provider.Track{ID: "seed", CatalogID: "seedcat"}
+	m.radio.skipped = map[string]bool{"blocked": true}
+	tracks := []provider.Track{{Title: "Blocked", ID: "blocked"}}
+	_, cmd := m.Update(vibeResultMsg{radio: true, tracks: tracks})
+	if cmd == nil {
+		t.Fatal("all-filtered radio result should retry via runRadioSearch, expected non-nil cmd")
+	}
+	if m.radio.retries != 1 {
+		t.Errorf("radio.retries = %d, want 1", m.radio.retries)
+	}
+}
+
+func TestModel_Update_VibeResultMsg_Radio_SearchError(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.refilling = true
+	_, cmd := m.Update(vibeResultMsg{radio: true, err: errors.New("network error")})
+	_ = cmd
+	if m.radio.refilling {
+		t.Error("radio.refilling should be cleared after a search error")
+	}
+}
+
 func TestModel_Update_LoveSongMsg_Success(t *testing.T) {
 	m := newModel(nil)
 	_, cmd := m.Update(loveSongMsg{title: "Song", loved: true})
@@ -1488,6 +1536,104 @@ func TestHandleNormalKey_D_StopDiscovery(t *testing.T) {
 	_ = cmd
 	if m.discovery.enabled {
 		t.Error("d key when discovery is on should stop discovery")
+	}
+}
+
+func TestHandleNormalKey_R_StartRadio(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	track := &provider.Track{Title: "Seed Song", Artist: "Artist", ID: "seed", CatalogID: "seedcat"}
+	m.playerState.Track = track
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd == nil {
+		t.Fatal("R key with a playing track should start radio and return a search cmd")
+	}
+	if !m.radio.enabled {
+		t.Error("R key with a playing track should enable radio")
+	}
+	if m.radio.seed != track {
+		t.Errorf("radio.seed = %+v, want %+v", m.radio.seed, track)
+	}
+}
+
+func TestHandleNormalKey_R_NoTrackPlaying_NoOp(t *testing.T) {
+	m := newModel(nil)
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd != nil {
+		t.Error("R key with nothing playing should not start radio")
+	}
+	if m.radio.enabled {
+		t.Error("radio should not be enabled with no track playing")
+	}
+}
+
+func TestHandleNormalKey_R_StopRadio(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.seed = &provider.Track{ID: "seed"}
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	_ = cmd
+	if m.radio.enabled {
+		t.Error("R key when radio is on should stop radio")
+	}
+}
+
+func TestHandleNormalKey_R_StopsDiscovery(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.discovery.enabled = true
+	m.discovery.seed = &provider.Track{ID: "old-seed"}
+	m.playerState.Track = &provider.Track{Title: "New Seed", ID: "new-seed", CatalogID: "newcat"}
+	m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if m.discovery.enabled {
+		t.Error("starting radio should stop discovery — both compete for the last-track refill trigger")
+	}
+	if !m.radio.enabled {
+		t.Error("R key should have started radio")
+	}
+}
+
+func TestHandleNormalKey_QueuePanel_R_StartRadioFromSelected(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.queueTracks = []provider.Track{
+		{Title: "A", Artist: "AA", ID: "a1", CatalogID: "cat1"},
+		{Title: "B", Artist: "BB", ID: "b1", CatalogID: "cat2"},
+	}
+	m.queueIDs = []string{"cat1", "cat2"}
+	m.queue.SetTracks(m.queueTracks)
+
+	// Open queue panel.
+	m.handleNormalKey(tea.KeyPressMsg{Code: 'q', Text: "q"}, "q")
+
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd == nil {
+		t.Fatal("R on a selected queue track should start radio")
+	}
+	if !m.radio.enabled {
+		t.Error("radio should be enabled after R on a queue track")
+	}
+	if m.radio.seed == nil || m.radio.seed.Title != "A" {
+		t.Errorf("radio.seed = %+v, want the selected queue track", m.radio.seed)
+	}
+}
+
+func TestHandleSearchKey_CtrlR_StartRadioFromSelected(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	track := provider.Track{Title: "Search Hit", Artist: "Artist", CatalogID: "cat-search"}
+	seedSearchResults(m, track)
+
+	cmd := m.handleSearchKey("ctrl+r", tea.KeyPressMsg{})
+	if cmd == nil {
+		t.Fatal("ctrl+r on a selected search track should start radio")
+	}
+	if !m.radio.enabled {
+		t.Error("radio should be enabled after ctrl+r in search")
+	}
+	if m.mode != modeSearch {
+		t.Error("ctrl+r should not close the search overlay, matching tab/shift+tab")
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -116,6 +116,16 @@ func (m *mockProvider) GetStationTracks(_ context.Context, _ string) ([]provider
 	return nil, nil
 }
 
+type stationMockProvider struct {
+	mockProvider
+	tracks []provider.Track
+	err    error
+}
+
+func (m *stationMockProvider) GetStationTracks(_ context.Context, _ string) ([]provider.Track, error) {
+	return m.tracks, m.err
+}
+
 // --- helpers ---
 
 func testCfg() *config.Config {
@@ -1099,6 +1109,25 @@ func TestModel_Update_VibeResultMsg_Radio(t *testing.T) {
 	}
 }
 
+func TestModel_Update_VibeResultMsg_Radio_StaleResultIgnored(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.generation = 2
+	m.radio.refilling = true
+
+	tracks := []provider.Track{{Title: "Old Radio Song", ID: "old", CatalogID: "oldcat"}}
+	_, cmd := m.Update(vibeResultMsg{tracks: tracks, radio: true, radioGen: 1})
+	_ = cmd
+
+	if len(m.queueTracks) != 0 {
+		t.Errorf("stale radio result appended queueTracks = %+v, want none", m.queueTracks)
+	}
+	if len(mp.appendQueueIDs) != 0 {
+		t.Errorf("stale radio result called AppendQueue with %v, want no call", mp.appendQueueIDs)
+	}
+}
+
 func TestModel_Update_VibeResultMsg_Radio_EmptyAfterFilterRetries(t *testing.T) {
 	mp := newMockPlayer()
 	m := newModel(mp)
@@ -1113,6 +1142,38 @@ func TestModel_Update_VibeResultMsg_Radio_EmptyAfterFilterRetries(t *testing.T) 
 	}
 	if m.radio.retries != 1 {
 		t.Errorf("radio.retries = %d, want 1", m.radio.retries)
+	}
+}
+
+func TestRunRadioSearch_EmptyFilteredBatchReturnsEmptyResultForRetry(t *testing.T) {
+	mp := newMockPlayer()
+	prov := &stationMockProvider{
+		tracks: []provider.Track{{Title: "Already Queued", Artist: "Artist", ID: "queued", CatalogID: "queuedcat"}},
+	}
+	m := New(testCfg(), prov, mp, Options{})
+	m.radio.enabled = true
+	m.radio.generation = 3
+	m.radio.seed = &provider.Track{ID: "seed", CatalogID: "seedcat"}
+	m.queueTracks = []provider.Track{{Title: "Already Queued", Artist: "Artist", ID: "queued", CatalogID: "queuedcat"}}
+	m.queueIDs = []string{"queuedcat"}
+
+	cmd := m.runRadioSearch()
+	if cmd == nil {
+		t.Fatal("runRadioSearch returned nil cmd")
+	}
+	raw := cmd()
+	msg, ok := raw.(vibeResultMsg)
+	if !ok {
+		t.Fatalf("runRadioSearch msg = %T, want vibeResultMsg", raw)
+	}
+	if msg.err != nil {
+		t.Fatalf("empty filtered radio batch err = %v, want nil so Update can retry", msg.err)
+	}
+	if !msg.radio || msg.radioGen != 3 {
+		t.Fatalf("radio result flags = radio:%v gen:%d, want radio:true gen:3", msg.radio, msg.radioGen)
+	}
+	if len(msg.tracks) != 0 {
+		t.Fatalf("tracks = %+v, want empty result", msg.tracks)
 	}
 }
 
@@ -1616,6 +1677,27 @@ func TestHandleNormalKey_QueuePanel_R_StartRadioFromSelected(t *testing.T) {
 	}
 	if m.radio.seed == nil || m.radio.seed.Title != "A" {
 		t.Errorf("radio.seed = %+v, want the selected queue track", m.radio.seed)
+	}
+}
+
+func TestHandleNormalKey_QueuePanel_R_StopRadioWhenActive(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.seed = &provider.Track{ID: "seed"}
+	m.queueTracks = []provider.Track{{Title: "A", Artist: "AA", ID: "a1", CatalogID: "cat1"}}
+	m.queueIDs = []string{"cat1"}
+	m.queue.SetTracks(m.queueTracks)
+
+	// Open queue panel.
+	m.handleNormalKey(tea.KeyPressMsg{Code: 'q', Text: "q"}, "q")
+
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd != nil {
+		t.Error("R in queue panel while radio is active should stop radio without starting a search")
+	}
+	if m.radio.enabled {
+		t.Error("R in queue panel should stop active radio")
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1672,6 +1672,57 @@ func TestHandleNormalKey_R_StartRadio_DropsRestOfQueue(t *testing.T) {
 	}
 }
 
+// TestHandleNormalKey_R_StartRadio_DroppedTracksExcludedFromRefill guards
+// against the regression where dropQueueAfter's truncation had no lasting
+// effect: it removed the rest of the album/playlist from the queue, but the
+// very next refill's dedup only checked what was *still* queued, so a
+// station response containing those same tracks (common, since they share
+// the seed's album/playlist context) handed them right back — radio looked
+// like it was doing nothing. Dropped tracks must be blacklisted so a refill
+// can't re-add them.
+func TestHandleNormalKey_R_StartRadio_DroppedTracksExcludedFromRefill(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	track2 := provider.Track{Title: "Track 2", Artist: "Artist", ID: "t2", CatalogID: "cat2"}
+	track3 := provider.Track{Title: "Track 3", Artist: "Artist", ID: "t3", CatalogID: "cat3"}
+	track4 := provider.Track{Title: "Track 4", Artist: "Artist", ID: "t4", CatalogID: "cat4"}
+	m.queueTracks = []provider.Track{
+		{Title: "Track 1", Artist: "Artist", ID: "t1", CatalogID: "cat1"},
+		track2,
+		track3,
+		track4,
+	}
+	m.queueIDs = []string{"cat1", "cat2", "cat3", "cat4"}
+	m.queue.SetTracks(m.queueTracks)
+	m.playerState.Track = &track2 // currently playing the 2nd (of 4) queued tracks
+
+	if cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R"); cmd == nil {
+		t.Fatal("R key with a playing track should start radio and return a cmd")
+	}
+
+	for _, dropped := range []provider.Track{track3, track4} {
+		if !m.radio.skipped[views.PlaybackID(dropped)] {
+			t.Errorf("radio.skipped missing dropped track %q (id=%s)", dropped.Title, views.PlaybackID(dropped))
+		}
+	}
+
+	// Simulate the imminent refill's station response echoing the two
+	// dropped tracks back alongside one genuinely new pick.
+	newTrack := provider.Track{Title: "New Pick", Artist: "Artist", ID: "t5", CatalogID: "cat5"}
+	m.Update(vibeResultMsg{
+		radio:    true,
+		radioGen: m.radio.generation,
+		tracks:   []provider.Track{track3, track4, newTrack},
+	})
+
+	if len(m.queueTracks) != 3 {
+		t.Fatalf("queueTracks = %+v, want 3 (t1, t2, New Pick) — dropped tracks must not return", m.queueTracks)
+	}
+	if got := m.queueTracks[2].Title; got != "New Pick" {
+		t.Errorf("queueTracks[2] = %q, want %q", got, "New Pick")
+	}
+}
+
 // TestHandleNormalKey_R_StartRadio_SeedNotInQueue_NoTruncation covers the
 // case where the seed track isn't present in the local queue at all (e.g.
 // radio started from a search result rather than something already queued)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1723,11 +1723,13 @@ func TestHandleNormalKey_R_StartRadio_DroppedTracksExcludedFromRefill(t *testing
 	}
 }
 
-// TestHandleNormalKey_R_StartRadio_SeedNotInQueue_NoTruncation covers the
-// case where the seed track isn't present in the local queue at all (e.g.
-// radio started from a search result rather than something already queued)
-// — there's nothing to drop, and the existing queue should be untouched.
-func TestHandleNormalKey_R_StartRadio_SeedNotInQueue_NoTruncation(t *testing.T) {
+// TestHandleNormalKey_R_StartRadio_SeedNotInQueue_InsertsAsPlayNext covers
+// the case where the seed track isn't present in the local queue at all
+// (e.g. radio started from a search result rather than something already
+// queued). dropQueueAfter has nothing to drop, but the seed must still be
+// queued up next so it actually plays — previously it was silently
+// dropped and radio picks were just appended after the existing queue.
+func TestHandleNormalKey_R_StartRadio_SeedNotInQueue_InsertsAsPlayNext(t *testing.T) {
 	mp := newMockPlayer()
 	m := newModel(mp)
 	m.queueTracks = []provider.Track{
@@ -1743,14 +1745,33 @@ func TestHandleNormalKey_R_StartRadio_SeedNotInQueue_NoTruncation(t *testing.T) 
 	if cmd == nil {
 		t.Fatal("R key with a playing track should start radio and return a cmd")
 	}
-	// dropQueueAfter's truncation runs synchronously inside startRadioFrom,
-	// before the returned cmd is ever invoked — no need to drive it here.
-
-	if len(m.queueTracks) != 2 {
-		t.Errorf("queueTracks = %+v, want unchanged (seed absent from queue)", m.queueTracks)
+	// The local insertion runs synchronously inside startRadioFrom, before
+	// the returned cmd is ever invoked.
+	if len(m.queueTracks) != 3 || m.queueTracks[0].ID != "seed" {
+		t.Fatalf("queueTracks = %+v, want seed inserted at front", m.queueTracks)
 	}
 	if len(mp.removeFromQueueIdx) != 0 {
 		t.Errorf("RemoveFromQueue calls = %v, want none", mp.removeFromQueueIdx)
+	}
+
+	// startRadioFrom batches dropQueueAfter's play-next command with
+	// runRadioSearch's — drive both from the resulting BatchMsg.
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("cmd() = %T, want tea.BatchMsg", msg)
+	}
+	for _, sub := range batch {
+		if sub != nil {
+			sub()
+		}
+	}
+
+	if len(mp.appendQueueIDs) != 1 || mp.appendQueueIDs[0][0] != "seedcat" {
+		t.Errorf("AppendQueue calls = %v, want [[seedcat]]", mp.appendQueueIDs)
+	}
+	if len(mp.moveInQueueCalls) != 1 || mp.moveInQueueCalls[0].From != 2 || mp.moveInQueueCalls[0].To != 0 {
+		t.Errorf("MoveInQueue calls = %v, want [{From:2 To:0}]", mp.moveInQueueCalls)
 	}
 }
 
@@ -1774,6 +1795,41 @@ func TestHandleNormalKey_R_StopRadio(t *testing.T) {
 	_ = cmd
 	if m.radio.enabled {
 		t.Error("R key when radio is on should stop radio")
+	}
+}
+
+// TestHandleNormalKey_R_StopRadio_ClearsSkipped guards against the
+// regression where m.radio.skipped was never cleared: tracks dropped
+// during one radio session stayed blacklisted forever across every
+// subsequent radio session in the run.
+func TestHandleNormalKey_R_StopRadio_ClearsSkipped(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.radio.enabled = true
+	m.radio.seed = &provider.Track{ID: "seed"}
+	m.radio.skipped = map[string]bool{"blocked": true}
+	m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if m.radio.skipped != nil {
+		t.Errorf("radio.skipped = %v, want nil after stopping radio", m.radio.skipped)
+	}
+}
+
+// TestHandleNormalKey_R_StartRadio_ResetsStaleSkipped guards against the
+// same regression from the other direction: starting a fresh radio
+// session must not inherit a blacklist left over from a previous one.
+func TestHandleNormalKey_R_StartRadio_ResetsStaleSkipped(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	seed := &provider.Track{Title: "New Seed", ID: "new-seed", CatalogID: "newcat"}
+	m.playerState.Track = seed
+	m.radio.skipped = map[string]bool{"stale-from-last-session": true}
+
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd == nil {
+		t.Fatal("R key with a playing track should start radio and return a cmd")
+	}
+	if m.radio.skipped["stale-from-last-session"] {
+		t.Error("radio.skipped carried a stale entry into the new radio session")
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -18,20 +18,21 @@ import (
 // --- mock player ---
 
 type mockPlayer struct {
-	state            player.State
-	playCalled       bool
-	pauseCalled      bool
-	nextCalled       bool
-	prevCalled       bool
-	closeCalled      bool
-	seekCalled       bool
-	seekPos          time.Duration
-	bitrateKbps      int
-	setQueueIDs      []string   // last IDs passed to SetQueue
-	appendQueueIDs   [][]string // all calls to AppendQueue (each call appended)
-	moveInQueueCalls []struct{ From, To int }
-	err              error
-	stateCh          chan player.State
+	state              player.State
+	playCalled         bool
+	pauseCalled        bool
+	nextCalled         bool
+	prevCalled         bool
+	closeCalled        bool
+	seekCalled         bool
+	seekPos            time.Duration
+	bitrateKbps        int
+	setQueueIDs        []string   // last IDs passed to SetQueue
+	appendQueueIDs     [][]string // all calls to AppendQueue (each call appended)
+	moveInQueueCalls   []struct{ From, To int }
+	removeFromQueueIdx []int // all calls to RemoveFromQueue, in call order
+	err                error
+	stateCh            chan player.State
 }
 
 func newMockPlayer() *mockPlayer {
@@ -62,7 +63,10 @@ func (m *mockPlayer) AppendQueue(ids []string) error {
 	m.appendQueueIDs = append(m.appendQueueIDs, ids)
 	return m.err
 }
-func (m *mockPlayer) RemoveFromQueue(_ int) error { return m.err }
+func (m *mockPlayer) RemoveFromQueue(idx int) error {
+	m.removeFromQueueIdx = append(m.removeFromQueueIdx, idx)
+	return m.err
+}
 func (m *mockPlayer) MoveInQueue(from, to int) error {
 	m.moveInQueueCalls = append(m.moveInQueueCalls, struct{ From, To int }{from, to})
 	return m.err
@@ -1614,6 +1618,88 @@ func TestHandleNormalKey_R_StartRadio(t *testing.T) {
 	}
 	if m.radio.seed != track {
 		t.Errorf("radio.seed = %+v, want %+v", m.radio.seed, track)
+	}
+}
+
+// TestHandleNormalKey_R_StartRadio_DropsRestOfQueue guards against the
+// regression where starting radio mid-album (or mid-playlist) had no
+// visible effect: the rest of the already-queued tracks kept playing
+// because radio only appended new tracks once the current track became the
+// *last* queued item. Radio should instead drop everything queued after the
+// seed so its picks play next.
+func TestHandleNormalKey_R_StartRadio_DropsRestOfQueue(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	track2 := provider.Track{Title: "Track 2", Artist: "Artist", ID: "t2", CatalogID: "cat2"}
+	m.queueTracks = []provider.Track{
+		{Title: "Track 1", Artist: "Artist", ID: "t1", CatalogID: "cat1"},
+		track2,
+		{Title: "Track 3", Artist: "Artist", ID: "t3", CatalogID: "cat3"},
+		{Title: "Track 4", Artist: "Artist", ID: "t4", CatalogID: "cat4"},
+	}
+	m.queueIDs = []string{"cat1", "cat2", "cat3", "cat4"}
+	m.queue.SetTracks(m.queueTracks)
+	m.playerState.Track = &track2 // currently playing the 2nd (of 4) queued tracks
+
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd == nil {
+		t.Fatal("R key with a playing track should start radio and return a cmd")
+	}
+	// startRadioFrom batches dropQueueAfter's RemoveFromQueue command with
+	// runRadioSearch's — drive both from the resulting BatchMsg.
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("cmd() = %T, want tea.BatchMsg", msg)
+	}
+	for _, sub := range batch {
+		if sub != nil {
+			sub()
+		}
+	}
+
+	if len(m.queueTracks) != 2 || m.queueTracks[1].ID != "t2" {
+		t.Errorf("queueTracks = %+v, want only the played-through tracks (t1, t2) kept", m.queueTracks)
+	}
+	if len(m.queueIDs) != 2 {
+		t.Errorf("queueIDs = %v, want 2 remaining", m.queueIDs)
+	}
+	if len(mp.removeFromQueueIdx) != 2 {
+		t.Fatalf("RemoveFromQueue calls = %v, want 2 (indices 3 then 2)", mp.removeFromQueueIdx)
+	}
+	if mp.removeFromQueueIdx[0] != 3 || mp.removeFromQueueIdx[1] != 2 {
+		t.Errorf("RemoveFromQueue calls = %v, want [3, 2] (highest index first)", mp.removeFromQueueIdx)
+	}
+}
+
+// TestHandleNormalKey_R_StartRadio_SeedNotInQueue_NoTruncation covers the
+// case where the seed track isn't present in the local queue at all (e.g.
+// radio started from a search result rather than something already queued)
+// — there's nothing to drop, and the existing queue should be untouched.
+func TestHandleNormalKey_R_StartRadio_SeedNotInQueue_NoTruncation(t *testing.T) {
+	mp := newMockPlayer()
+	m := newModel(mp)
+	m.queueTracks = []provider.Track{
+		{Title: "Queued 1", ID: "q1", CatalogID: "qcat1"},
+		{Title: "Queued 2", ID: "q2", CatalogID: "qcat2"},
+	}
+	m.queueIDs = []string{"qcat1", "qcat2"}
+	m.queue.SetTracks(m.queueTracks)
+	seed := &provider.Track{Title: "Seed Song", ID: "seed", CatalogID: "seedcat"}
+	m.playerState.Track = seed // playing a track that isn't in m.queueTracks
+
+	cmd := m.handleNormalKey(tea.KeyPressMsg{Code: 'R', Text: "R"}, "R")
+	if cmd == nil {
+		t.Fatal("R key with a playing track should start radio and return a cmd")
+	}
+	// dropQueueAfter's truncation runs synchronously inside startRadioFrom,
+	// before the returned cmd is ever invoked — no need to drive it here.
+
+	if len(m.queueTracks) != 2 {
+		t.Errorf("queueTracks = %+v, want unchanged (seed absent from queue)", m.queueTracks)
+	}
+	if len(mp.removeFromQueueIdx) != 0 {
+		t.Errorf("RemoveFromQueue calls = %v, want none", mp.removeFromQueueIdx)
 	}
 }
 

--- a/internal/tui/views/helpers_test.go
+++ b/internal/tui/views/helpers_test.go
@@ -75,3 +75,6 @@ func (m *mockProvider) AddToPlaylist(_ context.Context, _, _ string) error      
 func (m *mockProvider) GetRecommendations(_ context.Context) ([]provider.RecommendationGroup, error) {
 	return nil, nil
 }
+func (m *mockProvider) GetStationTracks(_ context.Context, _ string) ([]provider.Track, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
Closes #32.

- Press `R` on the currently playing track, a selected queue track, or a selected search result to start an Apple Music radio station seeded from it.
- Uses Apple's synthetic per-song radio station ID: `POST /v1/me/stations/next-tracks/ra.<catalogSongID>` (verified against the live API — the `stationSeed` body shape originally discussed in the issue turned out not to match Apple's actual endpoint; happy to elaborate on how I found the right one).
- Related tracks are appended to the queue and playback continues into them; the queue auto-refills as it runs low, reusing discovery mode's auto-refill/circuit-breaker machinery per our discussion in the issue.
- A `📻 radio` badge shows in the now-playing status bar while active, mirroring the existing discovery indicator.
- Radio and discovery are mutually exclusive (both compete for the same last-track refill trigger) — starting one stops the other.
- Search uses `ctrl+r` rather than a bare `R`, matching the existing `ctrl+p` precedent, since the search box is a live text input and a bare letter would steal from typing.

## Test plan
- [x] `go test ./...` and pinned `golangci-lint` (v2.11.4) both clean
- [x] Unit tests for `GetStationTracks` (Apple provider) and the model-layer keybindings/refill/retry/dedup logic
- [x] Manually verified in `--demo` mode: badge, queue refill, queue-panel seeding, `ctrl+r` from search, and that `r` (repeat) is unaffected
- [x] Manually verified against my real Apple Music account: played an album, pressed `R`, got real related tracks appended and playing, confirmed via debug log (`[radio] refilled N tracks`)