### PR TITLE
fix(search): surface partial provider failures instead of empty results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: musickit-js-test
         name: musickit js test
-        language: node
+        language: system
         entry: node internal/player/web/musickit_test.mjs
         files: '^internal/player/(web|webkit/web)/musickit'
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Search failures were reported as empty results** — `Search` queries the library, catalog songs, and catalog albums/playlists in parallel and only returned an error when all three failed, so one dead backend silently produced a thinner result set instead of a failure. Discovery refills then discarded the error entirely, leaving `[vibe] search error: no results` as the only clue. Partial failures are now carried on `SearchResult.Warnings`, logged as `[search] partial results: …`, and named in the "no results" message, so an unreachable backend is distinguishable from a query that genuinely matched nothing. Refs #93.
+
 ## [0.5.0] — 2026-07-10
 
 ### Added

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -464,6 +464,19 @@ func (a *AppleProvider) Search(ctx context.Context, query string) (*provider.Sea
 
 	result := &provider.SearchResult{}
 
+	// A single failing leg is not fatal: the other two still carry usable
+	// results. Record it so callers can report an incomplete search instead of
+	// presenting it as an empty one.
+	if lib.err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("library search: %v", lib.err))
+	}
+	if catSongs.err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("catalog song search: %v", catSongs.err))
+	}
+	if catColl.err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("catalog album/playlist search: %v", catColl.err))
+	}
+
 	// Library songs first — guaranteed playable.
 	seen := make(map[string]bool)
 	if lib.err == nil {

--- a/internal/provider/apple/apple_test.go
+++ b/internal/provider/apple/apple_test.go
@@ -263,6 +263,65 @@ func TestSearch_EmptyResults(t *testing.T) {
 	}
 }
 
+func TestSearch_PartialFailureRecordedAsWarning(t *testing.T) {
+	// One failing leg must not look like an empty catalog. When the catalog-song
+	// search fails but the library and album/playlist legs succeed, Search still
+	// returns the library results — and must say the result is incomplete.
+	libSong := songJSON("i.AbCdEf", "Humble", "Kendrick Lamar", "DAMN.", 212000, "")
+	libResp := map[string]any{
+		"results": map[string]any{
+			"library-songs":     map[string]any{"data": []any{libSong}},
+			"library-playlists": map[string]any{"data": []any{}},
+		},
+	}
+	empty := map[string]any{"results": map[string]any{}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/me/library/search"):
+			writeJSON(t, w, libResp)
+		case r.URL.Query().Get("types") == "songs":
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			writeJSON(t, w, empty)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	result, err := p.Search(context.Background(), "humble")
+	if err != nil {
+		t.Fatalf("Search: got error %v, want nil (two legs succeeded)", err)
+	}
+	if len(result.Tracks) != 1 || result.Tracks[0].ID != "i.AbCdEf" {
+		t.Errorf("Tracks: got %+v, want the library song", result.Tracks)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Warnings: got %d (%v), want 1", len(result.Warnings), result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0], "catalog song search") {
+		t.Errorf("Warnings[0] = %q, want it to name the catalog song search", result.Warnings[0])
+	}
+}
+
+func TestSearch_NoWarningsWhenAllLegsSucceed(t *testing.T) {
+	empty := map[string]any{"results": map[string]any{}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		searchHandler(t, w, r, empty, empty)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	result, err := p.Search(context.Background(), "zzznoresults")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("Warnings: got %v, want none — an empty result is not a failure", result.Warnings)
+	}
+}
+
 func TestSearch_QueryEncoded(t *testing.T) {
 	var gotURLs []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -53,6 +53,12 @@ type SearchResult struct {
 	Tracks    []Track
 	Albums    []Album
 	Playlists []Playlist
+
+	// Warnings carries non-fatal failures from providers that query several
+	// backends in parallel and return whatever succeeded. Without it a caller
+	// cannot distinguish "nothing matched the query" from "one backend is
+	// down and these results are incomplete".
+	Warnings []string
 }
 
 type Provider interface {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -148,9 +148,10 @@ type vibeResultMsg struct {
 	query     string
 	tracks    []provider.Track
 	err       error
-	discovery bool // true when result is from a discovery auto-refill
-	radio     bool // true when result is from a radio auto-refill
-	radioGen  int  // radio generation that produced this result
+	warnings  []string // non-fatal provider failures behind an incomplete result
+	discovery bool     // true when result is from a discovery auto-refill
+	radio     bool     // true when result is from a radio auto-refill
+	radioGen  int      // radio generation that produced this result
 }
 type loveSongMsg struct {
 	title string
@@ -721,6 +722,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			break
 		}
+		// A result can succeed and still be incomplete when one provider backend
+		// failed. Say so: otherwise a thin result set reads as a sparse catalog
+		// rather than a broken backend.
+		if len(msg.warnings) > 0 {
+			m.appendLog(fmt.Sprintf("[search] partial results: %s", strings.Join(msg.warnings, "; ")))
+		}
+
 		// For discovery/radio results, drop any track that arrived in the
 		// blacklist while the search was in flight (race between search
 		// goroutine and a concurrent goSkipped notification), and also drop
@@ -842,6 +850,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.search.SetResults(nil, false, msg.err)
 		} else {
 			if msg.result != nil {
+				if len(msg.result.Warnings) > 0 {
+					m.appendLog(fmt.Sprintf("[search] partial results: %s",
+						strings.Join(msg.result.Warnings, "; ")))
+				}
 				m.appendLog(fmt.Sprintf("[search] %d track(s), %d album(s), %d playlist(s)",
 					len(msg.result.Tracks), len(msg.result.Albums), len(msg.result.Playlists)))
 			}
@@ -2206,8 +2218,9 @@ func (m *Model) runVibeSearch(query string) tea.Cmd {
 		defer cancel()
 
 		type searchOut struct {
-			tracks []provider.Track
-			err    error
+			tracks   []provider.Track
+			warnings []string
+			err      error
 		}
 		chs := make([]chan searchOut, len(allQueries))
 		for i, q := range allQueries {
@@ -2219,15 +2232,22 @@ func (m *Model) runVibeSearch(query string) tea.Cmd {
 					out <- searchOut{err: err}
 					return
 				}
-				out <- searchOut{tracks: res.Tracks}
+				out <- searchOut{tracks: res.Tracks, warnings: res.Warnings}
 			}(q, ch)
 		}
 
-		// Merge results and deduplicate by (artist, title).
+		// Merge results and deduplicate by (artist, title). Failures and
+		// partial-result warnings are collected rather than dropped: when the
+		// merge comes back empty they are the only explanation available.
 		seen := map[string]bool{}
 		var merged []provider.Track
+		var reasons []string
 		for _, ch := range chs {
 			r := <-ch
+			if r.err != nil {
+				reasons = append(reasons, r.err.Error())
+			}
+			reasons = append(reasons, r.warnings...)
 			for _, t := range r.tracks {
 				key := strings.ToLower(t.Artist + "||" + t.Title)
 				if !seen[key] {
@@ -2240,8 +2260,18 @@ func (m *Model) runVibeSearch(query string) tea.Cmd {
 		if len(merged) == 0 {
 			// Fallback to raw input.
 			res, err := prov.Search(ctx, query)
+			if err != nil {
+				reasons = append(reasons, err.Error())
+			}
+			if res != nil {
+				reasons = append(reasons, res.Warnings...)
+			}
 			if err != nil || res == nil || len(res.Tracks) == 0 {
-				return vibeResultMsg{query: query, err: fmt.Errorf("no results for %q", query)}
+				return vibeResultMsg{
+					query:    query,
+					err:      noResultsError(query, reasons),
+					warnings: dedupeStrings(reasons),
+				}
 			}
 			merged = res.Tracks
 		}
@@ -2253,8 +2283,38 @@ func (m *Model) runVibeSearch(query string) tea.Cmd {
 		if len(merged) > cap {
 			merged = merged[:cap]
 		}
-		return vibeResultMsg{query: query, tracks: merged}
+		return vibeResultMsg{query: query, tracks: merged, warnings: dedupeStrings(reasons)}
 	}
+}
+
+// noResultsError builds the error shown when a search yields nothing. The
+// reasons, when present, distinguish an empty catalog match from a backend
+// that failed — the two are indistinguishable to a user otherwise.
+func noResultsError(query string, reasons []string) error {
+	reasons = dedupeStrings(reasons)
+	if len(reasons) == 0 {
+		return fmt.Errorf("no results for %q", query)
+	}
+	return fmt.Errorf("no results for %q (%s)", query, strings.Join(reasons, "; "))
+}
+
+// dedupeStrings returns s without duplicates, preserving order. Parallel
+// searches against one provider report the same backend failure once per
+// query, so the raw list is mostly repetition.
+func dedupeStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(s))
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
 }
 
 // loveSongCmd calls provider.LoveSong asynchronously and returns a loveSongMsg.
@@ -2375,7 +2435,11 @@ func (m *Model) runDiscoverySearch() tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
-		type out struct{ tracks []provider.Track }
+		type out struct {
+			tracks   []provider.Track
+			warnings []string
+			err      error
+		}
 		chs := make([]chan out, len(queries))
 		for i, q := range queries {
 			ch := make(chan out, 1)
@@ -2383,17 +2447,22 @@ func (m *Model) runDiscoverySearch() tea.Cmd {
 			go func(term string, c chan out) {
 				res, err := prov.Search(ctx, term)
 				if err != nil || res == nil {
-					c <- out{}
+					c <- out{err: err}
 					return
 				}
-				c <- out{tracks: res.Tracks}
+				c <- out{tracks: res.Tracks, warnings: res.Warnings}
 			}(q, ch)
 		}
 
 		seen := map[string]bool{}
 		var merged []provider.Track
+		var reasons []string
 		for _, ch := range chs {
 			r := <-ch
+			if r.err != nil {
+				reasons = append(reasons, r.err.Error())
+			}
+			reasons = append(reasons, r.warnings...)
 			for _, t := range r.tracks {
 				id := views.PlaybackID(t)
 				key := strings.ToLower(t.Artist + "||" + t.Title)
@@ -2414,9 +2483,17 @@ func (m *Model) runDiscoverySearch() tea.Cmd {
 			merged = merged[:refillCap]
 		}
 		if len(merged) == 0 {
-			return vibeResultMsg{discovery: true, err: fmt.Errorf("no results")}
+			reasons := dedupeStrings(reasons)
+			if len(reasons) == 0 {
+				return vibeResultMsg{discovery: true, err: errors.New("no results")}
+			}
+			return vibeResultMsg{
+				discovery: true,
+				err:       fmt.Errorf("no results (%s)", strings.Join(reasons, "; ")),
+				warnings:  reasons,
+			}
 		}
-		return vibeResultMsg{discovery: true, tracks: merged}
+		return vibeResultMsg{discovery: true, tracks: merged, warnings: dedupeStrings(reasons)}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3471,3 +3471,52 @@ func TestQueueReordering(t *testing.T) {
 		t.Errorf("expected selected index to be 1 after moving down, got %d", idx)
 	}
 }
+
+func TestDedupeStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil input", nil, nil},
+		{"empty input", []string{}, nil},
+		{"drops repeats, keeps order", []string{"b", "a", "b", "a"}, []string{"b", "a"}},
+		{"drops empty strings", []string{"", "a", ""}, []string{"a"}},
+		{"all empty", []string{"", ""}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupeStrings(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("dedupeStrings(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("dedupeStrings(%v)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNoResultsError(t *testing.T) {
+	// Without reasons the message stays as it was.
+	if got := noResultsError("jazz", nil).Error(); got != `no results for "jazz"` {
+		t.Errorf("noResultsError with no reasons = %q", got)
+	}
+
+	// With reasons the cause has to survive into the message — that is the whole
+	// point: a backend failure and an empty catalog match are otherwise identical
+	// from the log.
+	err := noResultsError("jazz", []string{"catalog song search: 401", "catalog song search: 401"})
+	got := err.Error()
+	if !strings.Contains(got, `no results for "jazz"`) {
+		t.Errorf("noResultsError = %q, want it to keep the query", got)
+	}
+	if !strings.Contains(got, "catalog song search: 401") {
+		t.Errorf("noResultsError = %q, want it to name the failing backend", got)
+	}
+	if strings.Count(got, "catalog song search") != 1 {
+		t.Errorf("noResultsError = %q, want the repeated reason collapsed to one", got)
+	}
+}


### PR DESCRIPTION
Refs #93. This is the diagnostics half of that issue, deliberately separate from the fix for the underlying breakage, since that one needs a decision from you about the `extendedAssetUrls` filter.

## The problem

`Search` fans out to three parallel requests — library, catalog songs, catalog albums/playlists — and only returns an error when all three fail (apple.go:461). One dead backend therefore produces a thinner result set with a nil error, and no caller can tell the difference between that and a query nothing matched.

The discovery refill made it worse by dropping its error on the floor entirely (`if err != nil || res == nil { c <- out{} }`), which is why the report in #93 contains nothing more useful than `[vibe] search error: no results` despite the catalog-song backend returning 401 on every request.

## What this changes

- `provider.SearchResult` gains a `Warnings []string` field for non-fatal backend failures.
- `apple.Search` records which leg failed instead of quietly returning less.
- The vibe search and discovery refill collect failures and warnings rather than discarding them, deduplicated because parallel queries against one provider report the same backend failure once per query.
- Warnings are logged as `[search] partial results: …` on both the plain search and the vibe/discovery paths, and named in the `no results` error so the log line carries a cause.

Results themselves are unchanged. A failing leg still contributes nothing, the other legs are still returned, and the success path behaves exactly as before. The vibe panel still shows its usual `no results` state, since it renders a fixed string rather than the error text.

With this applied, the situation in #93 logs as:

```
[search] partial results: catalog song search: apple music api 401 Unauthorized. Re-run `vibez login`; if you're using a local build, also refresh apple_developer_token.
[vibe] search error: no results (catalog song search: apple music api 401 Unauthorized. …)
```

## Tests

- `TestSearch_PartialFailureRecordedAsWarning` — 401 on the catalog-song leg only; asserts a nil error, the library track still returned, and one warning naming the failing leg.
- `TestSearch_NoWarningsWhenAllLegsSucceed` — an empty result is not a failure.
- `TestDedupeStrings`, `TestNoResultsError` — helper behaviour, including that a repeated reason collapses to one.

`go build ./...`, `go vet ./...`, `go test ./...` and `golangci-lint run` all pass.

## The first commit

7fed29f is a one-line tooling fix and unrelated to the rest — happy to pull it into its own PR if you'd rather.

The `musickit-js-test` hook declares `language: node`, which asks pre-commit to build a Node environment by installing the local package. With no `package.json` and no `additional_dependencies`, pre-commit 4.x aborts during environment installation:

```
AssertionError: `language: node` must have package.json or additional_dependencies
```

That fires at install time for every hook in the config, so it blocks any commit regardless of whether the staged files match the hook's own `files` pattern. It's why I couldn't commit this branch until it was fixed.

To be clear about the scope: CI is unaffected today — the `pre-commit` job is green on the other open PRs — so this is a local-environment failure rather than a broken pipeline. It'll reach anyone whose `pre-commit` is current, though, which is why it seemed worth a line rather than a local workaround.

The script has no npm dependencies and only needs a node binary, so `language: system` is the right declaration and matches the four Go hooks above it.
