### PR TITLE
Fix radio mode when seeded from a single library song; larger refill batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Radio refills pull a larger batch** — Apple's `next-tracks` endpoint returns only ~2 tracks per call, so `GetStationTracks` now pages several times (deduped, up to a target of 10) to give the queue more runway between refills.
+
 ### Fixed
 - **Search failures were reported as empty results** — `Search` queries the library, catalog songs, and catalog albums/playlists in parallel and only returned an error when all three failed, so one dead backend silently produced a thinner result set instead of a failure. Discovery refills then discarded the error entirely, leaving `[vibe] search error: no results` as the only clue. Partial failures are now carried on `SearchResult.Warnings`, logged as `[search] partial results: …`, and named in the "no results" message, so an unreachable backend is distinguishable from a query that genuinely matched nothing. Refs #93.
+- **Radio mode failed to start from a library song** — a per-song station can only be seeded by a catalog song ID; seeding with a library ID (`i.XXXX`) returns HTTP 500. `GetStationTracks` now resolves a library seed to its catalog ID (via the song's `playParams.catalogId`) before starting the station, and reports a clear error when a library song has no catalog equivalent. Radio seeded from a playlist already worked because those tracks carry catalog IDs.
 
 ## [0.5.0] — 2026-07-10
 

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -1176,16 +1176,46 @@ type stationTracksResponse struct {
 	Data []songResource `json:"data"`
 }
 
-// GetStationTracks fetches a batch of tracks for an Apple Music radio
-// station seeded by the given catalog song ID. "ra.<songID>" is Apple's
-// synthetic per-song radio station ID — POSTing to its next-tracks endpoint
-// starts/continues that station without a separately created station
-// resource. Verified against the live API: next-tracks without an ID only
-// accepts GET, and next-tracks/{id} only accepts POST with a body (an empty
-// object is sufficient — the ID alone carries the seed).
-func (a *AppleProvider) GetStationTracks(ctx context.Context, seedCatalogID string) ([]provider.Track, error) {
-	endpoint := "/me/stations/next-tracks/ra." + url.PathEscape(seedCatalogID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+endpoint, strings.NewReader("{}")) //nolint:gosec // G107: URL is constructed from config, not user input
+// stationBatchTarget/stationMaxCalls bound how many upcoming tracks a single
+// refill pulls. Apple's next-tracks endpoint returns only ~2 tracks per call,
+// so we page a few times (each POST advances the station) to give the queue
+// meaningful runway, without issuing an unbounded number of requests.
+const (
+	stationBatchTarget = 10
+	stationMaxCalls    = 6
+)
+
+// resolveCatalogSongID maps a library song ID ("i.XXXX") to its Apple Music
+// catalog song ID via the song's playParams.catalogId. A station can only be
+// seeded by a catalog ID — seeding with a library ID returns HTTP 500. Returns
+// an error if the song has no catalog equivalent (e.g. an uploaded/unmatched
+// track), for which no per-song station exists.
+func (a *AppleProvider) resolveCatalogSongID(ctx context.Context, libraryID string) (string, error) {
+	endpoint := "/me/library/songs/" + url.PathEscape(libraryID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.baseURL+endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.cfg.AppleDeveloperToken)
+	req.Header.Set("Music-User-Token", a.cfg.AppleUserToken)
+
+	var resp stationTracksResponse // same shape: { data: [songResource] }
+	if err := a.do(req, &resp); err != nil {
+		return "", err
+	}
+	if len(resp.Data) == 0 || resp.Data[0].Attributes.PlayParams == nil || resp.Data[0].Attributes.PlayParams.CatalogID == "" {
+		return "", fmt.Errorf("library song %q has no Apple Music catalog equivalent", libraryID)
+	}
+	return resp.Data[0].Attributes.PlayParams.CatalogID, nil
+}
+
+// stationNextTracksPage fetches one batch (~2 tracks) of upcoming tracks for the
+// per-song station ra.<catalogID>. Each POST advances the station. next-tracks
+// without an ID only accepts GET; next-tracks/{id} only accepts POST with a body
+// (an empty object suffices — the ID carries the seed).
+func (a *AppleProvider) stationNextTracksPage(ctx context.Context, catalogID string) ([]provider.Track, error) {
+	endpoint := "/me/stations/next-tracks/ra." + url.PathEscape(catalogID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+endpoint, strings.NewReader("{}")) //nolint:gosec // G107: URL is constructed from a resolved catalog ID, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -1195,13 +1225,58 @@ func (a *AppleProvider) GetStationTracks(ctx context.Context, seedCatalogID stri
 
 	var resp stationTracksResponse
 	if err := a.do(req, &resp); err != nil {
-		return nil, fmt.Errorf("GetStationTracks: %w", err)
+		return nil, err
 	}
 	tracks := make([]provider.Track, 0, len(resp.Data))
 	for _, s := range resp.Data {
 		tracks = append(tracks, toTrack(s))
 	}
 	return tracks, nil
+}
+
+// GetStationTracks returns a batch of upcoming tracks for the Apple Music radio
+// station seeded by the given song. "ra.<catalogSongID>" is Apple's synthetic
+// per-song station ID. The seed MUST be a catalog song ID; a library ID
+// ("i.XXXX") is resolved to its catalog ID first (a raw library seed 500s).
+// Because each next-tracks call yields only ~2 tracks, several pages are
+// accumulated (deduped) up to stationBatchTarget so refills have runway.
+func (a *AppleProvider) GetStationTracks(ctx context.Context, seed string) ([]provider.Track, error) {
+	if strings.HasPrefix(seed, "i.") {
+		catalogID, err := a.resolveCatalogSongID(ctx, seed)
+		if err != nil {
+			return nil, fmt.Errorf("GetStationTracks: resolve catalog id: %w", err)
+		}
+		seed = catalogID
+	}
+
+	var out []provider.Track
+	seen := make(map[string]bool)
+	for calls := 0; len(out) < stationBatchTarget && calls < stationMaxCalls; calls++ {
+		page, err := a.stationNextTracksPage(ctx, seed)
+		if err != nil {
+			if len(out) > 0 {
+				break // return what we already have rather than fail the refill
+			}
+			return nil, fmt.Errorf("GetStationTracks: %w", err)
+		}
+		added := 0
+		for _, t := range page {
+			key := t.ID
+			if key == "" {
+				key = t.CatalogID
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, t)
+			added++
+		}
+		if added == 0 {
+			break // station returned nothing new — stop paging
+		}
+	}
+	return out, nil
 }
 
 // ratingRequest is the body for PUT /v1/me/ratings/songs/{id}.

--- a/internal/provider/apple/apple_test.go
+++ b/internal/provider/apple/apple_test.go
@@ -1127,6 +1127,94 @@ func TestGetStationTracks_HTTPError(t *testing.T) {
 	}
 }
 
+func TestGetStationTracks_Batches(t *testing.T) {
+	// Apple returns ~2 tracks per next-tracks call; GetStationTracks should page
+	// several times and accumulate a larger, deduped batch.
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		n := calls.Add(1)
+		writeJSON(t, w, map[string]any{"data": []any{
+			songJSON("s"+strconv.FormatInt(n*2-1, 10), "T", "A", "Al", 200000, ""),
+			songJSON("s"+strconv.FormatInt(n*2, 10), "T", "A", "Al", 200000, ""),
+		}})
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	tracks, err := p.GetStationTracks(context.Background(), "500")
+	if err != nil {
+		t.Fatalf("GetStationTracks: %v", err)
+	}
+	if len(tracks) != 10 {
+		t.Fatalf("expected 10 accumulated tracks, got %d (server calls=%d)", len(tracks), calls.Load())
+	}
+}
+
+func TestGetStationTracks_ResolvesLibraryID(t *testing.T) {
+	// A library seed ("i.XXXX") 500s at Apple, so it must be resolved to its
+	// catalog id (playParams.catalogId) before seeding the station.
+	var stationPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/me/library/songs/i.LIB1"):
+			writeJSON(t, w, map[string]any{"data": []any{
+				songJSONWithCatalog("i.LIB1", "777", "Lib Song", "Artist", "Album", 200000, ""),
+			}})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "stations/next-tracks/"):
+			stationPath = r.URL.Path
+			writeJSON(t, w, map[string]any{"data": []any{
+				songJSON("1001", "Related", "A", "Al", 200000, ""),
+			}})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	tracks, err := p.GetStationTracks(context.Background(), "i.LIB1")
+	if err != nil {
+		t.Fatalf("GetStationTracks: %v", err)
+	}
+	if !strings.Contains(stationPath, "ra.777") {
+		t.Errorf("station should be seeded with resolved catalog id ra.777, got path %q", stationPath)
+	}
+	if len(tracks) == 0 {
+		t.Error("expected tracks after resolving library id")
+	}
+}
+
+func TestGetStationTracks_LibraryNoCatalog(t *testing.T) {
+	// A library song with no catalog equivalent has no per-song station: error
+	// out cleanly instead of seeding with a doomed library id.
+	var stationCalled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "stations/next-tracks/") {
+			stationCalled.Store(true)
+		}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/me/library/songs/") {
+			writeJSON(t, w, map[string]any{"data": []any{
+				songJSON("i.LIB2", "Uploaded", "Artist", "Album", 200000, ""), // no catalogId
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	if _, err := p.GetStationTracks(context.Background(), "i.LIB2"); err == nil {
+		t.Error("expected error for library song with no catalog equivalent")
+	}
+	if stationCalled.Load() {
+		t.Error("should not hit the station endpoint when the catalog id cannot be resolved")
+	}
+}
+
 // --- LoveSong ---
 
 func TestLoveSong_LoveSuccess(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -92,8 +92,10 @@ type Provider interface {
 	// playlists) from Apple Music based on the user's library and history.
 	GetRecommendations(ctx context.Context) ([]RecommendationGroup, error)
 	// GetStationTracks fetches a batch of tracks for an Apple Music radio
-	// station seeded by the given catalog song ID.
-	GetStationTracks(ctx context.Context, seedCatalogID string) ([]Track, error)
+	// station seeded by the given song. The seed may be a catalog song ID or a
+	// library ID ("i.XXXX"); a library ID is resolved to its catalog ID first,
+	// since a station can only be seeded by a catalog ID.
+	GetStationTracks(ctx context.Context, seed string) ([]Track, error)
 	// AddToPlaylist adds a track to an existing library playlist.
 	// playlistID must be a library playlist ID (e.g. "p.XXXXX").
 	// trackID should be a catalog song ID or a library song ID ("i.XXXXX").


### PR DESCRIPTION
## Summary

Radio mode (`R`) worked when seeded from a playlist but failed when seeded from a single library song, and each refill only pulled ~2 tracks. This fixes the library-song seeding and gives refills more runway.

## Root cause

Verified against the live API: an Apple Music per-song station (`ra.<id>`) only accepts a **catalog** song ID. Seeding with a **library** ID (`i.XXXX`) returns HTTP 500 ("Service failure: Stations"). Playlist tracks carry catalog IDs, so playlist-seeded radio worked; a library single song's ID is `i.XXXX`, so `GetStationTracks` sent `ra.i.XXXX` and the station failed.

## Changes

- `GetStationTracks` resolves a library seed to its catalog ID before seeding the station, using the song's `playParams.catalogId` from `GET /me/library/songs/{id}`. When a library song has no catalog equivalent (e.g. an uploaded/unmatched track), it returns a clear error instead of a doomed 500.
- Because `next-tracks` returns only ~2 tracks per call, `GetStationTracks` now pages a few times (deduped, up to a target of 10) so refills give the queue meaningful runway.
- Added provider tests: multi-page batching, library-ID → catalog-ID resolution, and the no-catalog error path.

## Verification

- Live API: `ra.<catalogId>` → 200 with tracks; `ra.i.<libraryId>` → 500; resolving the library song's `playParams.catalogId` then seeding → 200. Repeated `next-tracks` calls return fresh tracks (10 unique across 5 calls), which is what the batching relies on.
- `make build`, `go vet ./...`, the full `go test ./...` suite, and `golangci-lint` are all clean.

## Not included (follow-up)

There's a separate issue where radio can stop advancing after a track — a client-side auto-advance stall in the MusicKit JS queue (`playbackStateDidChange` → "completed" handler), unrelated to seeding. That needs runtime logs to pin down and will be a separate change.
