### PR TITLE
fix(cdp): keep Playwright off the terminal with retained diagnostics

### DIFF
--- a/cmd/cdp_common.go
+++ b/cmd/cdp_common.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -31,7 +32,7 @@ type cdpPlatformHooks struct {
 func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int, hooks cdpPlatformHooks) error {
 	prog := tea.NewProgram(tui.New(cfg, nil, nil, opts))
 	playerCh := make(chan *cdp.Player, 1)
-	runDone := make(chan struct{})
+	runDone := make(chan error, 1)
 	restartExe := make(chan string, 1)
 
 	go func() {
@@ -98,8 +99,7 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 
 		playerCh <- cdpPlayer
 		go func() {
-			defer close(runDone)
-			cdpPlayer.Run()
+			runDone <- cdpPlayer.Run()
 		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -125,10 +125,11 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 
 	_, err := prog.Run()
 
+	var shutdownErr error
 	select {
 	case p := <-playerCh:
 		p.Terminate()
-		<-runDone
+		shutdownErr = <-runDone
 	default:
 	}
 
@@ -138,7 +139,7 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 	default:
 	}
 
-	return err
+	return errors.Join(err, shutdownErr)
 }
 
 func startLastfmScrobbler(cfg *config.Config, player interface {

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -68,8 +68,6 @@ func linkHelper() {
 func isDriverUpToDate() bool {
 	driver, err := playwright.NewDriver(&playwright.RunOptions{
 		DriverDirectory: driverDir(),
-		Stdout:          driverOutput(),
-		Stderr:          driverOutput(),
 	})
 	if err != nil {
 		return false
@@ -103,12 +101,7 @@ func EnsureBrowser(onProgress func(string)) error {
 	// Also ensure the playwright driver is available (no browser install via playwright).
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress("Fetching dependencies…")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	}); err != nil {
+	if err := installPlaywright(driverDir()); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
 	}
 
@@ -208,21 +201,6 @@ func extractDeb(debPath, destDir string) error {
 		}
 	}
 	return fmt.Errorf("data.tar.* member not found in %s", filepath.Base(debPath))
-}
-
-// runPlaywright starts the Playwright driver backed by our cached Chrome.
-func runPlaywright() (*playwright.Playwright, error) {
-	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
-	pw, err := playwright.Run(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("playwright driver: %w", err)
-	}
-	return pw, nil
 }
 
 func chromeLaunchArgs(headless bool, wsl bool) []string {

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -68,6 +68,8 @@ func linkHelper() {
 func isDriverUpToDate() bool {
 	driver, err := playwright.NewDriver(&playwright.RunOptions{
 		DriverDirectory: driverDir(),
+		Stdout:          driverOutput(),
+		Stderr:          driverOutput(),
 	})
 	if err != nil {
 		return false
@@ -104,6 +106,8 @@ func EnsureBrowser(onProgress func(string)) error {
 	if err := playwright.Install(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	}); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
 	}
@@ -212,6 +216,8 @@ func runPlaywright() (*playwright.Playwright, error) {
 	pw, err := playwright.Run(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("playwright driver: %w", err)

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -89,6 +89,8 @@ func EnsureBrowser(onProgress func(string)) error {
 	if err := playwright.Install(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	}); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
 	}
@@ -100,6 +102,8 @@ func runPlaywright() (*playwright.Playwright, error) {
 	pw, err := playwright.Run(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("playwright driver: %w", err)

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	playwright "github.com/mxschmitt/playwright-go"
 )
 
 const chromeInstallHelp = "install Google Chrome from https://www.google.com/chrome/ or set VIBEZ_CHROME_PATH/CHROME_PATH"
@@ -86,29 +84,10 @@ func EnsureBrowser(onProgress func(string)) error {
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress(fmt.Sprintf("Using Google Chrome: %s", chromePath))
 	onProgress("Fetching browser driver...")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	}); err != nil {
+	if err := installPlaywright(driverDir()); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
 	}
 	return nil
-}
-
-func runPlaywright() (*playwright.Playwright, error) {
-	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
-	pw, err := playwright.Run(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("playwright driver: %w", err)
-	}
-	return pw, nil
 }
 
 func chromeLaunchArgs(headless bool, _ bool) []string {

--- a/internal/player/cdp/driverio.go
+++ b/internal/player/cdp/driverio.go
@@ -1,0 +1,19 @@
+package cdp
+
+import "io"
+
+// driverOutput is what the Playwright driver process gets for stdout/stderr.
+// It must never be the terminal.
+//
+// playwright-go defaults both to os.Stdout/os.Stderr, which hands the node
+// driver a live TTY file descriptor. Node snapshots that terminal's termios
+// at startup — by which point BubbleTea has already switched the terminal to
+// raw mode — and re-applies the snapshot from its exit handler. Shutdown waits
+// for the driver to exit (Player.Run stops the browser and the driver), so
+// node's restore lands *after* BubbleTea has put the terminal back into cooked
+// mode and silently undoes it, leaving the shell with no echo, no line editing
+// and no ctrl+c until the user closes the window.
+//
+// Returning a plain io.Writer rather than an *os.File also makes os/exec give
+// the child a pipe, so driver diagnostics can never scribble over the TUI.
+func driverOutput() io.Writer { return io.Discard }

--- a/internal/player/cdp/driverio.go
+++ b/internal/player/cdp/driverio.go
@@ -1,19 +1,138 @@
 package cdp
 
-import "io"
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 
-// driverOutput is what the Playwright driver process gets for stdout/stderr.
-// It must never be the terminal.
-//
-// playwright-go defaults both to os.Stdout/os.Stderr, which hands the node
-// driver a live TTY file descriptor. Node snapshots that terminal's termios
-// at startup — by which point BubbleTea has already switched the terminal to
-// raw mode — and re-applies the snapshot from its exit handler. Shutdown waits
-// for the driver to exit (Player.Run stops the browser and the driver), so
-// node's restore lands *after* BubbleTea has put the terminal back into cooked
-// mode and silently undoes it, leaving the shell with no echo, no line editing
-// and no ctrl+c until the user closes the window.
-//
-// Returning a plain io.Writer rather than an *os.File also makes os/exec give
-// the child a pipe, so driver diagnostics can never scribble over the TUI.
-func driverOutput() io.Writer { return io.Discard }
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+const driverOutputLimit = 64 << 10
+
+// playwright-go stores RunOptions.Logger in package-global state. Reusing one
+// stable sink avoids redirecting the standard logger or an existing driver's
+// Go-side logs when another driver starts. Node diagnostics are captured
+// separately through Stdout and Stderr below.
+var playwrightLogger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+var (
+	errPlaywrightActive = errors.New("a Playwright driver is already active")
+	playwrightActive    atomic.Bool
+)
+
+type managedPlaywright struct {
+	*playwright.Playwright
+	stopOnce sync.Once
+	stopErr  error
+}
+
+func claimPlaywright() error {
+	if !playwrightActive.CompareAndSwap(false, true) {
+		return errPlaywrightActive
+	}
+	return nil
+}
+
+func releasePlaywright() {
+	if !playwrightActive.CompareAndSwap(true, false) {
+		panic("cdp: released Playwright without an active driver")
+	}
+}
+
+func (p *managedPlaywright) Stop() error {
+	p.stopOnce.Do(func() {
+		defer releasePlaywright()
+		p.stopErr = p.Playwright.Stop()
+	})
+	return p.stopErr
+}
+
+// boundedDriverOutput keeps the Playwright child on a pipe while retaining
+// enough recent output to make startup failures actionable.
+type boundedDriverOutput struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func newDriverRunOptions(directory string) (*playwright.RunOptions, *boundedDriverOutput) {
+	output := &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}
+	return &playwright.RunOptions{
+		DriverDirectory:     directory,
+		SkipInstallBrowsers: true,
+		Stdout:              output,
+		Stderr:              output,
+		Logger:              playwrightLogger,
+	}, output
+}
+
+func installPlaywright(directory string) error {
+	if err := claimPlaywright(); err != nil {
+		return err
+	}
+	defer releasePlaywright()
+
+	driverOptions, driverOutput := newDriverRunOptions(directory)
+	return addDriverOutput(playwright.Install(driverOptions), driverOutput)
+}
+
+func runPlaywright() (*managedPlaywright, *boundedDriverOutput, error) {
+	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
+	if err := claimPlaywright(); err != nil {
+		return nil, nil, err
+	}
+
+	driverOptions, driverOutput := newDriverRunOptions(driverDir())
+	pw, err := playwright.Run(driverOptions)
+	if err != nil {
+		releasePlaywright()
+		return nil, nil, fmt.Errorf("playwright driver: %w", addDriverOutput(err, driverOutput))
+	}
+	return &managedPlaywright{Playwright: pw}, driverOutput, nil
+}
+
+func (o *boundedDriverOutput) Write(p []byte) (int, error) {
+	written := len(p)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if len(p) >= driverOutputLimit {
+		o.data = append(o.data[:0], p[len(p)-driverOutputLimit:]...)
+		return written, nil
+	}
+	if overflow := len(o.data) + len(p) - driverOutputLimit; overflow > 0 {
+		copy(o.data, o.data[overflow:])
+		o.data = o.data[:len(o.data)-overflow]
+	}
+	o.data = append(o.data, p...)
+	return written, nil
+}
+
+func (o *boundedDriverOutput) String() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return string(o.data)
+}
+
+func addDriverOutput(err error, output *boundedDriverOutput) error {
+	if err == nil {
+		return nil
+	}
+	if output == nil {
+		return err
+	}
+	details := strings.TrimSpace(output.String())
+	if details == "" {
+		return err
+	}
+	return fmt.Errorf("%w\n\nPlaywright driver output:\n%s", err, details)
+}
+
+// Keep compile-time interface coverage explicit: os/exec creates a pipe for an
+// io.Writer that is not an *os.File, preventing Node from inheriting the TTY.
+var _ io.Writer = (*boundedDriverOutput)(nil)

--- a/internal/player/cdp/driverio_test.go
+++ b/internal/player/cdp/driverio_test.go
@@ -1,0 +1,20 @@
+package cdp
+
+import (
+	"os"
+	"testing"
+)
+
+// The driver must never be handed a terminal file descriptor. os/exec passes
+// an *os.File straight through to the child, so anything but a plain io.Writer
+// lets the node driver reach the user's terminal — see driverio.go for what
+// that costs.
+func TestDriverOutput_NeverATerminal(t *testing.T) {
+	w := driverOutput()
+	if w == nil {
+		t.Fatal("driverOutput() = nil; os/exec would hand the driver the parent's terminal")
+	}
+	if f, ok := w.(*os.File); ok {
+		t.Fatalf("driverOutput() = *os.File(%q); os/exec passes the descriptor through unchanged, so the driver can reach the terminal", f.Name())
+	}
+}

--- a/internal/player/cdp/driverio_test.go
+++ b/internal/player/cdp/driverio_test.go
@@ -1,20 +1,119 @@
 package cdp
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"log"
 	"os"
+	"strings"
 	"testing"
+
+	playwright "github.com/mxschmitt/playwright-go"
 )
 
-// The driver must never be handed a terminal file descriptor. os/exec passes
-// an *os.File straight through to the child, so anything but a plain io.Writer
-// lets the node driver reach the user's terminal — see driverio.go for what
-// that costs.
-func TestDriverOutput_NeverATerminal(t *testing.T) {
-	w := driverOutput()
-	if w == nil {
-		t.Fatal("driverOutput() = nil; os/exec would hand the driver the parent's terminal")
+func TestNewDriverRunOptions_DoNotRedirectStandardLogger(t *testing.T) {
+	previous := log.Writer()
+	var captured bytes.Buffer
+	log.SetOutput(&captured)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	options, _ := newDriverRunOptions("driver-dir")
+	if _, err := playwright.NewDriver(options); err != nil {
+		t.Fatalf("NewDriver: %v", err)
 	}
-	if f, ok := w.(*os.File); ok {
-		t.Fatalf("driverOutput() = *os.File(%q); os/exec passes the descriptor through unchanged, so the driver can reach the terminal", f.Name())
+	log.Print("standard logger remains configured")
+	if !strings.Contains(captured.String(), "standard logger remains configured") {
+		t.Fatal("playwright.NewDriver redirected the process-wide standard logger")
 	}
+}
+
+func TestNewDriverRunOptions_KeepDriverOffTerminal(t *testing.T) {
+	options, _ := newDriverRunOptions("driver-dir")
+	if options.DriverDirectory != "driver-dir" {
+		t.Fatalf("DriverDirectory = %q, want driver-dir", options.DriverDirectory)
+	}
+	if !options.SkipInstallBrowsers {
+		t.Fatal("SkipInstallBrowsers = false, want true")
+	}
+	if options.Logger == nil {
+		t.Fatal("Logger = nil; playwright-go would redirect the process-wide standard logger")
+	}
+	secondOptions, _ := newDriverRunOptions("other-driver-dir")
+	if secondOptions.Logger != options.Logger {
+		t.Fatal("newDriverRunOptions created a per-instance logger for playwright-go's package-global logger")
+	}
+
+	writers := map[string]io.Writer{"stdout": options.Stdout, "stderr": options.Stderr}
+	for name, writer := range writers {
+		if writer == nil {
+			t.Fatalf("%s = nil; os/exec would hand the driver the parent's terminal", name)
+		}
+		if file, ok := writer.(*os.File); ok {
+			t.Fatalf("%s = *os.File(%q); os/exec would pass the terminal descriptor through", name, file.Name())
+		}
+	}
+}
+
+func TestBoundedDriverOutput_KeepsRecentOutput(t *testing.T) {
+	output := &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}
+	input := strings.Repeat("a", driverOutputLimit) + "fatal tail"
+	written, err := output.Write([]byte(input))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if written != len(input) {
+		t.Fatalf("Write returned %d, want %d", written, len(input))
+	}
+	got := output.String()
+	if len(got) != driverOutputLimit {
+		t.Fatalf("captured %d bytes, want %d", len(got), driverOutputLimit)
+	}
+	if !strings.HasSuffix(got, "fatal tail") {
+		t.Fatalf("captured output does not retain recent tail: %q", got[len(got)-32:])
+	}
+}
+
+func TestAddDriverOutput_PreservesCauseAndDetails(t *testing.T) {
+	cause := errors.New("connection closed")
+	output := &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}
+	_, _ = output.Write([]byte("FATAL: driver bundle corrupt"))
+
+	got := addDriverOutput(cause, output)
+	if !errors.Is(got, cause) {
+		t.Fatalf("addDriverOutput() does not preserve cause: %v", got)
+	}
+	if !strings.Contains(got.Error(), "FATAL: driver bundle corrupt") {
+		t.Fatalf("addDriverOutput() omitted driver details: %v", got)
+	}
+}
+
+func TestPlayerWithDriverOutputIncludesRuntimeDiagnostics(t *testing.T) {
+	cause := errors.New("browser launch failed")
+	player := &Player{driverOutput: &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}}
+	_, _ = player.driverOutput.Write([]byte("late driver diagnostic"))
+
+	got := player.withDriverOutput(cause)
+	if !errors.Is(got, cause) {
+		t.Fatalf("withDriverOutput() does not preserve cause: %v", got)
+	}
+	if !strings.Contains(got.Error(), "late driver diagnostic") {
+		t.Fatalf("withDriverOutput() omitted runtime details: %v", got)
+	}
+}
+
+func TestClaimPlaywrightRejectsSecondDriver(t *testing.T) {
+	if err := claimPlaywright(); err != nil {
+		t.Fatalf("first claimPlaywright: %v", err)
+	}
+	if err := claimPlaywright(); !errors.Is(err, errPlaywrightActive) {
+		releasePlaywright()
+		t.Fatalf("second claimPlaywright error = %v, want %v", err, errPlaywrightActive)
+	}
+	releasePlaywright()
+
+	if err := claimPlaywright(); err != nil {
+		t.Fatalf("claimPlaywright after release: %v", err)
+	}
+	releasePlaywright()
 }

--- a/internal/player/cdp/player.go
+++ b/internal/player/cdp/player.go
@@ -5,6 +5,7 @@ package cdp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -32,10 +33,11 @@ type Player struct {
 	OnStorefront     func(sf string)
 	OnSessionExpired func()
 
-	pw      *playwright.Playwright
-	browser playwright.Browser
-	page    playwright.Page
-	srv     *http.Server
+	pw           *managedPlaywright
+	driverOutput *boundedDriverOutput
+	browser      playwright.Browser
+	page         playwright.Page
+	srv          *http.Server
 
 	mu                 sync.RWMutex
 	state              player.State
@@ -75,12 +77,13 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 		doneCh:  make(chan struct{}),
 	}
 
-	pw, err := runPlaywright()
+	pw, driverOutput, err := runPlaywright()
 	if err != nil {
 		_ = srv.Close()
 		return nil, err
 	}
 	p.pw = pw
+	p.driverOutput = driverOutput
 
 	chromePath := HelperPath()
 	if _, err := os.Stat(chromePath); err != nil {
@@ -106,7 +109,7 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 	if err != nil {
 		_ = pw.Stop()
 		_ = srv.Close()
-		return nil, fmt.Errorf("cdp: launch browser: %w", err)
+		return nil, p.withDriverOutput(fmt.Errorf("cdp: launch browser: %w", err))
 	}
 	p.browser = browser
 
@@ -115,17 +118,17 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 		_ = browser.Close()
 		_ = pw.Stop()
 		_ = srv.Close()
-		return nil, fmt.Errorf("cdp: new page: %w", err)
+		return nil, p.withDriverOutput(fmt.Errorf("cdp: new page: %w", err))
 	}
 	p.page = pg
 
 	// Forward page crashes and unhandled JS errors to errCh so WaitReady
 	// returns immediately instead of waiting for the full timeout.
 	pg.On("crash", func() {
-		p.sendError(fmt.Errorf("cdp: Chrome page crashed"))
+		p.sendError(p.withDriverOutput(fmt.Errorf("cdp: Chrome page crashed")))
 	})
 	pg.On("pageerror", func(err error) {
-		p.sendError(fmt.Errorf("cdp: page JS error: %w", err))
+		p.sendError(p.withDriverOutput(fmt.Errorf("cdp: page JS error: %w", err)))
 	})
 	// Route browser console messages through the TUI debug log.
 	// Non-fatal 403s from resource loads (artwork, fonts) are filtered out
@@ -225,7 +228,7 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 			_ = browser.Close()
 			_ = pw.Stop()
 			_ = srv.Close()
-			return nil, fmt.Errorf("cdp: expose %s: %w", name, err)
+			return nil, p.withDriverOutput(fmt.Errorf("cdp: expose %s: %w", name, err))
 		}
 	}
 
@@ -235,12 +238,16 @@ func New(devToken, userToken, storefront string, wsl bool, audioBitrateKbps int)
 			select {
 			case <-p.doneCh:
 			default:
-				p.sendError(fmt.Errorf("cdp navigate: %w", err))
+				p.sendError(p.withDriverOutput(fmt.Errorf("cdp navigate: %w", err)))
 			}
 		}
 	}()
 
 	return p, nil
+}
+
+func (p *Player) withDriverOutput(err error) error {
+	return addDriverOutput(err, p.driverOutput)
 }
 
 func (p *Player) sendError(err error) {
@@ -363,11 +370,19 @@ func (p *Player) dispatch(js string) {
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
 
-func (p *Player) Run() {
+func (p *Player) Run() error {
 	<-p.doneCh
-	_ = p.browser.Close()
-	_ = p.pw.Stop()
-	_ = p.srv.Close()
+	var shutdownErrors []error
+	if err := p.browser.Close(); err != nil {
+		shutdownErrors = append(shutdownErrors, fmt.Errorf("cdp: close browser: %w", err))
+	}
+	if err := p.pw.Stop(); err != nil {
+		shutdownErrors = append(shutdownErrors, fmt.Errorf("cdp: stop Playwright: %w", err))
+	}
+	if err := p.srv.Close(); err != nil {
+		shutdownErrors = append(shutdownErrors, fmt.Errorf("cdp: stop local server: %w", err))
+	}
+	return p.withDriverOutput(errors.Join(shutdownErrors...))
 }
 
 func (p *Player) Terminate() {
@@ -385,7 +400,7 @@ func (p *Player) WaitReady(ctx context.Context) error {
 	case err := <-p.errCh:
 		return err
 	case <-ctx.Done():
-		return fmt.Errorf("cdp player: %w", ctx.Err())
+		return p.withDriverOutput(fmt.Errorf("cdp player: %w", ctx.Err()))
 	}
 }
 


### PR DESCRIPTION
## Summary

- route Playwright output through a bounded, non-file pipe instead of the live terminal
- retain the latest 64 KiB of Node diagnostics through startup, runtime, and shutdown errors
- use a stable logger sink and enforce one managed Playwright lifecycle around playwright-go's package-global logger
- propagate browser, driver, and local-server shutdown failures to the caller

## Why

The Node driver can snapshot Bubble Tea's raw termios state and restore it after Bubble Tea returns the terminal to cooked mode. The shell is then left without normal echo, canonical input, signals, or output post-processing.

The first commit is Ian Swope's change from #99 with authorship preserved. This combined PR layers a reviewed follow-up on #99 because the original cross-fork branch is not writable. Maintainers can merge this PR, or merge #99 and cherry-pick the follow-up commit `3cd1b21`.

Refs #88

## Tests

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=10 ./internal/player/cdp`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go test -c ./internal/player/cdp`
