### PR TITLE
Fix Playwright driver cache upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Playwright driver upgrades failed against an older cache** — Remove Vibez's cached Playwright driver before installing a different bundled version. This prevents upgrades from failing with `driver exists but version not ...`; the separately cached Chrome installation is preserved. Refs #89.
 - **Search failures were reported as empty results** — `Search` queries the library, catalog songs, and catalog albums/playlists in parallel and only returned an error when all three failed, so one dead backend silently produced a thinner result set instead of a failure. Discovery refills then discarded the error entirely, leaving `[vibe] search error: no results` as the only clue. Partial failures are now carried on `SearchResult.Warnings`, logged as `[search] partial results: …`, and named in the "no results" message, so an unreachable backend is distinguishable from a query that genuinely matched nothing. Refs #93.
 
 ## [0.5.0] — 2026-07-10

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -11,7 +11,6 @@
 package cdp
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -65,27 +64,6 @@ func linkHelper() {
 // cache directory if not already present. Never calls apt-get or sudo.
 // onProgress is called with human-readable status strings (e.g. "Downloading
 // Chrome… 42%", "Extracting Chrome…"). Pass func(string){} to silence.
-func isDriverUpToDate() bool {
-	driver, err := playwright.NewDriver(&playwright.RunOptions{
-		DriverDirectory: driverDir(),
-	})
-	if err != nil {
-		return false
-	}
-	pkgJSONPath := filepath.Join(driverDir(), "package", "package.json")
-	data, err := os.ReadFile(pkgJSONPath) //nolint:gosec // path constructed from cache dir
-	if err != nil {
-		return false
-	}
-	var pkg struct {
-		Version string `json:"version"`
-	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return false
-	}
-	return pkg.Version == driver.Version
-}
-
 func EnsureBrowser(onProgress func(string)) error {
 	driverUpToDate := isDriverUpToDate()
 	chromeInstalled := false
@@ -99,13 +77,9 @@ func EnsureBrowser(onProgress func(string)) error {
 	}
 
 	// Also ensure the playwright driver is available (no browser install via playwright).
-	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress("Fetching dependencies…")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-	}); err != nil {
-		return fmt.Errorf("playwright driver: %w", err)
+	if err := installPlaywrightDriver(); err != nil {
+		return err
 	}
 
 	if chromeInstalled {

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -218,13 +218,9 @@ func ensureBrowserARM64(onProgress func(string)) error {
 		return fmt.Errorf("no Widevine CDM found (required for full-track playback); %s", chromeInstallHelpARM64)
 	}
 
-	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress("Fetching dependencies…")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-	}); err != nil {
-		return fmt.Errorf("playwright driver: %w", err)
+	if err := installPlaywrightDriver(); err != nil {
+		return err
 	}
 	if err := warmUpWidevineARM64(onProgress); err != nil {
 		return err

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -83,14 +83,10 @@ func EnsureBrowser(onProgress func(string)) error {
 		return err
 	}
 
-	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress(fmt.Sprintf("Using Google Chrome: %s", chromePath))
 	onProgress("Fetching browser driver...")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-	}); err != nil {
-		return fmt.Errorf("playwright driver: %w", err)
+	if err := installPlaywrightDriver(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/player/cdp/browser_test.go
+++ b/internal/player/cdp/browser_test.go
@@ -322,6 +322,10 @@ func TestEnsureBrowser_AlreadyInstalled(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(pkgJSON), 0o600); err != nil { //nolint:gosec // test fixture
 		t.Fatalf("write driver package.json: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "cli.js"), []byte(driver.Version), 0o600); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write driver CLI: %v", err)
+	}
+	setVersionReportingNode(t)
 
 	var progress []string
 	err = EnsureBrowser(func(s string) { progress = append(progress, s) })

--- a/internal/player/cdp/driver.go
+++ b/internal/player/cdp/driver.go
@@ -1,0 +1,57 @@
+//go:build linux || darwin
+
+package cdp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+func isDriverUpToDate() bool {
+	driver, err := playwright.NewDriver(&playwright.RunOptions{
+		DriverDirectory: driverDir(),
+	})
+	if err != nil {
+		return false
+	}
+	packageJSONPath := filepath.Join(driverDir(), "package", "package.json")
+	data, err := os.ReadFile(packageJSONPath) //nolint:gosec // path constructed from cache dir
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	return pkg.Version == driver.Version
+}
+
+func preparePlaywrightDriverInstall() error {
+	if isDriverUpToDate() {
+		return nil
+	}
+	if err := os.RemoveAll(driverDir()); err != nil {
+		return fmt.Errorf("remove outdated Playwright driver cache: %w", err)
+	}
+	return nil
+}
+
+func installPlaywrightDriver() error {
+	if err := preparePlaywrightDriverInstall(); err != nil {
+		return err
+	}
+	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
+	if err := playwright.Install(&playwright.RunOptions{
+		DriverDirectory:     driverDir(),
+		SkipInstallBrowsers: true,
+	}); err != nil {
+		return fmt.Errorf("playwright driver: %w", err)
+	}
+	return nil
+}

--- a/internal/player/cdp/driver.go
+++ b/internal/player/cdp/driver.go
@@ -3,10 +3,9 @@
 package cdp
 
 import (
-	"encoding/json"
+	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	playwright "github.com/mxschmitt/playwright-go"
 )
@@ -18,18 +17,11 @@ func isDriverUpToDate() bool {
 	if err != nil {
 		return false
 	}
-	packageJSONPath := filepath.Join(driverDir(), "package", "package.json")
-	data, err := os.ReadFile(packageJSONPath) //nolint:gosec // path constructed from cache dir
+	output, err := driver.Command("--version").Output()
 	if err != nil {
 		return false
 	}
-	var pkg struct {
-		Version string `json:"version"`
-	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return false
-	}
-	return pkg.Version == driver.Version
+	return bytes.Contains(output, []byte(driver.Version))
 }
 
 func preparePlaywrightDriverInstall() error {

--- a/internal/player/cdp/driver_test.go
+++ b/internal/player/cdp/driver_test.go
@@ -1,0 +1,180 @@
+//go:build linux || darwin
+
+package cdp
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+const outdatedPlaywrightVersion = "1.57.0"
+
+func playwrightPackageArchive(t *testing.T, version string) []byte {
+	t.Helper()
+
+	files := map[string]string{
+		"package/package.json": fmt.Sprintf(`{"version":%q}`, version),
+		"package/cli.js":       version,
+	}
+	var archive bytes.Buffer
+	gzipWriter := gzip.NewWriter(&archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for name, content := range files {
+		header := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write Playwright package header: %v", err)
+		}
+		if _, err := tarWriter.Write([]byte(content)); err != nil {
+			t.Fatalf("write Playwright package content: %v", err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close Playwright package tar: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close Playwright package gzip: %v", err)
+	}
+	return archive.Bytes()
+}
+
+func setTestCacheHome(t *testing.T) {
+	t.Helper()
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("HOME", cacheHome)
+}
+
+func setVersionReportingNode(t *testing.T) {
+	t.Helper()
+	fakeNodePath := filepath.Join(t.TempDir(), "node")
+	fakeNode := `#!/bin/sh
+printf 'Version '
+cat "$1"
+printf '\n'
+`
+	if err := os.WriteFile(fakeNodePath, []byte(fakeNode), 0o700); err != nil { //nolint:gosec // test fixture must be executable
+		t.Fatalf("write fake Node.js: %v", err)
+	}
+	t.Setenv("PLAYWRIGHT_NODEJS_PATH", fakeNodePath)
+}
+
+func TestInstallPlaywrightDriverReplacesOutdatedCache(t *testing.T) {
+	setTestCacheHome(t)
+
+	driver, err := playwright.NewDriver(&playwright.RunOptions{DriverDirectory: driverDir()})
+	if err != nil {
+		t.Fatalf("create Playwright driver: %v", err)
+	}
+	if driver.Version == outdatedPlaywrightVersion {
+		t.Fatalf("test requires an outdated version, current version is %q", driver.Version)
+	}
+
+	packageDir := filepath.Join(driverDir(), "package")
+	if err := os.MkdirAll(packageDir, 0o750); err != nil {
+		t.Fatalf("create stale driver cache: %v", err)
+	}
+	stalePackageJSON := fmt.Sprintf(`{"version":%q}`, outdatedPlaywrightVersion)
+	if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(stalePackageJSON), 0o600); err != nil {
+		t.Fatalf("write stale driver version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "cli.js"), []byte(outdatedPlaywrightVersion), 0o600); err != nil {
+		t.Fatalf("write stale driver CLI: %v", err)
+	}
+	markerPath := filepath.Join(driverDir(), "stale-marker")
+	if err := os.WriteFile(markerPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale driver marker: %v", err)
+	}
+
+	setVersionReportingNode(t)
+
+	archive := playwrightPackageArchive(t, driver.Version)
+	registry := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		wantPath := fmt.Sprintf("/playwright-core/-/playwright-core-%s.tgz", driver.Version)
+		if request.URL.Path != wantPath {
+			http.NotFound(response, request)
+			return
+		}
+		response.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = response.Write(archive)
+	}))
+	t.Cleanup(registry.Close)
+	t.Setenv("PLAYWRIGHT_GO_NPM_REGISTRY", registry.URL)
+
+	if err := installPlaywrightDriver(); err != nil {
+		t.Fatalf("install Playwright driver over stale cache: %v", err)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("stale driver cache marker still exists: %v", err)
+	}
+	packageJSON, err := os.ReadFile(filepath.Join(packageDir, "package.json")) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read installed driver version: %v", err)
+	}
+	wantPackageJSON := fmt.Sprintf(`{"version":%q}`, driver.Version)
+	if string(packageJSON) != wantPackageJSON {
+		t.Fatalf("installed package.json = %s, want %s", packageJSON, wantPackageJSON)
+	}
+	versionOutput, err := driver.Command("--version").Output()
+	if err != nil {
+		t.Fatalf("run installed driver version probe: %v", err)
+	}
+	wantVersionOutput := fmt.Sprintf("Version %s\n", driver.Version)
+	if string(versionOutput) != wantVersionOutput {
+		t.Fatalf("installed driver version = %q, want %q", versionOutput, wantVersionOutput)
+	}
+	if err := playwright.Install(&playwright.RunOptions{
+		DriverDirectory:     driverDir(),
+		SkipInstallBrowsers: true,
+	}); err != nil {
+		t.Fatalf("validate installed driver on a second install: %v", err)
+	}
+}
+
+func TestPreparePlaywrightDriverInstallPreservesCurrentCache(t *testing.T) {
+	setTestCacheHome(t)
+
+	driver, err := playwright.NewDriver(&playwright.RunOptions{DriverDirectory: driverDir()})
+	if err != nil {
+		t.Fatalf("create Playwright driver: %v", err)
+	}
+	packageDir := filepath.Join(driverDir(), "package")
+	if err := os.MkdirAll(packageDir, 0o750); err != nil {
+		t.Fatalf("create current driver cache: %v", err)
+	}
+	packageJSON := fmt.Sprintf(`{"version":%q}`, driver.Version)
+	if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(packageJSON), 0o600); err != nil {
+		t.Fatalf("write current driver version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "cli.js"), []byte(driver.Version), 0o600); err != nil {
+		t.Fatalf("write current driver CLI: %v", err)
+	}
+	setVersionReportingNode(t)
+	markerPath := filepath.Join(driverDir(), "current-marker")
+	if err := os.WriteFile(markerPath, []byte("current"), 0o600); err != nil {
+		t.Fatalf("write current driver marker: %v", err)
+	}
+
+	if err := preparePlaywrightDriverInstall(); err != nil {
+		t.Fatalf("prepare driver install: %v", err)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("current driver cache was removed: %v", err)
+	}
+	versionOutput, err := driver.Command("--version").Output()
+	if err != nil {
+		t.Fatalf("run preserved driver version probe: %v", err)
+	}
+	wantVersionOutput := fmt.Sprintf("Version %s\n", driver.Version)
+	if string(versionOutput) != wantVersionOutput {
+		t.Fatalf("preserved driver version = %q, want %q", versionOutput, wantVersionOutput)
+	}
+}

--- a/internal/player/cdp/driver_test.go
+++ b/internal/player/cdp/driver_test.go
@@ -139,6 +139,37 @@ func TestInstallPlaywrightDriverReplacesOutdatedCache(t *testing.T) {
 	}
 }
 
+func TestPreparePlaywrightDriverInstallRemovesCacheWithStaleCLI(t *testing.T) {
+	setTestCacheHome(t)
+
+	driver, err := playwright.NewDriver(&playwright.RunOptions{DriverDirectory: driverDir()})
+	if err != nil {
+		t.Fatalf("create Playwright driver: %v", err)
+	}
+	if driver.Version == outdatedPlaywrightVersion {
+		t.Fatalf("test requires an outdated version, current version is %q", driver.Version)
+	}
+	packageDir := filepath.Join(driverDir(), "package")
+	if err := os.MkdirAll(packageDir, 0o750); err != nil {
+		t.Fatalf("create inconsistent driver cache: %v", err)
+	}
+	packageJSON := fmt.Sprintf(`{"version":%q}`, driver.Version)
+	if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(packageJSON), 0o600); err != nil {
+		t.Fatalf("write current driver metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "cli.js"), []byte(outdatedPlaywrightVersion), 0o600); err != nil {
+		t.Fatalf("write stale driver CLI: %v", err)
+	}
+	setVersionReportingNode(t)
+
+	if err := preparePlaywrightDriverInstall(); err != nil {
+		t.Fatalf("prepare driver install: %v", err)
+	}
+	if _, err := os.Stat(driverDir()); !os.IsNotExist(err) {
+		t.Fatalf("inconsistent driver cache still exists: %v", err)
+	}
+}
+
 func TestPreparePlaywrightDriverInstallPreservesCurrentCache(t *testing.T) {
 	setTestCacheHome(t)
 


### PR DESCRIPTION
## Summary
- remove Vibez's stale Playwright driver cache before installing a newly bundled driver version
- validate the cached CLI's actual version so incomplete or inconsistent caches are also repaired
- preserve the separate cached Chrome installation
- share the upgrade handling across Linux and macOS

Refs #89.

## Tests
- `uvx pre-commit run --all-files`
- `PKG_CONFIG_PATH="$PWD/pkg-config" go test -count=1 ./...`
- Darwin amd64 and arm64 CDP test cross-compilation
- Windows amd64 CDP test cross-compilation
