### PR TITLE
fix(mpris): harden track identity updates

### DIFF
--- a/internal/player/mpris/mpris_test.go
+++ b/internal/player/mpris/mpris_test.go
@@ -775,13 +775,132 @@ func TestServer_Update_TrackWithArtwork(t *testing.T) {
 	srv.Update(player.State{Playing: true, Track: track})
 }
 
+func TestServer_Update_TrackWithoutID(t *testing.T) {
+	ctrl := &mockController{}
+	srv, err := NewServer(ctrl)
+	if err != nil {
+		t.Skipf("NewServer failed: %v", err)
+	}
+	defer srv.Close() //nolint:errcheck
+
+	track := &provider.Track{Title: "Partial Track"}
+	srv.Update(player.State{Playing: true, Track: track})
+	time.Sleep(300 * time.Millisecond)
+
+	metadata, ok := srv.props.GetMust(mprisPlayerIface, "Metadata").(map[string]dbus.Variant)
+	if !ok {
+		t.Fatal("Metadata property has unexpected type")
+	}
+	trackID, ok := metadata["mpris:trackid"].Value().(dbus.ObjectPath)
+	if !ok {
+		t.Fatal("mpris:trackid has unexpected type")
+	}
+	want := trackObjectPath(track)
+	if trackID != want {
+		t.Fatalf("mpris:trackid = %q, want %q", trackID, want)
+	}
+}
+
 func TestServer_Close(t *testing.T) {
 	ctrl := &mockController{}
 	srv, err := NewServer(ctrl)
 	if err != nil {
 		t.Skipf("NewServer failed: %v", err)
 	}
-	if err := srv.Close(); err != nil {
+	srv.Update(player.State{Playing: true, Track: &provider.Track{ID: "pending"}})
+
+	// Holding flushMu models a callback already publishing. Close must mark the
+	// server closed immediately, then wait before closing the D-Bus connection.
+	srv.flushMu.Lock()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- srv.Close() }()
+	deadline := time.Now().Add(time.Second)
+	for {
+		srv.mu.Lock()
+		closed := srv.closed
+		srv.mu.Unlock()
+		if closed {
+			break
+		}
+		if time.Now().After(deadline) {
+			srv.flushMu.Unlock()
+			t.Fatal("Close did not mark the server closed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	select {
+	case err := <-closeDone:
+		srv.flushMu.Unlock()
+		t.Fatalf("Close returned before the in-flight flush completed: %v", err)
+	default:
+	}
+	srv.flushMu.Unlock()
+	if err := <-closeDone; err != nil {
 		t.Errorf("Close() error: %v", err)
 	}
+
+	// Pending and post-close updates must not flush against the closed D-Bus connection.
+	srv.Update(player.State{Playing: true, Track: &provider.Track{ID: "closed"}})
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestServer_Update_DistinguishesCollidingTrackIDs(t *testing.T) {
+	ctrl := &mockController{}
+	srv, err := NewServer(ctrl)
+	if err != nil {
+		t.Skipf("NewServer failed: %v", err)
+	}
+	defer srv.Close() //nolint:errcheck
+
+	first := &provider.Track{ID: "i.track/1", Title: "First"}
+	srv.Update(player.State{Playing: true, Track: first})
+	srv.flush()
+
+	second := &provider.Track{ID: "i_track_1", Title: "Second"}
+	srv.Update(player.State{Playing: true, Track: second})
+	srv.flush()
+
+	metadata, ok := srv.props.GetMust(mprisPlayerIface, "Metadata").(map[string]dbus.Variant)
+	if !ok {
+		t.Fatal("Metadata property has unexpected type")
+	}
+	title, ok := metadata["xesam:title"].Value().(string)
+	if !ok {
+		t.Fatal("xesam:title has unexpected type")
+	}
+	if title != second.Title {
+		t.Fatalf("xesam:title = %q, want %q", title, second.Title)
+	}
+}
+
+func TestServer_UpdateAfterBusLossDoesNotPanic(t *testing.T) {
+	ctrl := &mockController{}
+	srv, err := NewServer(ctrl)
+	if err != nil {
+		t.Skipf("NewServer failed: %v", err)
+	}
+
+	srv.Update(player.State{Playing: true, Track: &provider.Track{ID: "track"}})
+	if err := srv.conn.Close(); err != nil {
+		t.Fatalf("close D-Bus connection: %v", err)
+	}
+
+	// flush runs synchronously so any panic fails this test directly.
+	srv.flush()
+
+	srv.mu.Lock()
+	unavailable := srv.unavailable
+	srv.mu.Unlock()
+	if !unavailable {
+		t.Fatal("server remained available after losing its D-Bus connection")
+	}
+
+	srv.Update(player.State{Playing: true, Track: &provider.Track{ID: "ignored"}})
+	srv.mu.Lock()
+	pending := srv.pending
+	srv.mu.Unlock()
+	if pending != nil {
+		t.Fatal("server accepted an update after losing its D-Bus connection")
+	}
+	_ = srv.Close()
 }

--- a/internal/player/mpris/mpris_test.go
+++ b/internal/player/mpris/mpris_test.go
@@ -785,7 +785,7 @@ func TestServer_Update_TrackWithoutID(t *testing.T) {
 
 	track := &provider.Track{Title: "Partial Track"}
 	srv.Update(player.State{Playing: true, Track: track})
-	time.Sleep(300 * time.Millisecond)
+	srv.flush()
 
 	metadata, ok := srv.props.GetMust(mprisPlayerIface, "Metadata").(map[string]dbus.Variant)
 	if !ok {

--- a/internal/player/mpris/server.go
+++ b/internal/player/mpris/server.go
@@ -91,7 +91,10 @@ func trackObjectPath(track *provider.Track) dbus.ObjectPath {
 			_, _ = hash.Write(fieldLength[:])
 			_, _ = hash.Write([]byte(field))
 		}
-		binary.BigEndian.PutUint64(fieldLength[:], uint64(track.Duration))
+		// int64 -> uint64 reinterprets the bits rather than losing them, so the
+		// hash stays injective over Duration. Clamping a negative value would
+		// instead fold distinct tracks onto the same digest.
+		binary.BigEndian.PutUint64(fieldLength[:], uint64(track.Duration)) //nolint:gosec // bijective conversion; hash input only
 		_, _ = hash.Write(fieldLength[:])
 		copy(sum[:], hash.Sum(nil))
 	} else {

--- a/internal/player/mpris/server.go
+++ b/internal/player/mpris/server.go
@@ -14,8 +14,9 @@ package mpris
 //	go func() { for st := range audioEngine.Subscribe() { srv.Update(st) } }()
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/godbus/dbus/v5/prop"
 
 	"github.com/simone-vibes/vibez/internal/player"
+	"github.com/simone-vibes/vibez/internal/provider"
 )
 
 const (
@@ -49,25 +51,57 @@ type Server struct {
 	conn  *dbus.Conn
 	props *prop.Properties
 
-	mu          sync.Mutex
-	pos         time.Duration
-	lastStatus  string
-	lastTrackID string
-	lastPos     time.Duration // position at the previous flush, for seek detection
-	lastPosAt   time.Time     // wall-clock time lastPos was sampled
-	debounce    *time.Timer
-	pending     *player.State
+	mu                   sync.Mutex
+	flushMu              sync.Mutex
+	pos                  time.Duration
+	lastStatus           string
+	lastTrackID          string
+	lastPos              time.Duration // position at the previous flush, for seek detection
+	lastPosAt            time.Time     // wall-clock time lastPos was sampled
+	currentTrackPath     dbus.ObjectPath
+	currentTrackDuration time.Duration
+	hasCurrentTrack      bool
+	debounce             *time.Timer
+	pending              *player.State
+	unavailable          bool
+	closed               bool
 }
 
-// sanitizePathElement replaces any character that is not a valid D-Bus object
-// path element character ([A-Za-z0-9_]) with an underscore.
-func sanitizePathElement(s string) string {
-	return strings.Map(func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			return r
+// MusicKit can expose a partial now-playing item with no ID during a track
+// transition. Hashing the strongest available identity keeps paths valid and
+// bounded without conflating IDs that differ only by D-Bus path punctuation.
+func trackObjectPath(track *provider.Track) dbus.ObjectPath {
+	if track == nil {
+		return noTrackPath
+	}
+
+	namespace := "id"
+	identity := track.ID
+	if identity == "" {
+		namespace = "catalog"
+		identity = track.CatalogID
+	}
+	var sum [sha256.Size]byte
+	if identity == "" {
+		namespace = "unknown"
+		hash := sha256.New()
+		var fieldLength [8]byte
+		for _, field := range []string{track.Title, track.Artist, track.Album} {
+			binary.BigEndian.PutUint64(fieldLength[:], uint64(len(field)))
+			_, _ = hash.Write(fieldLength[:])
+			_, _ = hash.Write([]byte(field))
 		}
-		return '_'
-	}, s)
+		binary.BigEndian.PutUint64(fieldLength[:], uint64(track.Duration))
+		_, _ = hash.Write(fieldLength[:])
+		copy(sum[:], hash.Sum(nil))
+	} else {
+		sum = sha256.Sum256([]byte(identity))
+	}
+	path := dbus.ObjectPath(fmt.Sprintf("/org/vibez/track/%s_%x", namespace, sum))
+	if !path.IsValid() {
+		panic(fmt.Sprintf("mpris: generated invalid track path %q", path))
+	}
+	return path
 }
 
 // ── D-Bus method objects ──────────────────────────────────────────────────
@@ -107,9 +141,22 @@ func (p *playerObj) seekRelative(offsetUs int64) *dbus.Error {
 	return nil
 }
 
-// setPosition seeks to an absolute position (µs) for the given track ID.
-func (p *playerObj) setPosition(_ dbus.ObjectPath, posUs int64) *dbus.Error {
-	_ = p.ctrl.Seek(time.Duration(posUs) * time.Microsecond)
+// setPosition seeks to an absolute position (µs) only when the supplied track
+// is still current. MPRIS clients can race a track transition with this call.
+func (p *playerObj) setPosition(trackPath dbus.ObjectPath, posUs int64) *dbus.Error {
+	const maxPositionUs = int64(time.Duration(1<<63-1) / time.Microsecond)
+	if posUs < 0 || posUs > maxPositionUs {
+		return nil
+	}
+	position := time.Duration(posUs) * time.Microsecond
+
+	p.srv.mu.Lock()
+	isCurrent := p.srv.hasCurrentTrack && trackPath == p.srv.currentTrackPath
+	withinTrack := p.srv.currentTrackDuration == 0 || position <= p.srv.currentTrackDuration
+	p.srv.mu.Unlock()
+	if isCurrent && withinTrack {
+		_ = p.ctrl.Seek(position)
+	}
 	return nil
 }
 
@@ -240,7 +287,18 @@ func NewServer(ctrl Controller) (*Server, error) {
 // the audio engine emits a new State on its Subscribe channel.
 func (s *Server) Update(st player.State) {
 	s.mu.Lock()
+	if s.closed || s.unavailable {
+		s.mu.Unlock()
+		return
+	}
 	s.pos = st.Position
+	s.currentTrackPath = trackObjectPath(st.Track)
+	s.hasCurrentTrack = st.Track != nil
+	if st.Track == nil {
+		s.currentTrackDuration = 0
+	} else {
+		s.currentTrackDuration = st.Track.Duration
+	}
 	s.pending = &st
 	if s.debounce == nil {
 		s.debounce = time.AfterFunc(100*time.Millisecond, s.flush)
@@ -275,10 +333,38 @@ func isSeek(playing bool, lastPos time.Duration, lastAt time.Time, newPos time.D
 	return delta > seekThreshold
 }
 
+// trySetProperty contains godbus's panic-on-error API. MPRIS is optional, so
+// malformed provider metadata or a lost session bus must not terminate vibez.
+func (s *Server) trySetProperty(name string, value any) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			s.markUnavailable()
+			ok = false
+		}
+	}()
+	s.props.SetMust(mprisPlayerIface, name, value)
+	return true
+}
+
+func (s *Server) markUnavailable() {
+	s.mu.Lock()
+	s.unavailable = true
+	if s.debounce != nil {
+		s.debounce.Stop()
+		s.debounce = nil
+	}
+	s.pending = nil
+	s.mu.Unlock()
+	_ = s.conn.Close()
+}
+
 func (s *Server) flush() {
+	s.flushMu.Lock()
+	defer s.flushMu.Unlock()
+
 	s.mu.Lock()
 	st := s.pending
-	if st == nil {
+	if st == nil || s.closed {
 		s.mu.Unlock()
 		return
 	}
@@ -288,10 +374,8 @@ func (s *Server) flush() {
 	if st.Playing {
 		status = "Playing"
 	}
-	trackID := ""
-	if st.Track != nil {
-		trackID = st.Track.ID
-	}
+	trackPath := trackObjectPath(st.Track)
+	trackID := string(trackPath)
 
 	statusChanged := status != s.lastStatus
 	trackChanged := trackID != s.lastTrackID
@@ -315,8 +399,13 @@ func (s *Server) flush() {
 	// Seeked signal (the Position property does not emit PropertiesChanged).
 	// Refresh Position first so a client reading it in response gets the new value.
 	if seeked {
-		s.props.SetMust(mprisPlayerIface, "Position", st.Position.Microseconds())
-		_ = s.conn.Emit(mprisObjectPath, mprisPlayerIface+".Seeked", st.Position.Microseconds())
+		if !s.trySetProperty("Position", st.Position.Microseconds()) {
+			return
+		}
+		if err := s.conn.Emit(mprisObjectPath, mprisPlayerIface+".Seeked", st.Position.Microseconds()); err != nil {
+			s.markUnavailable()
+			return
+		}
 		if !statusChanged && !trackChanged {
 			return
 		}
@@ -326,7 +415,7 @@ func (s *Server) flush() {
 		"mpris:trackid": dbus.MakeVariant(noTrackPath),
 	}
 	if t := st.Track; t != nil {
-		meta["mpris:trackid"] = dbus.MakeVariant(dbus.ObjectPath("/org/vibez/track/" + sanitizePathElement(t.ID)))
+		meta["mpris:trackid"] = dbus.MakeVariant(trackPath)
 		meta["xesam:title"] = dbus.MakeVariant(t.Title)
 		meta["xesam:artist"] = dbus.MakeVariant([]string{t.Artist})
 		meta["xesam:album"] = dbus.MakeVariant(t.Album)
@@ -336,11 +425,17 @@ func (s *Server) flush() {
 		}
 	}
 
-	s.props.SetMust(mprisPlayerIface, "PlaybackStatus", status)
-	s.props.SetMust(mprisPlayerIface, "Metadata", meta)
-	s.props.SetMust(mprisPlayerIface, "Position", st.Position.Microseconds())
-	if st.Volume > 0 {
-		s.props.SetMust(mprisPlayerIface, "Volume", st.Volume)
+	if !s.trySetProperty("PlaybackStatus", status) {
+		return
+	}
+	if !s.trySetProperty("Metadata", meta) {
+		return
+	}
+	if !s.trySetProperty("Position", st.Position.Microseconds()) {
+		return
+	}
+	if st.Volume > 0 && !s.trySetProperty("Volume", st.Volume) {
+		return
 	}
 
 	loopStatus := "None"
@@ -350,11 +445,28 @@ func (s *Server) flush() {
 	case player.RepeatModeAll:
 		loopStatus = "Playlist"
 	}
-	s.props.SetMust(mprisPlayerIface, "LoopStatus", loopStatus)
-	s.props.SetMust(mprisPlayerIface, "Shuffle", st.ShuffleMode)
+	if !s.trySetProperty("LoopStatus", loopStatus) {
+		return
+	}
+	_ = s.trySetProperty("Shuffle", st.ShuffleMode)
 }
 
 // Close releases the session bus connection.
 func (s *Server) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	if s.debounce != nil {
+		s.debounce.Stop()
+		s.debounce = nil
+	}
+	s.pending = nil
+	s.mu.Unlock()
+
+	s.flushMu.Lock()
+	defer s.flushMu.Unlock()
 	return s.conn.Close()
 }

--- a/internal/player/mpris/server_test.go
+++ b/internal/player/mpris/server_test.go
@@ -3,8 +3,13 @@
 package mpris
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/simone-vibes/vibez/internal/provider"
 )
 
 // isSeek distinguishes a deliberate seek from normal playback progression.
@@ -60,5 +65,118 @@ func TestIsSeek_SubThresholdJitter(t *testing.T) {
 	// A sub-threshold discrepancy (timing jitter) is not a seek.
 	if isSeek(true, 10*time.Second, base, 11500*time.Millisecond, base.Add(time.Second)) {
 		t.Error("sub-threshold jitter should not be a seek")
+	}
+}
+
+func TestTrackObjectPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		track      *provider.Track
+		wantPrefix string
+	}{
+		{name: "nil track uses no-track path"},
+		{name: "primary ID", track: &provider.Track{ID: "12345"}, wantPrefix: "/org/vibez/track/id_"},
+		{name: "catalog ID", track: &provider.Track{CatalogID: "67890"}, wantPrefix: "/org/vibez/track/catalog_"},
+		{name: "ID with path separators", track: &provider.Track{ID: "i.track/1"}, wantPrefix: "/org/vibez/track/id_"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := trackObjectPath(test.track)
+			if !got.IsValid() {
+				t.Fatalf("trackObjectPath(%+v) produced invalid D-Bus path %q", test.track, got)
+			}
+			if test.track == nil {
+				if got != noTrackPath {
+					t.Fatalf("trackObjectPath(nil) = %q, want %q", got, noTrackPath)
+				}
+				return
+			}
+			if !strings.HasPrefix(string(got), test.wantPrefix) {
+				t.Fatalf("trackObjectPath(%+v) = %q, want prefix %q", test.track, got, test.wantPrefix)
+			}
+			if again := trackObjectPath(test.track); again != got {
+				t.Fatalf("trackObjectPath(%+v) is unstable: first %q, then %q", test.track, got, again)
+			}
+		})
+	}
+}
+
+func TestTrackObjectPath_DistinguishesIdentitySourcesAndRawIDs(t *testing.T) {
+	tracks := []*provider.Track{
+		{ID: "i.track/1"},
+		{ID: "i_track_1"},
+		{ID: "catalog_67890"},
+		{CatalogID: "67890"},
+		{Title: "a", Artist: "b\x00c", Album: "d", Duration: 1},
+		{Title: "a\x00b", Artist: "c", Album: "d", Duration: 1},
+	}
+	seen := make(map[string]*provider.Track, len(tracks))
+	for _, track := range tracks {
+		path := trackObjectPath(track)
+		if previous, exists := seen[string(path)]; exists {
+			t.Fatalf("tracks %+v and %+v share object path %q", previous, track, path)
+		}
+		seen[string(path)] = track
+	}
+}
+
+func TestTrackObjectPath_MissingIDUsesStableTrackIdentity(t *testing.T) {
+	track := &provider.Track{Title: "Partial Track", Artist: "Artist", Album: "Album", Duration: time.Minute}
+	got := trackObjectPath(track)
+	if !got.IsValid() {
+		t.Fatalf("trackObjectPath() produced invalid D-Bus path %q", got)
+	}
+	if got == noTrackPath {
+		t.Fatalf("trackObjectPath() = no-track path %q for a current track", got)
+	}
+	if again := trackObjectPath(track); again != got {
+		t.Fatalf("trackObjectPath() is unstable: first %q, then %q", got, again)
+	}
+	other := &provider.Track{Title: "Other Partial Track", Artist: track.Artist, Album: track.Album, Duration: track.Duration}
+	if otherPath := trackObjectPath(other); otherPath == got {
+		t.Fatalf("distinct partial tracks share object path %q", got)
+	}
+}
+
+func TestPlayerObj_SetPositionValidatesTrackAndPosition(t *testing.T) {
+	current := &provider.Track{ID: "current", Duration: 10 * time.Second}
+	currentPath := trackObjectPath(current)
+	tests := []struct {
+		name      string
+		trackPath dbus.ObjectPath
+		position  int64
+	}{
+		{name: "stale track", trackPath: trackObjectPath(&provider.Track{ID: "stale"}), position: int64((5 * time.Second).Microseconds())},
+		{name: "negative position", trackPath: currentPath, position: -1},
+		{name: "overflowing position", trackPath: currentPath, position: 1<<63 - 1},
+		{name: "position beyond track", trackPath: currentPath, position: int64((11 * time.Second).Microseconds())},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := &mockController{}
+			srv := &Server{
+				currentTrackPath:     currentPath,
+				currentTrackDuration: current.Duration,
+				hasCurrentTrack:      true,
+			}
+			obj := &playerObj{ctrl: ctrl, srv: srv}
+			obj.setPosition(test.trackPath, test.position)
+			if ctrl.seekDuration != 0 {
+				t.Fatalf("invalid SetPosition sought to %s", ctrl.seekDuration)
+			}
+		})
+	}
+
+	ctrl := &mockController{}
+	srv := &Server{
+		currentTrackPath:     currentPath,
+		currentTrackDuration: current.Duration,
+		hasCurrentTrack:      true,
+	}
+	obj := &playerObj{ctrl: ctrl, srv: srv}
+	obj.setPosition(currentPath, int64((5 * time.Second).Microseconds()))
+	if ctrl.seekDuration != 5*time.Second {
+		t.Fatalf("current SetPosition sought to %s, want 5s", ctrl.seekDuration)
 	}
 }

--- a/internal/player/mpris/server_test.go
+++ b/internal/player/mpris/server_test.go
@@ -161,7 +161,9 @@ func TestPlayerObj_SetPositionValidatesTrackAndPosition(t *testing.T) {
 				hasCurrentTrack:      true,
 			}
 			obj := &playerObj{ctrl: ctrl, srv: srv}
-			obj.setPosition(test.trackPath, test.position)
+			if err := obj.setPosition(test.trackPath, test.position); err != nil {
+				t.Fatalf("SetPosition returned error: %v", err)
+			}
 			if ctrl.seekDuration != 0 {
 				t.Fatalf("invalid SetPosition sought to %s", ctrl.seekDuration)
 			}
@@ -175,7 +177,9 @@ func TestPlayerObj_SetPositionValidatesTrackAndPosition(t *testing.T) {
 		hasCurrentTrack:      true,
 	}
 	obj := &playerObj{ctrl: ctrl, srv: srv}
-	obj.setPosition(currentPath, int64((5 * time.Second).Microseconds()))
+	if err := obj.setPosition(currentPath, int64((5 * time.Second).Microseconds())); err != nil {
+		t.Fatalf("SetPosition returned error: %v", err)
+	}
 	if ctrl.seekDuration != 5*time.Second {
 		t.Fatalf("current SetPosition sought to %s, want 5s", ctrl.seekDuration)
 	}


### PR DESCRIPTION
## Summary

- generate bounded, collision-resistant MPRIS track paths from the primary ID, catalog ID, or length-prefixed metadata
- contain godbus property panics and disable MPRIS cleanly if the session bus is lost
- serialize debounced publication with shutdown and reject pending or post-close updates
- validate `SetPosition` against the current track and position bounds

## Why

An empty MusicKit track ID produces `/org/vibez/track/`. godbus rejects that path while metadata is flushed and `SetMust` panics in the timer goroutine, terminating vibez. Lossy path sanitization can also conflate distinct tracks, while bus loss or a shutdown race can trigger the same panic-on-error API.

## Tests

- `go test -count=1 ./...`
- `go vet ./...`
- targeted MPRIS regression tests under `go test -race -count=10`
