### PR TITLE
build: add 'make refresh-token' to regenerate the dev token into config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOFLAGS=-tags webkit2gtk_4_1
 PKG_CONFIG_PATH=$(CURDIR)/pkg-config
 
-.PHONY: build run test lint clean release build-with-token
+.PHONY: build run test lint clean release build-with-token refresh-token
 
 build:
 	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) go build -o vibez .
@@ -52,6 +52,28 @@ release:
 		          -X 'github.com/simone-vibes/vibez/internal/lastfm.apiKey=$$LASTFM_API_KEY' \
 		          -X 'github.com/simone-vibes/vibez/internal/lastfm.apiSecret=$$LASTFM_API_SECRET'" \
 		-o vibez . && echo "Done."
+
+# refresh-token generates a fresh Apple developer JWT and writes it into your
+# local vibez config (apple_developer_token). Use it when the token expires
+# (~30 days) and you build without an embedded token (plain `make build`).
+#
+# Credentials are read from the environment or a local .env file (gitignored):
+#   APPLE_KEY_ID, APPLE_TEAM_ID
+#   APPLE_PRIVATE_KEY       - PEM contents of the .p8 key, OR
+#   APPLE_PRIVATE_KEY_FILE  - path to the .p8 key (~ is expanded)
+# After refreshing, run `vibez auth login` if your user token is not set.
+refresh-token:
+	@set -e; \
+	if [ -f .env ]; then set -a; . ./.env; set +a; fi; \
+	if [ -z "$$APPLE_PRIVATE_KEY" ] && [ -n "$$APPLE_PRIVATE_KEY_FILE" ]; then \
+		APPLE_PRIVATE_KEY="$$(cat "$$(eval echo $$APPLE_PRIVATE_KEY_FILE)")"; \
+		export APPLE_PRIVATE_KEY; \
+	fi; \
+	test -n "$$APPLE_KEY_ID"      || { echo "APPLE_KEY_ID is not set (env or .env)";      exit 1; }; \
+	test -n "$$APPLE_TEAM_ID"     || { echo "APPLE_TEAM_ID is not set (env or .env)";     exit 1; }; \
+	test -n "$$APPLE_PRIVATE_KEY" || { echo "APPLE_PRIVATE_KEY or APPLE_PRIVATE_KEY_FILE is not set (env or .env)"; exit 1; }; \
+	export APPLE_KEY_ID APPLE_TEAM_ID APPLE_PRIVATE_KEY; \
+	GOFLAGS= go run ./scripts/gen-devtoken -write
 
 run: build
 	./vibez

--- a/scripts/gen-devtoken/main.go
+++ b/scripts/gen-devtoken/main.go
@@ -1,6 +1,10 @@
 // gen-devtoken generates a short-lived Apple Music developer JWT.
-// It reads credentials from environment variables and prints the signed token
-// to stdout so CI can capture and inject it at build time.
+// It reads credentials from environment variables and, by default, prints the
+// signed token to stdout so CI can capture and inject it at build time.
+//
+// With -write it instead writes the token into apple_developer_token in the
+// vibez config file, which is handy for local (non-embedded) builds where the
+// token expires every 30 days.
 //
 // Required env vars:
 //
@@ -13,21 +17,51 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/simone-vibes/vibez/internal/config"
 )
 
 func main() {
+	write := flag.Bool("write", false, "write the token into apple_developer_token in the vibez config instead of printing it to stdout")
+	configPath := flag.String("config", "", "config file to update with -write (default: ~/.config/vibez/config.json)")
+	flag.Parse()
+
 	keyID := mustEnv("APPLE_KEY_ID")
 	teamID := mustEnv("APPLE_TEAM_ID")
 	privateKeyPEM := mustEnv("APPLE_PRIVATE_KEY")
 
+	signed, err := generateToken(keyID, teamID, privateKeyPEM)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	if !*write {
+		fmt.Print(signed)
+		return
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fatalf("loading config: %v", err)
+	}
+	cfg.AppleDeveloperToken = signed
+	if err := cfg.Save(*configPath); err != nil {
+		fatalf("saving config: %v", err)
+	}
+	path, _ := config.ConfigPath(*configPath)
+	fmt.Fprintf(os.Stderr, "wrote developer token to %s\n", path)
+}
+
+// generateToken signs an Apple Music developer JWT valid for 30 days.
+func generateToken(keyID, teamID, privateKeyPEM string) (string, error) {
 	ecKey, err := parsePrivateKey(privateKeyPEM)
 	if err != nil {
-		fatalf("parsing private key: %v", err)
+		return "", fmt.Errorf("parsing private key: %w", err)
 	}
 
 	token := jwt.New(jwt.SigningMethodES256)
@@ -42,10 +76,9 @@ func main() {
 
 	signed, err := token.SignedString(ecKey)
 	if err != nil {
-		fatalf("signing token: %v", err)
+		return "", fmt.Errorf("signing token: %w", err)
 	}
-
-	fmt.Print(signed)
+	return signed, nil
 }
 
 func parsePrivateKey(pem string) (*ecdsa.PrivateKey, error) {

--- a/scripts/gen-devtoken/main_test.go
+++ b/scripts/gen-devtoken/main_test.go
@@ -120,6 +120,41 @@ func TestGeneratedTokenClaims(t *testing.T) {
 	_ = pemStr // consumed above via generateTestKey
 }
 
+func TestGenerateToken_SignsWithClaims(t *testing.T) {
+	key, pemStr := generateTestKey(t)
+
+	signed, err := generateToken("KEYIDABC12", "TEAMIDXYZ9", pemStr)
+	if err != nil {
+		t.Fatalf("generateToken: %v", err)
+	}
+
+	parsed, err := jwt.Parse(signed, func(*jwt.Token) (any, error) {
+		return &key.PublicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("parsing generated token: %v", err)
+	}
+	if !parsed.Valid {
+		t.Error("token should be valid")
+	}
+	if kid := parsed.Header["kid"]; kid != "KEYIDABC12" {
+		t.Errorf("kid = %v, want KEYIDABC12", kid)
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("unexpected claims type")
+	}
+	if claims["iss"] != "TEAMIDXYZ9" {
+		t.Errorf("iss = %v, want TEAMIDXYZ9", claims["iss"])
+	}
+}
+
+func TestGenerateToken_InvalidKey(t *testing.T) {
+	if _, err := generateToken("kid", "team", "not-a-pem"); err == nil {
+		t.Error("expected error for invalid private key, got nil")
+	}
+}
+
 func TestTokenHasCorrectHeader(t *testing.T) {
 	key, _ := generateTestKey(t)
 


### PR DESCRIPTION
Local (non-embedded) builds read `apple_developer_token` from `~/.config/vibez/config.json`, and a signed Apple MusicKit token expires after ~30 days — so a dev token that worked last month silently starts returning `invalid token` at launch. This adds a quick way to refresh it:

- **`gen-devtoken -write`** — saves the freshly signed JWT straight into the vibez config (optional `-config` path) instead of printing it to stdout.
- **`make refresh-token`** — signs a token from credentials in the environment or a gitignored `.env` (`APPLE_KEY_ID`, `APPLE_TEAM_ID`, and `APPLE_PRIVATE_KEY` or `APPLE_PRIVATE_KEY_FILE`) and writes it in.

Default stdout behaviour is unchanged, so `build-with-token` / `release` still work exactly as before. Adds a test for the `-write` path.
