### PR TITLE
fix(cdp): preserve logs and retain startup diagnostics

### DIFF
--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -68,8 +68,6 @@ func linkHelper() {
 func isDriverUpToDate() bool {
 	driver, err := playwright.NewDriver(&playwright.RunOptions{
 		DriverDirectory: driverDir(),
-		Stdout:          driverOutput(),
-		Stderr:          driverOutput(),
 	})
 	if err != nil {
 		return false
@@ -103,13 +101,9 @@ func EnsureBrowser(onProgress func(string)) error {
 	// Also ensure the playwright driver is available (no browser install via playwright).
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress("Fetching dependencies…")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	}); err != nil {
-		return fmt.Errorf("playwright driver: %w", err)
+	driverOptions, driverOutput := newDriverRunOptions(driverDir())
+	if err := playwright.Install(driverOptions); err != nil {
+		return fmt.Errorf("playwright driver: %w", addDriverOutput(err, driverOutput))
 	}
 
 	if chromeInstalled {
@@ -213,14 +207,10 @@ func extractDeb(debPath, destDir string) error {
 // runPlaywright starts the Playwright driver backed by our cached Chrome.
 func runPlaywright() (*playwright.Playwright, error) {
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
-	pw, err := playwright.Run(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	})
+	driverOptions, driverOutput := newDriverRunOptions(driverDir())
+	pw, err := playwright.Run(driverOptions)
 	if err != nil {
-		return nil, fmt.Errorf("playwright driver: %w", err)
+		return nil, fmt.Errorf("playwright driver: %w", addDriverOutput(err, driverOutput))
 	}
 	return pw, nil
 }

--- a/internal/player/cdp/browser.go
+++ b/internal/player/cdp/browser.go
@@ -68,6 +68,8 @@ func linkHelper() {
 func isDriverUpToDate() bool {
 	driver, err := playwright.NewDriver(&playwright.RunOptions{
 		DriverDirectory: driverDir(),
+		Stdout:          driverOutput(),
+		Stderr:          driverOutput(),
 	})
 	if err != nil {
 		return false
@@ -104,6 +106,8 @@ func EnsureBrowser(onProgress func(string)) error {
 	if err := playwright.Install(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	}); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
 	}
@@ -212,6 +216,8 @@ func runPlaywright() (*playwright.Playwright, error) {
 	pw, err := playwright.Run(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("playwright driver: %w", err)

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -89,6 +89,8 @@ func EnsureBrowser(onProgress func(string)) error {
 	if err := playwright.Install(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	}); err != nil {
 		return fmt.Errorf("playwright driver: %w", err)
 	}
@@ -100,6 +102,8 @@ func runPlaywright() (*playwright.Playwright, error) {
 	pw, err := playwright.Run(&playwright.RunOptions{
 		DriverDirectory:     driverDir(),
 		SkipInstallBrowsers: true,
+		Stdout:              driverOutput(),
+		Stderr:              driverOutput(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("playwright driver: %w", err)

--- a/internal/player/cdp/browser_darwin.go
+++ b/internal/player/cdp/browser_darwin.go
@@ -86,27 +86,19 @@ func EnsureBrowser(onProgress func(string)) error {
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
 	onProgress(fmt.Sprintf("Using Google Chrome: %s", chromePath))
 	onProgress("Fetching browser driver...")
-	if err := playwright.Install(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	}); err != nil {
-		return fmt.Errorf("playwright driver: %w", err)
+	driverOptions, driverOutput := newDriverRunOptions(driverDir())
+	if err := playwright.Install(driverOptions); err != nil {
+		return fmt.Errorf("playwright driver: %w", addDriverOutput(err, driverOutput))
 	}
 	return nil
 }
 
 func runPlaywright() (*playwright.Playwright, error) {
 	_ = os.Setenv("PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS", "1")
-	pw, err := playwright.Run(&playwright.RunOptions{
-		DriverDirectory:     driverDir(),
-		SkipInstallBrowsers: true,
-		Stdout:              driverOutput(),
-		Stderr:              driverOutput(),
-	})
+	driverOptions, driverOutput := newDriverRunOptions(driverDir())
+	pw, err := playwright.Run(driverOptions)
 	if err != nil {
-		return nil, fmt.Errorf("playwright driver: %w", err)
+		return nil, fmt.Errorf("playwright driver: %w", addDriverOutput(err, driverOutput))
 	}
 	return pw, nil
 }

--- a/internal/player/cdp/driverio.go
+++ b/internal/player/cdp/driverio.go
@@ -1,0 +1,19 @@
+package cdp
+
+import "io"
+
+// driverOutput is what the Playwright driver process gets for stdout/stderr.
+// It must never be the terminal.
+//
+// playwright-go defaults both to os.Stdout/os.Stderr, which hands the node
+// driver a live TTY file descriptor. Node snapshots that terminal's termios
+// at startup — by which point BubbleTea has already switched the terminal to
+// raw mode — and re-applies the snapshot from its exit handler. Shutdown waits
+// for the driver to exit (Player.Run stops the browser and the driver), so
+// node's restore lands *after* BubbleTea has put the terminal back into cooked
+// mode and silently undoes it, leaving the shell with no echo, no line editing
+// and no ctrl+c until the user closes the window.
+//
+// Returning a plain io.Writer rather than an *os.File also makes os/exec give
+// the child a pipe, so driver diagnostics can never scribble over the TUI.
+func driverOutput() io.Writer { return io.Discard }

--- a/internal/player/cdp/driverio.go
+++ b/internal/player/cdp/driverio.go
@@ -1,19 +1,73 @@
 package cdp
 
-import "io"
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
 
-// driverOutput is what the Playwright driver process gets for stdout/stderr.
-// It must never be the terminal.
-//
-// playwright-go defaults both to os.Stdout/os.Stderr, which hands the node
-// driver a live TTY file descriptor. Node snapshots that terminal's termios
-// at startup — by which point BubbleTea has already switched the terminal to
-// raw mode — and re-applies the snapshot from its exit handler. Shutdown waits
-// for the driver to exit (Player.Run stops the browser and the driver), so
-// node's restore lands *after* BubbleTea has put the terminal back into cooked
-// mode and silently undoes it, leaving the shell with no echo, no line editing
-// and no ctrl+c until the user closes the window.
-//
-// Returning a plain io.Writer rather than an *os.File also makes os/exec give
-// the child a pipe, so driver diagnostics can never scribble over the TUI.
-func driverOutput() io.Writer { return io.Discard }
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+const driverOutputLimit = 64 << 10
+
+// playwright-go stores RunOptions.Logger in package-global state. Reusing one
+// stable sink prevents it from redirecting the process-wide standard logger.
+var playwrightLogger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+// boundedDriverOutput keeps the Playwright child on a pipe while retaining
+// enough recent output to make startup failures actionable.
+type boundedDriverOutput struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func newDriverRunOptions(directory string) (*playwright.RunOptions, *boundedDriverOutput) {
+	output := &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}
+	return &playwright.RunOptions{
+		DriverDirectory:     directory,
+		SkipInstallBrowsers: true,
+		Stdout:              output,
+		Stderr:              output,
+		Logger:              playwrightLogger,
+	}, output
+}
+
+func (o *boundedDriverOutput) Write(p []byte) (int, error) {
+	written := len(p)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if len(p) >= driverOutputLimit {
+		o.data = append(o.data[:0], p[len(p)-driverOutputLimit:]...)
+		return written, nil
+	}
+	if overflow := len(o.data) + len(p) - driverOutputLimit; overflow > 0 {
+		copy(o.data, o.data[overflow:])
+		o.data = o.data[:len(o.data)-overflow]
+	}
+	o.data = append(o.data, p...)
+	return written, nil
+}
+
+func (o *boundedDriverOutput) String() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return string(o.data)
+}
+
+func addDriverOutput(err error, output *boundedDriverOutput) error {
+	if err == nil {
+		return nil
+	}
+	details := strings.TrimSpace(output.String())
+	if details == "" {
+		return err
+	}
+	return fmt.Errorf("%w\n\nPlaywright driver output:\n%s", err, details)
+}
+
+// Keep compile-time interface coverage explicit: os/exec creates a pipe for an
+// io.Writer that is not an *os.File, preventing Node from inheriting the TTY.
+var _ io.Writer = (*boundedDriverOutput)(nil)

--- a/internal/player/cdp/driverio_test.go
+++ b/internal/player/cdp/driverio_test.go
@@ -1,0 +1,20 @@
+package cdp
+
+import (
+	"os"
+	"testing"
+)
+
+// The driver must never be handed a terminal file descriptor. os/exec passes
+// an *os.File straight through to the child, so anything but a plain io.Writer
+// lets the node driver reach the user's terminal — see driverio.go for what
+// that costs.
+func TestDriverOutput_NeverATerminal(t *testing.T) {
+	w := driverOutput()
+	if w == nil {
+		t.Fatal("driverOutput() = nil; os/exec would hand the driver the parent's terminal")
+	}
+	if f, ok := w.(*os.File); ok {
+		t.Fatalf("driverOutput() = *os.File(%q); os/exec passes the descriptor through unchanged, so the driver can reach the terminal", f.Name())
+	}
+}

--- a/internal/player/cdp/driverio_test.go
+++ b/internal/player/cdp/driverio_test.go
@@ -1,20 +1,89 @@
 package cdp
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"log"
 	"os"
+	"strings"
 	"testing"
+
+	playwright "github.com/mxschmitt/playwright-go"
 )
 
-// The driver must never be handed a terminal file descriptor. os/exec passes
-// an *os.File straight through to the child, so anything but a plain io.Writer
-// lets the node driver reach the user's terminal — see driverio.go for what
-// that costs.
-func TestDriverOutput_NeverATerminal(t *testing.T) {
-	w := driverOutput()
-	if w == nil {
-		t.Fatal("driverOutput() = nil; os/exec would hand the driver the parent's terminal")
+func TestNewDriverRunOptions_DoNotRedirectStandardLogger(t *testing.T) {
+	previous := log.Writer()
+	var captured bytes.Buffer
+	log.SetOutput(&captured)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	options, _ := newDriverRunOptions("driver-dir")
+	if _, err := playwright.NewDriver(options); err != nil {
+		t.Fatalf("NewDriver: %v", err)
 	}
-	if f, ok := w.(*os.File); ok {
-		t.Fatalf("driverOutput() = *os.File(%q); os/exec passes the descriptor through unchanged, so the driver can reach the terminal", f.Name())
+	log.Print("standard logger remains configured")
+	if !strings.Contains(captured.String(), "standard logger remains configured") {
+		t.Fatal("playwright.NewDriver redirected the process-wide standard logger")
+	}
+}
+
+func TestNewDriverRunOptions_KeepDriverOffTerminal(t *testing.T) {
+	options, _ := newDriverRunOptions("driver-dir")
+	if options.DriverDirectory != "driver-dir" {
+		t.Fatalf("DriverDirectory = %q, want driver-dir", options.DriverDirectory)
+	}
+	if !options.SkipInstallBrowsers {
+		t.Fatal("SkipInstallBrowsers = false, want true")
+	}
+	if options.Logger == nil {
+		t.Fatal("Logger = nil; playwright-go would redirect the process-wide standard logger")
+	}
+	secondOptions, _ := newDriverRunOptions("other-driver-dir")
+	if secondOptions.Logger != options.Logger {
+		t.Fatal("newDriverRunOptions created a per-call package-global logger")
+	}
+
+	writers := map[string]io.Writer{"stdout": options.Stdout, "stderr": options.Stderr}
+	for name, writer := range writers {
+		if writer == nil {
+			t.Fatalf("%s = nil; os/exec would hand the driver the parent's terminal", name)
+		}
+		if file, ok := writer.(*os.File); ok {
+			t.Fatalf("%s = *os.File(%q); os/exec would pass the terminal descriptor through", name, file.Name())
+		}
+	}
+}
+
+func TestBoundedDriverOutput_KeepsRecentOutput(t *testing.T) {
+	output := &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}
+	input := strings.Repeat("a", driverOutputLimit) + "fatal tail"
+	written, err := output.Write([]byte(input))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if written != len(input) {
+		t.Fatalf("Write returned %d, want %d", written, len(input))
+	}
+	got := output.String()
+	if len(got) != driverOutputLimit {
+		t.Fatalf("captured %d bytes, want %d", len(got), driverOutputLimit)
+	}
+	if !strings.HasSuffix(got, "fatal tail") {
+		t.Fatalf("captured output does not retain recent tail: %q", got[len(got)-32:])
+	}
+}
+
+func TestAddDriverOutput_PreservesCauseAndDetails(t *testing.T) {
+	cause := errors.New("connection closed")
+	output := &boundedDriverOutput{data: make([]byte, 0, driverOutputLimit)}
+	_, _ = output.Write([]byte("FATAL: driver bundle corrupt"))
+
+	got := addDriverOutput(cause, output)
+	if !errors.Is(got, cause) {
+		t.Fatalf("addDriverOutput() does not preserve cause: %v", got)
+	}
+	if !strings.Contains(got.Error(), "FATAL: driver bundle corrupt") {
+		t.Fatalf("addDriverOutput() omitted driver details: %v", got)
 	}
 }


### PR DESCRIPTION
## Status

Draft follow-up to #99. Do not merge before #99. This branch is stacked on Ian Swope's PR head, so GitHub will show that commit until #99 lands and this branch is rebased. The intended follow-up is commit `a1f648c` only.

## Summary

- avoid configuring Playwright output during the version-only driver check, which does not spawn a child
- pass one explicit Playwright logger so playwright-go does not redirect Go's process-wide standard logger
- keep the newest 64 KiB of piped Node output and attach it to Playwright install/startup errors
- preserve full error causes while keeping Node off the terminal

## Value

#99 fixes the terminal corruption. This follow-up addresses two separate consequences of routing output away from the terminal: playwright-go otherwise redirects the global standard logger to the supplied stderr writer, and discarding all Node output removes useful diagnostics when the driver fails to start.

## Tests

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=10 ./internal/player/cdp`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go test -c ./internal/player/cdp`
