### PR TITLE
Add Linux/arm64 full-track playback support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,11 @@ builds:
       - linux
     goarch:
       - amd64
+      # linux/arm64 works at runtime (internal/player/cdp discovers a system
+      # Chromium + Widevine CDM), but is not published here yet: this CGO/webkit
+      # build needs an aarch64 toolchain (CC=aarch64-linux-gnu-gcc + arm64
+      # webkit2gtk) or a native arm64 runner. Until then arm64 users build from
+      # source with `make build`.
 
   - id: vibez-darwin
     binary: vibez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Linux/arm64 (aarch64) full-track playback** — the Chrome/CDP backend now runs on arm64 Linux, where Google publishes no Chrome build. vibez discovers a system Chromium and a system-registered Widevine CDM instead of downloading a browser, warms up the CDM once (Chromium registers it via a component-updater hint file that needs a persistent profile at `~/.cache/vibez/chromium-arm64`), and falls back to the WebKit 30 s preview backend when a browser or CDM is missing. Requires building from source (`make build`) plus a system Chromium + Widevine CDM (e.g. `pacman -S chromium widevine`). Addresses #11.
+
 ### Fixed
 - **Search failures were reported as empty results** — `Search` queries the library, catalog songs, and catalog albums/playlists in parallel and only returned an error when all three failed, so one dead backend silently produced a thinner result set instead of a failure. Discovery refills then discarded the error entirely, leaving `[vibe] search error: no results` as the only clue. Partial failures are now carried on `SearchResult.Warnings`, logged as `[search] partial results: …`, and named in the "no results" message, so an unreachable backend is distinguishable from a query that genuinely matched nothing. Refs #93.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 vibez is an open-source TUI Apple Music player for Linux and macOS. Search, queue, and control playback entirely from the keyboard.
 
-Full tracks stream via Chrome with Widevine DRM. On Linux amd64, Chrome is auto-downloaded into vibez's private cache; on other Linux builds, WebKit + GStreamer remains available as a 30-second preview backend. On macOS, install Google Chrome before using Apple Music playback.
+Full tracks stream via Chrome with Widevine DRM. On Linux amd64, Chrome is auto-downloaded into vibez's private cache; on Linux arm64, vibez uses a system-installed Chromium plus a system Widevine CDM (Google publishes no arm64 Chrome for Linux). Where neither is available, WebKit + GStreamer remains available as a 30-second preview backend. On macOS, install Google Chrome before using Apple Music playback.
 
 ---
 
@@ -146,7 +146,7 @@ cd vibez
 make build-with-token   # requires APPLE_KEY_ID, APPLE_TEAM_ID, APPLE_PRIVATE_KEY
 ```
 
-**Requirements:** Linux x86-64 or macOS · Go 1.26+ · WebKit/GStreamer development packages on Linux · Google Chrome on macOS · Apple Developer Account with a MusicKit key
+**Requirements:** Linux x86-64 or arm64, or macOS · Go 1.26+ · WebKit/GStreamer development packages on Linux · Google Chrome on macOS · on Linux arm64, a system Chromium + Widevine CDM for full-track playback (e.g. `pacman -S chromium widevine`) · Apple Developer Account with a MusicKit key
 
 ---
 
@@ -336,10 +336,10 @@ Use `↑` / `↓` (or `ctrl+p` / `ctrl+n`) to cycle through suggestions, and `ta
 
 | Engine | Tracks | How it works |
 |--------|--------|--------------|
-| **Chrome + Widevine** | Full tracks | Chrome via Playwright; MusicKit JS + Widevine DRM |
+| **Chrome + Widevine** | Full tracks | Chrome (amd64) or system Chromium (arm64) via Playwright; MusicKit JS + Widevine DRM |
 | **WebKit + GStreamer** *(Linux fallback)* | 30 s previews | Embedded webkit2gtk-4.1; GStreamer decodes preview URLs |
 
-On Linux, Chrome is downloaded once to `~/.cache/vibez/chrome` and the Playwright driver is stored in `~/.cache/vibez/driver`. On macOS, vibez uses an installed Google Chrome app.
+On Linux amd64, Chrome is downloaded once to `~/.cache/vibez/chrome`. On Linux arm64, vibez uses the system Chromium with a persistent profile in `~/.cache/vibez/chromium-arm64` and a system-registered Widevine CDM (registered on a one-time warm-up launch). The Playwright driver is stored in `~/.cache/vibez/driver`. On macOS, vibez uses an installed Google Chrome app.
 
 ---
 

--- a/cmd/root_linux.go
+++ b/cmd/root_linux.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -20,10 +19,7 @@ import (
 )
 
 func runPlatform(cfg *config.Config, iconPath string, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int) error {
-	_, chromeErr := os.Stat(cdp.ChromePath())
-	cdpAvailable := chromeErr == nil || runtime.GOARCH == "amd64"
-
-	if cdpAvailable {
+	if cdp.Available() {
 		return runCDPFlow(cfg, opts, onUserToken, onStorefront, audioBitrateKbps, cdpPlatformHooks{
 			initStatus: "Initializing vibez...",
 			afterReady: func(cdpPlayer *cdp.Player) {

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -17,8 +17,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	playwright "github.com/mxschmitt/playwright-go"
 )
@@ -39,26 +41,157 @@ func chromeInstallDir() string { return filepath.Join(baseDir(), "chrome") }
 // driverDir is where the Playwright Node.js driver lives.
 func driverDir() string { return filepath.Join(baseDir(), "driver") }
 
-// ChromePath returns the path to the cached Chrome binary.
+// ChromePath returns the path to the Chrome/Chromium binary vibez launches.
+// On amd64 this is the privately downloaded Google Chrome; on arm64 — where
+// Google publishes no Linux build — it is a discovered system Chromium/Chrome.
 func ChromePath() string {
+	if runtime.GOARCH == "arm64" {
+		path, _ := findSystemBrowser()
+		return path
+	}
+	return bundledChromePath()
+}
+
+// bundledChromePath is the amd64 layout: the extracted Google Chrome .deb.
+func bundledChromePath() string {
 	return filepath.Join(chromeInstallDir(), "opt", "google", "chrome", "chrome")
 }
 
 // HelperPath returns the path to the vibez-helper hard link of the Chrome
 // binary. Launching Chrome via this path causes the process (and child
 // processes that re-exec via /proc/self/exe) to appear as "vibez-helper"
-// in ps/top instead of "chrome".
+// in ps/top instead of "chrome". On arm64 the browser lives in a read-only
+// system location we cannot hard-link into, so it equals ChromePath().
 func HelperPath() string {
+	if runtime.GOARCH == "arm64" {
+		return ChromePath()
+	}
 	return filepath.Join(chromeInstallDir(), "opt", "google", "chrome", "vibez-helper")
 }
 
 // linkHelper creates a hard link vibez-helper → chrome so the spawned
-// process shows as "vibez-helper" in process listings. Idempotent.
+// process shows as "vibez-helper" in process listings. Idempotent. No-op on
+// arm64, where the system browser is not owned by vibez.
 func linkHelper() {
+	if runtime.GOARCH == "arm64" {
+		return
+	}
 	if _, err := os.Stat(HelperPath()); err == nil {
 		return // already exists
 	}
 	_ = os.Link(ChromePath(), HelperPath())
+}
+
+// chromeInstallHelpARM64 guides arm64 users when a browser or Widevine CDM is
+// missing. Google ships no Linux/arm64 Chrome, so vibez relies on a
+// system-installed Chromium plus a system-registered Widevine CDM.
+const chromeInstallHelpARM64 = "install Chromium and a Widevine CDM (e.g. `pacman -S chromium widevine` on Arch Linux ARM, or your distro's equivalent) — or set VIBEZ_CHROME_PATH to a browser binary"
+
+// systemBrowserCandidates lists the executables searched on PATH (in order)
+// for the arm64 full-track backend.
+func systemBrowserCandidates() []string {
+	return []string{"chromium", "chromium-browser", "google-chrome-stable", "google-chrome"}
+}
+
+// systemBrowserRealBinaries lists absolute paths to real browser binaries,
+// preferred over PATH entries. On several distros the PATH `chromium` is a
+// launcher wrapper that injects flags from config files; launching the real
+// binary avoids that and matches how vibez launches Chrome on amd64/macOS.
+func systemBrowserRealBinaries() []string {
+	return []string{
+		"/usr/lib/chromium/chromium",
+		"/usr/lib64/chromium/chromium",
+		"/usr/lib/chromium-browser/chromium-browser",
+		"/opt/google/chrome/chrome",
+		"/opt/chromium.org/chromium/chromium",
+	}
+}
+
+func usableExecutable(p string) bool {
+	st, err := os.Stat(p)
+	return err == nil && !st.IsDir() && st.Mode()&0o111 != 0
+}
+
+// findSystemBrowser locates a Chromium/Chrome executable for the arm64 path.
+// Order: VIBEZ_CHROME_PATH / CHROME_PATH overrides, then known real binaries,
+// then whatever launcher is on PATH.
+func findSystemBrowser() (string, error) {
+	for _, env := range []string{"VIBEZ_CHROME_PATH", "CHROME_PATH"} {
+		if p := os.Getenv(env); p != "" {
+			if !usableExecutable(p) {
+				return "", fmt.Errorf("%s=%q is not a usable browser executable", env, p)
+			}
+			return p, nil
+		}
+	}
+	for _, p := range systemBrowserRealBinaries() {
+		if usableExecutable(p) {
+			return p, nil
+		}
+	}
+	for _, name := range systemBrowserCandidates() {
+		if p, err := exec.LookPath(name); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no Chromium/Chrome found on PATH; %s", chromeInstallHelpARM64)
+}
+
+// widevineCDMDir returns the first directory holding an arm64 Widevine CDM, or
+// "" if none is found. It checks well-known package locations plus the
+// directory next to the discovered browser (where Chromium keeps its CDM).
+// Chromium can also locate a system-registered CDM on its own, so callers may
+// launch without an explicit --widevine-path even when this returns "".
+// widevineSystemDirs are the fixed locations checked for a registered Widevine
+// CDM. Declared as a var so tests can substitute a controlled list.
+var widevineSystemDirs = []string{
+	"/usr/lib/chromium/WidevineCdm",
+	"/usr/lib64/chromium/WidevineCdm",
+	"/usr/lib/chromium-browser/WidevineCdm",
+	"/opt/google/chrome/WidevineCdm",
+	"/opt/WidevineCdm/chromium",
+	"/var/lib/widevine/WidevineCdm",
+}
+
+func widevineCDMDir() string {
+	candidates := append([]string(nil), widevineSystemDirs...)
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".local", "lib", "widevine", "WidevineCdm"))
+	}
+	// The CDM commonly sits next to the browser binary (e.g. Arch's
+	// /usr/lib/chromium/WidevineCdm alongside /usr/lib/chromium/chromium).
+	if b, err := findSystemBrowser(); err == nil {
+		if real, err := filepath.EvalSymlinks(b); err == nil {
+			candidates = append(candidates, filepath.Join(filepath.Dir(real), "WidevineCdm"))
+		}
+	}
+	for _, dir := range candidates {
+		if _, err := os.Stat(filepath.Join(dir, "_platform_specific", "linux_arm64", "libwidevinecdm.so")); err == nil {
+			return dir
+		}
+		if _, err := os.Stat(filepath.Join(dir, "libwidevinecdm.so")); err == nil {
+			return dir
+		}
+	}
+	return ""
+}
+
+// Available reports whether the full-track Chrome/CDP backend can run on this
+// host. On amd64 vibez downloads Google Chrome, so it is always available. On
+// arm64 it requires a system Chromium/Chrome plus a Widevine CDM. Every other
+// Linux arch uses the WebKit + GStreamer preview fallback.
+func Available() bool {
+	switch runtime.GOARCH {
+	case "amd64":
+		return true
+	case "arm64":
+		if _, err := findSystemBrowser(); err != nil {
+			return false
+		}
+		return widevineCDMDir() != ""
+	default:
+		return false
+	}
 }
 
 // EnsureBrowser downloads and extracts Google Chrome into vibez's private
@@ -87,6 +220,93 @@ func isDriverUpToDate() bool {
 }
 
 func EnsureBrowser(onProgress func(string)) error {
+	if runtime.GOARCH == "arm64" {
+		return ensureBrowserARM64(onProgress)
+	}
+	return ensureBrowserAMD64(onProgress)
+}
+
+// ensureBrowserARM64 prepares the arm64 full-track backend. Google publishes no
+// Linux/arm64 Chrome, so rather than download a browser it verifies a system
+// Chromium/Chrome and a system-registered Widevine CDM are present, then
+// fetches only the arch-aware Playwright Node driver.
+func ensureBrowserARM64(onProgress func(string)) error {
+	browser, err := findSystemBrowser()
+	if err != nil {
+		return err
+	}
+	onProgress(fmt.Sprintf("Using system browser: %s", browser))
+	if widevineCDMDir() == "" {
+		return fmt.Errorf("Widevine CDM not found (required for full-track playback); %s", chromeInstallHelpARM64)
+	}
+
+	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
+	onProgress("Fetching dependencies…")
+	if err := playwright.Install(&playwright.RunOptions{
+		DriverDirectory:     driverDir(),
+		SkipInstallBrowsers: true,
+	}); err != nil {
+		return fmt.Errorf("playwright driver: %w", err)
+	}
+	if err := warmUpWidevineARM64(onProgress); err != nil {
+		return err
+	}
+	onProgress("Browser ready.")
+	return nil
+}
+
+// chromiumProfileDir is the persistent Chromium profile vibez uses on arm64.
+// A persistent profile is required because the system Chromium registers its
+// Widevine CDM through the component-updater, which writes a "hint file" into
+// the profile on first launch that only takes effect on subsequent launches.
+// An ephemeral profile (Playwright's default) would never load Widevine.
+func chromiumProfileDir() string { return filepath.Join(baseDir(), "chromium-arm64") }
+
+// widevineHintFile is the marker Chromium writes once it has registered the
+// preinstalled Widevine CDM into chromiumProfileDir.
+func widevineHintFile() string {
+	return filepath.Join(chromiumProfileDir(), "WidevineCdm", "latest-component-updated-widevine-cdm")
+}
+
+// warmUpWidevineARM64 launches the system Chromium once against the persistent
+// profile so its component-updater registers the preinstalled Widevine CDM and
+// writes the hint file. It is a no-op once the hint file exists. Without this,
+// the first playback session would silently fall back to previews.
+func warmUpWidevineARM64(onProgress func(string)) error {
+	if _, err := os.Stat(widevineHintFile()); err == nil {
+		return nil // Widevine already registered in this profile
+	}
+	browser, err := findSystemBrowser()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(chromiumProfileDir(), 0o750); err != nil {
+		return fmt.Errorf("create chromium profile dir: %w", err)
+	}
+	onProgress("Registering Widevine CDM…")
+	cmd := exec.Command(browser, //nolint:gosec // path from trusted discovery
+		"--headless=new", "--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage",
+		"--user-data-dir="+chromiumProfileDir(), "about:blank")
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("warm-up launch: %w", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(widevineHintFile()); err == nil {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return fmt.Errorf("Widevine CDM did not register within timeout; %s", chromeInstallHelpARM64)
+}
+
+// ensureBrowserAMD64 downloads and extracts Google Chrome into vibez's private
+// cache directory if not already present. Never calls apt-get or sudo.
+func ensureBrowserAMD64(onProgress func(string)) error {
 	driverUpToDate := isDriverUpToDate()
 	chromeInstalled := false
 	if _, err := os.Stat(ChromePath()); err == nil {
@@ -220,7 +440,14 @@ func runPlaywright() (*playwright.Playwright, error) {
 }
 
 func chromeLaunchArgs(headless bool, wsl bool) []string {
-	widevinePath := filepath.Join(chromeInstallDir(), "opt", "google", "chrome", "WidevineCdm")
+	var widevinePath string
+	if runtime.GOARCH == "arm64" {
+		// System Chromium locates its registered CDM itself; pass the path
+		// only when we found one, so a non-default location still works.
+		widevinePath = widevineCDMDir()
+	} else {
+		widevinePath = filepath.Join(chromeInstallDir(), "opt", "google", "chrome", "WidevineCdm")
+	}
 	return launchArgs(widevinePath, headless, wsl)
 }
 
@@ -242,7 +469,6 @@ func launchArgs(widevinePath string, headless bool, wsl bool) []string {
 		"--autoplay-policy=no-user-gesture-required",
 		"--enable-features=MediaCapabilities,WidevineCdm",
 		"--disable-blink-features=AutomationControlled",
-		"--widevine-path=" + widevinePath,
 		// Suppress Chrome's built-in MPRIS D-Bus registration so our Go
 		// MPRIS server (org.mpris.MediaPlayer2.vibez) is the sole player
 		// visible to the desktop environment.
@@ -262,6 +488,12 @@ func launchArgs(widevinePath string, headless bool, wsl bool) []string {
 		// Disable background network activity (prefetch, DNS pre-resolve,
 		// speculative connections). Not needed for a single-page music player.
 		"--disable-background-networking",
+	}
+
+	// On amd64 this is always the bundled Chrome's CDM; on arm64 it is set only
+	// when a CDM directory was discovered (otherwise Chromium self-locates it).
+	if widevinePath != "" {
+		args = append(args, "--widevine-path="+widevinePath)
 	}
 
 	if headless {

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -108,7 +108,7 @@ func systemBrowserRealBinaries() []string {
 }
 
 func usableExecutable(p string) bool {
-	st, err := os.Stat(p)
+	st, err := os.Stat(p) //nolint:gosec // G703: path is an operator-provided (VIBEZ_CHROME_PATH) or fixed system browser path, not attacker input
 	return err == nil && !st.IsDir() && st.Mode()&0o111 != 0
 }
 
@@ -237,7 +237,7 @@ func ensureBrowserARM64(onProgress func(string)) error {
 	}
 	onProgress(fmt.Sprintf("Using system browser: %s", browser))
 	if widevineCDMDir() == "" {
-		return fmt.Errorf("Widevine CDM not found (required for full-track playback); %s", chromeInstallHelpARM64)
+		return fmt.Errorf("no Widevine CDM found (required for full-track playback); %s", chromeInstallHelpARM64)
 	}
 
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
@@ -301,7 +301,7 @@ func warmUpWidevineARM64(onProgress func(string)) error {
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
-	return fmt.Errorf("Widevine CDM did not register within timeout; %s", chromeInstallHelpARM64)
+	return fmt.Errorf("timed out waiting for the Widevine CDM to register; %s", chromeInstallHelpARM64)
 }
 
 // ensureBrowserAMD64 downloads and extracts Google Chrome into vibez's private

--- a/internal/player/cdp/browser_amd64_test.go
+++ b/internal/player/cdp/browser_amd64_test.go
@@ -1,0 +1,121 @@
+//go:build linux && amd64
+
+package cdp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+// These tests cover the amd64 layout, where vibez downloads Google Chrome into
+// its private cache and hard-links a vibez-helper alias. The arm64 backend uses
+// a discovered system browser instead (see browser_arm64_test.go).
+
+func TestChromePath_IsAbsolute(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	got := ChromePath()
+	if !filepath.IsAbs(got) {
+		t.Errorf("ChromePath() = %q, want absolute path", got)
+	}
+	if filepath.Base(got) != "chrome" {
+		t.Errorf("ChromePath() base = %q, want %q", filepath.Base(got), "chrome")
+	}
+}
+
+func TestHelperPath_IsAbsolute(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	got := HelperPath()
+	if !filepath.IsAbs(got) {
+		t.Errorf("HelperPath() = %q, want absolute path", got)
+	}
+	if filepath.Base(got) != "vibez-helper" {
+		t.Errorf("HelperPath() base = %q, want %q", filepath.Base(got), "vibez-helper")
+	}
+}
+
+func TestLinkHelper_CreatesHardLink(t *testing.T) {
+	// Set up a fake chrome directory structure in a temp cache dir.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	// Create the directories and a fake chrome binary.
+	chromeBin := ChromePath()
+	if err := os.MkdirAll(filepath.Dir(chromeBin), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(chromeBin, []byte("fake chrome"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write chrome: %v", err)
+	}
+
+	// Call linkHelper — should create vibez-helper.
+	linkHelper()
+
+	if _, err := os.Stat(HelperPath()); err != nil {
+		t.Errorf("vibez-helper not created by linkHelper(): %v", err)
+	}
+}
+
+func TestLinkHelper_IdempotentWhenHelperExists(t *testing.T) {
+	// Set up a fake chrome + helper already present.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	chromeBin := ChromePath()
+	if err := os.MkdirAll(filepath.Dir(chromeBin), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(chromeBin, []byte("fake chrome"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write chrome: %v", err)
+	}
+	if err := os.WriteFile(HelperPath(), []byte("fake helper"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write helper: %v", err)
+	}
+
+	// Should not panic and should be a no-op.
+	linkHelper()
+}
+
+func TestEnsureBrowser_AlreadyInstalled(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	chromeBin := ChromePath()
+	if err := os.MkdirAll(filepath.Dir(chromeBin), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(chromeBin, []byte("fake chrome"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write chrome: %v", err)
+	}
+
+	// Mock the playwright driver as also already installed and up-to-date.
+	driver, err := playwright.NewDriver(&playwright.RunOptions{
+		DriverDirectory: driverDir(),
+	})
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	pkgDir := filepath.Join(driverDir(), "package")
+	if err := os.MkdirAll(pkgDir, 0o750); err != nil {
+		t.Fatalf("mkdir driver package: %v", err)
+	}
+	pkgJSON := fmt.Sprintf(`{"version": %q}`, driver.Version)
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(pkgJSON), 0o600); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write driver package.json: %v", err)
+	}
+
+	var progress []string
+	err = EnsureBrowser(func(s string) { progress = append(progress, s) })
+	if err != nil {
+		t.Errorf("EnsureBrowser when already installed should return nil, got: %v", err)
+	}
+	// No download should have been triggered.
+	if len(progress) > 0 {
+		t.Errorf("EnsureBrowser when installed should not call onProgress, got: %v", progress)
+	}
+}

--- a/internal/player/cdp/browser_arm64_test.go
+++ b/internal/player/cdp/browser_arm64_test.go
@@ -1,0 +1,123 @@
+//go:build linux && arm64
+
+package cdp
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// The arm64 backend discovers a system Chromium/Chrome and a system-registered
+// Widevine CDM instead of downloading Google Chrome (which Google does not
+// publish for Linux/arm64). Tests drive discovery through the
+// VIBEZ_CHROME_PATH override and an overridable widevineSystemDirs list so they
+// never depend on what is actually installed on the host.
+
+// fakeBrowser writes an executable stub and points VIBEZ_CHROME_PATH at it,
+// isolating HOME and the fixed CDM search list so discovery is hermetic.
+func fakeBrowser(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "chromium")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write fake browser: %v", err)
+	}
+	t.Setenv("VIBEZ_CHROME_PATH", bin)
+	t.Setenv("HOME", dir)
+
+	saved := widevineSystemDirs
+	widevineSystemDirs = nil // only browser-adjacent discovery is exercised
+	t.Cleanup(func() { widevineSystemDirs = saved })
+	return bin
+}
+
+// installAdjacentCDM drops a fake arm64 Widevine CDM next to the given browser
+// and returns the WidevineCdm directory.
+func installAdjacentCDM(t *testing.T, browser string) string {
+	t.Helper()
+	cdmDir := filepath.Join(filepath.Dir(browser), "WidevineCdm")
+	soDir := filepath.Join(cdmDir, "_platform_specific", "linux_arm64")
+	if err := os.MkdirAll(soDir, 0o750); err != nil {
+		t.Fatalf("mkdir cdm: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(soDir, "libwidevinecdm.so"), []byte("fake cdm"), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write cdm: %v", err)
+	}
+	return cdmDir
+}
+
+func TestFindSystemBrowser_EnvOverride(t *testing.T) {
+	bin := fakeBrowser(t)
+	got, err := findSystemBrowser()
+	if err != nil {
+		t.Fatalf("findSystemBrowser: %v", err)
+	}
+	if got != bin {
+		t.Errorf("findSystemBrowser() = %q, want %q", got, bin)
+	}
+}
+
+func TestFindSystemBrowser_EnvOverrideInvalid(t *testing.T) {
+	t.Setenv("VIBEZ_CHROME_PATH", filepath.Join(t.TempDir(), "does-not-exist"))
+	if _, err := findSystemBrowser(); err == nil {
+		t.Error("expected error for non-existent VIBEZ_CHROME_PATH, got nil")
+	}
+}
+
+func TestChromePath_UsesSystemBrowser(t *testing.T) {
+	bin := fakeBrowser(t)
+	if got := ChromePath(); got != bin {
+		t.Errorf("ChromePath() = %q, want %q", got, bin)
+	}
+}
+
+func TestHelperPath_EqualsChromePath(t *testing.T) {
+	fakeBrowser(t)
+	if HelperPath() != ChromePath() {
+		t.Errorf("HelperPath() = %q, want == ChromePath() = %q", HelperPath(), ChromePath())
+	}
+}
+
+func TestLinkHelper_NoOpOnARM64(t *testing.T) {
+	bin := fakeBrowser(t)
+	linkHelper() // must not panic and must not create a sibling helper
+	if _, err := os.Stat(filepath.Join(filepath.Dir(bin), "vibez-helper")); err == nil {
+		t.Error("linkHelper() created a helper link on arm64; expected no-op")
+	}
+}
+
+func TestWidevineCDMDir_DiscoversAdjacentCDM(t *testing.T) {
+	bin := fakeBrowser(t)
+	if got := widevineCDMDir(); got != "" {
+		t.Fatalf("widevineCDMDir() = %q before install, want empty", got)
+	}
+	want := installAdjacentCDM(t, bin)
+	if got := widevineCDMDir(); got != want {
+		t.Errorf("widevineCDMDir() = %q, want %q", got, want)
+	}
+}
+
+func TestAvailable_RequiresBrowserAndCDM(t *testing.T) {
+	bin := fakeBrowser(t)
+	if Available() {
+		t.Error("Available() = true with no Widevine CDM; want false")
+	}
+	installAdjacentCDM(t, bin)
+	if !Available() {
+		t.Error("Available() = false with browser + CDM present; want true")
+	}
+}
+
+func TestChromeLaunchArgs_ARM64WidevinePath(t *testing.T) {
+	bin := fakeBrowser(t)
+	cdmDir := installAdjacentCDM(t, bin)
+	args := chromeLaunchArgs(true, false)
+	if !slices.Contains(args, "--widevine-path="+cdmDir) {
+		t.Errorf("chromeLaunchArgs missing --widevine-path=%s; got %v", cdmDir, args)
+	}
+	if !slices.Contains(args, "--headless=new") {
+		t.Error("chromeLaunchArgs should contain --headless=new when headless=true")
+	}
+}

--- a/internal/player/cdp/browser_test.go
+++ b/internal/player/cdp/browser_test.go
@@ -12,8 +12,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-
-	playwright "github.com/mxschmitt/playwright-go"
 )
 
 // buildAr writes a minimal ar(1) archive from an ordered list of (name, data)
@@ -182,7 +180,7 @@ func TestExtractDeb_MissingDataTar(t *testing.T) {
 	}
 }
 
-// ─── Path functions: baseDir, chromeInstallDir, driverDir, ChromePath, HelperPath ─
+// ─── Path functions: baseDir, chromeInstallDir, driverDir ──────────────────
 
 func TestBaseDir_UsesXDGCacheHome(t *testing.T) {
 	tmp := t.TempDir()
@@ -222,115 +220,6 @@ func TestDriverDir_ContainsDriver(t *testing.T) {
 	got := driverDir()
 	if filepath.Base(got) != "driver" {
 		t.Errorf("driverDir() base = %q, want %q", filepath.Base(got), "driver")
-	}
-}
-
-func TestChromePath_IsAbsolute(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", tmp)
-	got := ChromePath()
-	if !filepath.IsAbs(got) {
-		t.Errorf("ChromePath() = %q, want absolute path", got)
-	}
-	if filepath.Base(got) != "chrome" {
-		t.Errorf("ChromePath() base = %q, want %q", filepath.Base(got), "chrome")
-	}
-}
-
-func TestHelperPath_IsAbsolute(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", tmp)
-	got := HelperPath()
-	if !filepath.IsAbs(got) {
-		t.Errorf("HelperPath() = %q, want absolute path", got)
-	}
-	if filepath.Base(got) != "vibez-helper" {
-		t.Errorf("HelperPath() base = %q, want %q", filepath.Base(got), "vibez-helper")
-	}
-}
-
-// ─── linkHelper ────────────────────────────────────────────────────────────
-
-func TestLinkHelper_CreatesHardLink(t *testing.T) {
-	// Set up a fake chrome directory structure in a temp cache dir.
-	tmp := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", tmp)
-
-	// Create the directories and a fake chrome binary.
-	chromeBin := ChromePath()
-	if err := os.MkdirAll(filepath.Dir(chromeBin), 0o750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(chromeBin, []byte("fake chrome"), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write chrome: %v", err)
-	}
-
-	// Call linkHelper — should create vibez-helper.
-	linkHelper()
-
-	if _, err := os.Stat(HelperPath()); err != nil {
-		t.Errorf("vibez-helper not created by linkHelper(): %v", err)
-	}
-}
-
-func TestLinkHelper_IdempotentWhenHelperExists(t *testing.T) {
-	// Set up a fake chrome + helper already present.
-	tmp := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", tmp)
-
-	chromeBin := ChromePath()
-	if err := os.MkdirAll(filepath.Dir(chromeBin), 0o750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(chromeBin, []byte("fake chrome"), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write chrome: %v", err)
-	}
-	if err := os.WriteFile(HelperPath(), []byte("fake helper"), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write helper: %v", err)
-	}
-
-	// Should not panic and should be a no-op.
-	linkHelper()
-}
-
-// ─── EnsureBrowser when Chrome already installed ────────────────────────────
-
-func TestEnsureBrowser_AlreadyInstalled(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", tmp)
-
-	chromeBin := ChromePath()
-	if err := os.MkdirAll(filepath.Dir(chromeBin), 0o750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(chromeBin, []byte("fake chrome"), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write chrome: %v", err)
-	}
-
-	// Mock the playwright driver as also already installed and up-to-date.
-	driver, err := playwright.NewDriver(&playwright.RunOptions{
-		DriverDirectory: driverDir(),
-	})
-	if err != nil {
-		t.Fatalf("new driver: %v", err)
-	}
-	pkgDir := filepath.Join(driverDir(), "package")
-	if err := os.MkdirAll(pkgDir, 0o750); err != nil {
-		t.Fatalf("mkdir driver package: %v", err)
-	}
-	pkgJSON := fmt.Sprintf(`{"version": %q}`, driver.Version)
-	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(pkgJSON), 0o600); err != nil { //nolint:gosec // test fixture
-		t.Fatalf("write driver package.json: %v", err)
-	}
-
-	var progress []string
-	err = EnsureBrowser(func(s string) { progress = append(progress, s) })
-	if err != nil {
-		t.Errorf("EnsureBrowser when already installed should return nil, got: %v", err)
-	}
-	// No download should have been triggered.
-	if len(progress) > 0 {
-		t.Errorf("EnsureBrowser when installed should not call onProgress, got: %v", progress)
 	}
 }
 

--- a/internal/player/cdp/launch_darwin.go
+++ b/internal/player/cdp/launch_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package cdp
+
+import playwright "github.com/mxschmitt/playwright-go"
+
+// launchBrowser starts Chromium with an ephemeral profile and returns the page
+// to drive plus a close function. macOS uses the installed Google Chrome, which
+// bundles Widevine directly, so no persistent profile or warm-up is needed.
+//
+// Playwright injects --mute-audio into every headless Chromium launch; we strip
+// it so audio routes normally. Playwright also injects --disable-component-update;
+// we strip it so Chrome can load the Widevine CDM component.
+func launchBrowser(pw *playwright.Playwright, chromePath string, headless, wsl bool) (playwright.Page, func(), error) {
+	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
+		ExecutablePath:    &chromePath,
+		Headless:          &headless,
+		IgnoreDefaultArgs: []string{"--mute-audio", "--disable-component-update"},
+		Args:              chromeLaunchArgs(headless, wsl),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	pg, err := browser.NewPage()
+	if err != nil {
+		_ = browser.Close()
+		return nil, nil, err
+	}
+	return pg, func() { _ = browser.Close() }, nil
+}

--- a/internal/player/cdp/launch_linux.go
+++ b/internal/player/cdp/launch_linux.go
@@ -1,0 +1,61 @@
+//go:build linux
+
+package cdp
+
+import (
+	"runtime"
+
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+// launchBrowser starts Chromium and returns the page to drive plus a close
+// function.
+//
+// On linux/arm64 it uses a persistent profile (chromiumProfileDir) so the
+// Widevine component "hint file" — written during EnsureBrowser's warm-up — is
+// read and the CDM loads. An ephemeral profile (the default Launch) never loads
+// Widevine there because the hint only takes effect on a subsequent launch. On
+// amd64, Chrome bundles Widevine directly, so an ephemeral launch is used.
+//
+// Playwright injects --mute-audio into every headless Chromium launch; we strip
+// it so audio routes through PulseAudio/PipeWire. Playwright also injects
+// --disable-component-update; we strip it so Chrome can load the Widevine CDM
+// component. DRM in headless mode is enabled via --headless=new (chromeLaunchArgs).
+func launchBrowser(pw *playwright.Playwright, chromePath string, headless, wsl bool) (playwright.Page, func(), error) {
+	ignore := []string{"--mute-audio", "--disable-component-update"}
+	args := chromeLaunchArgs(headless, wsl)
+
+	if runtime.GOARCH == "arm64" {
+		ctx, err := pw.Chromium.LaunchPersistentContext(chromiumProfileDir(), playwright.BrowserTypeLaunchPersistentContextOptions{
+			ExecutablePath:    &chromePath,
+			Headless:          &headless,
+			IgnoreDefaultArgs: ignore,
+			Args:              args,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		pg, err := ctx.NewPage()
+		if err != nil {
+			_ = ctx.Close()
+			return nil, nil, err
+		}
+		return pg, func() { _ = ctx.Close() }, nil
+	}
+
+	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
+		ExecutablePath:    &chromePath,
+		Headless:          &headless,
+		IgnoreDefaultArgs: ignore,
+		Args:              args,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	pg, err := browser.NewPage()
+	if err != nil {
+		_ = browser.Close()
+		return nil, nil, err
+	}
+	return pg, func() { _ = browser.Close() }, nil
+}

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -222,55 +221,6 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 	}()
 
 	return p, nil
-}
-
-// launchBrowser starts Chromium and returns the page to drive plus a close
-// function. On linux/arm64 it uses a persistent profile (chromiumProfileDir) so
-// Chromium's Widevine component "hint file" — written during EnsureBrowser's
-// warm-up — is read and the CDM loads; every other platform uses an ephemeral
-// launch, where Google Chrome bundles Widevine directly.
-//
-// Playwright injects --mute-audio into every headless Chromium launch; we strip
-// it so audio routes through PulseAudio/PipeWire. Playwright also injects
-// --disable-component-update; we strip it so Chrome can load the Widevine CDM
-// component. DRM in headless mode is enabled via --headless=new (chromeLaunchArgs).
-func launchBrowser(pw *playwright.Playwright, chromePath string, headless, wsl bool) (playwright.Page, func(), error) {
-	ignore := []string{"--mute-audio", "--disable-component-update"}
-	args := chromeLaunchArgs(headless, wsl)
-
-	if runtime.GOARCH == "arm64" {
-		ctx, err := pw.Chromium.LaunchPersistentContext(chromiumProfileDir(), playwright.BrowserTypeLaunchPersistentContextOptions{
-			ExecutablePath:    &chromePath,
-			Headless:          &headless,
-			IgnoreDefaultArgs: ignore,
-			Args:              args,
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-		pg, err := ctx.NewPage()
-		if err != nil {
-			_ = ctx.Close()
-			return nil, nil, err
-		}
-		return pg, func() { _ = ctx.Close() }, nil
-	}
-
-	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
-		ExecutablePath:    &chromePath,
-		Headless:          &headless,
-		IgnoreDefaultArgs: ignore,
-		Args:              args,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	pg, err := browser.NewPage()
-	if err != nil {
-		_ = browser.Close()
-		return nil, nil, err
-	}
-	return pg, func() { _ = browser.Close() }, nil
 }
 
 func (p *Player) sendError(err error) {

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -32,10 +33,10 @@ type Player struct {
 	OnStorefront     func(sf string)
 	OnSessionExpired func()
 
-	pw      *playwright.Playwright
-	browser playwright.Browser
-	page    playwright.Page
-	srv     *http.Server
+	pw           *playwright.Playwright
+	closeBrowser func()
+	page         playwright.Page
+	srv          *http.Server
 
 	mu                 sync.RWMutex
 	state              player.State
@@ -86,37 +87,17 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 	if _, err := os.Stat(chromePath); err != nil {
 		chromePath = ChromePath() // fall back if link not yet created
 	}
-	// Playwright injects --mute-audio into every headless Chromium launch.
-	// We must strip it so Chrome's audio service can route through
-	// PulseAudio/PipeWire normally. Use headless when we have a saved token
-	// (no auth UI needed); show a real window for first-run interactive login.
+	// Use headless when we have a saved token (no auth UI needed); show a real
+	// window for first-run interactive login.
 	headless := userToken != ""
 
-	// To ensure DRM (Widevine) playback works correctly in headless mode, we
-	// launch in headless mode (Headless = true) and pass "--headless=new" in
-	// the browser arguments. Playwright by default blocks Google Chrome component
-	// updates via the --disable-component-update flag; we must ignore this default
-	// argument to allow Chrome to download/load the Widevine CDM component.
-	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
-		ExecutablePath:    &chromePath,
-		Headless:          &headless,
-		IgnoreDefaultArgs: []string{"--mute-audio", "--disable-component-update"},
-		Args:              chromeLaunchArgs(headless, wsl),
-	})
+	pg, closeBrowser, err := launchBrowser(pw, chromePath, headless, wsl)
 	if err != nil {
 		_ = pw.Stop()
 		_ = srv.Close()
 		return nil, fmt.Errorf("cdp: launch browser: %w", err)
 	}
-	p.browser = browser
-
-	pg, err := browser.NewPage()
-	if err != nil {
-		_ = browser.Close()
-		_ = pw.Stop()
-		_ = srv.Close()
-		return nil, fmt.Errorf("cdp: new page: %w", err)
-	}
+	p.closeBrowser = closeBrowser
 	p.page = pg
 
 	// Forward page crashes and unhandled JS errors to errCh so WaitReady
@@ -222,7 +203,7 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 
 	for name, fn := range bindings {
 		if err := pg.ExposeFunction(name, fn); err != nil {
-			_ = browser.Close()
+			closeBrowser()
 			_ = pw.Stop()
 			_ = srv.Close()
 			return nil, fmt.Errorf("cdp: expose %s: %w", name, err)
@@ -241,6 +222,55 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 	}()
 
 	return p, nil
+}
+
+// launchBrowser starts Chromium and returns the page to drive plus a close
+// function. On linux/arm64 it uses a persistent profile (chromiumProfileDir) so
+// Chromium's Widevine component "hint file" — written during EnsureBrowser's
+// warm-up — is read and the CDM loads; every other platform uses an ephemeral
+// launch, where Google Chrome bundles Widevine directly.
+//
+// Playwright injects --mute-audio into every headless Chromium launch; we strip
+// it so audio routes through PulseAudio/PipeWire. Playwright also injects
+// --disable-component-update; we strip it so Chrome can load the Widevine CDM
+// component. DRM in headless mode is enabled via --headless=new (chromeLaunchArgs).
+func launchBrowser(pw *playwright.Playwright, chromePath string, headless, wsl bool) (playwright.Page, func(), error) {
+	ignore := []string{"--mute-audio", "--disable-component-update"}
+	args := chromeLaunchArgs(headless, wsl)
+
+	if runtime.GOARCH == "arm64" {
+		ctx, err := pw.Chromium.LaunchPersistentContext(chromiumProfileDir(), playwright.BrowserTypeLaunchPersistentContextOptions{
+			ExecutablePath:    &chromePath,
+			Headless:          &headless,
+			IgnoreDefaultArgs: ignore,
+			Args:              args,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		pg, err := ctx.NewPage()
+		if err != nil {
+			_ = ctx.Close()
+			return nil, nil, err
+		}
+		return pg, func() { _ = ctx.Close() }, nil
+	}
+
+	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
+		ExecutablePath:    &chromePath,
+		Headless:          &headless,
+		IgnoreDefaultArgs: ignore,
+		Args:              args,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	pg, err := browser.NewPage()
+	if err != nil {
+		_ = browser.Close()
+		return nil, nil, err
+	}
+	return pg, func() { _ = browser.Close() }, nil
 }
 
 func (p *Player) sendError(err error) {
@@ -365,7 +395,9 @@ func (p *Player) dispatch(js string) {
 
 func (p *Player) Run() {
 	<-p.doneCh
-	_ = p.browser.Close()
+	if p.closeBrowser != nil {
+		p.closeBrowser()
+	}
 	_ = p.pw.Stop()
 	_ = p.srv.Close()
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,7 +91,11 @@ case "${ARCH_RAW}" in
 esac
 
 [ "${OS}" = "linux" ] || die "vibez currently supports Linux only (got: ${OS})"
-[ "${ARCH}" = "amd64" ] || die "vibez currently ships amd64 binaries only (got: ${ARCH_RAW})"
+if [ "${ARCH}" = "arm64" ]; then
+    die "no prebuilt Linux/arm64 binary is published yet — build from source: git clone https://github.com/simonepelosi/vibez && cd vibez && make build (arm64 full-track playback needs a system Chromium + Widevine CDM installed)"
+elif [ "${ARCH}" != "amd64" ]; then
+    die "vibez ships amd64 binaries only (got: ${ARCH_RAW})"
+fi
 
 need_cmd tar
 need_cmd grep


### PR DESCRIPTION
## Summary

Addresses #11. Google publishes no Chrome build for Linux/arm64, so the Chrome/CDP full-track backend was effectively amd64-only and arm64 fell back to WebKit 30-second previews. This adds an arm64 path that uses a system-installed Chromium plus a system-registered Widevine CDM instead of downloading a browser.

amd64 and macOS behavior is unchanged.

## How it works on arm64

- **Discovery instead of download.** On arm64, `EnsureBrowser` no longer downloads Chrome. It discovers a system browser (preferring the real `/usr/lib/chromium/chromium` binary over launcher wrappers, with `VIBEZ_CHROME_PATH` / `CHROME_PATH` overrides) and a registered Widevine CDM.
- **`cdp.Available()`** replaces the `runtime.GOARCH == "amd64"` gate in `root_linux.go`. CDP is selected on arm64 only when both a browser and a CDM are present; otherwise the existing WebKit preview fallback still applies.
- **Persistent profile + one-time warm-up.** This was the non-obvious part. A system Chromium registers its preinstalled Widevine CDM through the component-updater, which writes a "hint file" into the *profile* on first launch that only takes effect on a subsequent launch. So the arm64 path launches via a persistent user-data-dir (`~/.cache/vibez/chromium-arm64`) and warms the CDM up once during `EnsureBrowser`. An ephemeral profile (the default `Launch`) would never load Widevine.
- The amd64-only `vibez-helper` hard link and explicit `--widevine-path` are skipped on arm64 (Chromium locates its registered CDM itself).

## Verification

Tested on an Apple Silicon MacBook running Arch Linux ARM (aarch64, glibc 2.43), Chromium 150, with the `widevine` package (4.10.2891.0) installed:

- An EME check — `navigator.requestMediaKeySystemAccess('com.widevine.alpha', …)` — resolves and creates MediaKeys, with a ClearKey control also passing.
- A real Apple Music track plays full-length (well past the 30-second preview boundary) through the CDP backend.
- `make build`, `go vet ./...`, and the full `go test ./...` suite pass. The `cdp` tests are split by arch build tag (`browser_amd64_test.go` / `browser_arm64_test.go`) with new arm64 coverage for discovery, `Available()`, and launch args.

## Requirements for arm64 users

- A system Chromium and a Widevine CDM — for example `pacman -S chromium widevine` on Arch Linux ARM (glibc ≥ 2.36).
- Build from source with `make build`.

## Follow-ups (intentionally not in this PR)

- Publishing prebuilt arm64 release binaries. The Linux build is `CGO_ENABLED=1` (webkit), so it needs an aarch64 cross-toolchain or a native arm64 runner; `.goreleaser.yml` and CI still produce amd64 only, with the reason documented inline. Happy to follow up on arm64 artifacts if that's wanted.
- Flatpak `aarch64`.

Feedback very welcome on the approach — especially the "discover a system Chromium" model versus a fully self-contained download. The latter isn't currently practical on arm64 (there's no Google arm64 Chrome, and the Widevine CDM can't be cleanly bundled), but I'm glad to adjust if you'd prefer a different direction.
