### PR TITLE
fix(tui): keep status hints inside the border

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3052,9 +3052,10 @@ func (m *Model) renderBoxLayout() string {
 		sb.WriteString("├" + strings.Repeat("─", splitW) + "┴" + strings.Repeat("─", rightW) + "┤\n")
 	}
 
-	// ── Status bar (two lines: context/mode + playback) ──
-	sb.WriteString("│ " + padRight(m.statusNavContent(inner-2), inner-2) + " │\n")
-	sb.WriteString("│ " + padRight(m.statusPlayContent(inner-2), inner-2) + " │\n")
+	// ── Status bar (context/mode then playback, each wrapped as needed) ──
+	for _, line := range m.statusLines(inner - 2) {
+		sb.WriteString("│ " + padRight(line, inner-2) + " │\n")
+	}
 
 	// ── Bottom border ──
 	sb.WriteString("└" + strings.Repeat("─", inner) + "┘")
@@ -3468,8 +3469,9 @@ func (m *Model) searchLines(contentW, h int) []string {
 	return result[:h]
 }
 
-// statusNavContent is the top status line: mode chip + context-aware shortcuts.
-func (m *Model) statusNavContent(_ int) string {
+// statusNavLines is the top status line: mode chip + context-aware shortcuts,
+// wrapped to fit width w.
+func (m *Model) statusNavLines(w int) []string {
 	muted := styles.QueueItemMuted
 	accent := styles.KeyName
 	dot := muted.Render("  ·  ")
@@ -3480,12 +3482,12 @@ func (m *Model) statusNavContent(_ int) string {
 		cur := min(m.searchCursor, len(runes))
 		before := styles.Header.Render(string(runes[:cur]))
 		after := styles.Header.Render(string(runes[cur:]))
-		return styles.ModeSearch.Render("SEARCH") + "  " +
-			accent.Render("/") + before + accent.Render("█") + after
+		return []string{styles.ModeSearch.Render("SEARCH") + "  " +
+			accent.Render("/") + before + accent.Render("█") + after}
 	case modeCommand:
-		return styles.ModeCommand.Render("CMD") + "  " +
+		return []string{styles.ModeCommand.Render("CMD") + "  " +
 			muted.Render(":") + m.cmdBuf + accent.Render("_") +
-			muted.Render("  Tab complete · ↑/↓ navigate · Esc cancel")
+			muted.Render("  Tab complete · ↑/↓ navigate · Esc cancel")}
 	default:
 		var parts []string
 		switch {
@@ -3567,12 +3569,13 @@ func (m *Model) statusNavContent(_ int) string {
 				accent.Render(":q") + muted.Render(" quit"),
 			}
 		}
-		return strings.Join(parts, dot)
+		return wrapFit(parts, dot, w)
 	}
 }
 
-// statusPlayContent is the bottom status line: always shows playback controls.
-func (m *Model) statusPlayContent(_ int) string {
+// statusPlayLines is the bottom status line: always shows playback controls,
+// wrapped to fit width w.
+func (m *Model) statusPlayLines(w int) []string {
 	muted := styles.QueueItemMuted
 	accent := styles.KeyName
 	dot := muted.Render("  ·  ")
@@ -3599,7 +3602,7 @@ func (m *Model) statusPlayContent(_ int) string {
 		discoverHint,
 		radioHint,
 	}
-	return strings.Join(parts, dot)
+	return wrapFit(parts, dot, w)
 }
 
 // commandLines renders the command palette in the panel area when CMD mode is active.
@@ -3635,21 +3638,72 @@ func (m *Model) commandLines(_ int, h int) []string {
 	return result[:h]
 }
 
+// statusLines returns every status row — nav hints then playback controls —
+// each already wrapped to fit width w. The count varies with terminal width,
+// so panelHeight consults it rather than assuming a fixed two rows.
+func (m *Model) statusLines(w int) []string {
+	return append(m.statusNavLines(w), m.statusPlayLines(w)...)
+}
+
 // panelHeight returns the number of rows available for the split panel section.
+// Fixed overhead = top(1)+hdr(1)+hdrdiv(1)+splitdiv(1)+joindiv(1)+bottom(1) = 6,
+// plus the now-playing section, which grows in art mode, and the status rows,
+// which grow as hints wrap on a narrow terminal — so both are measured rather
+// than assumed.
 func (m *Model) panelHeight() int {
-	fixedOverhead := 8 + m.nowPlayingHeight()
+	fixedOverhead := 6 + m.nowPlayingHeight() + len(m.statusLines(m.width-4))
 	return max(3, m.height-fixedOverhead)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-// padRight pads s on the right with spaces to reach visual width w.
+// padRight pads s on the right with spaces to reach visual width w, and clips
+// it when it is wider. Clipping is the backstop that keeps an over-long line
+// from pushing past the right border and breaking the vertical rule; it is
+// ANSI-aware so styled content is never cut mid-escape-sequence.
 func padRight(s string, w int) string {
-	sw := lipgloss.Width(s)
-	if sw >= w {
-		return s
+	if w <= 0 {
+		return ""
 	}
-	return s + strings.Repeat(" ", w-sw)
+	sw := lipgloss.Width(s)
+	switch {
+	case sw > w:
+		return ansi.Truncate(s, w, "…")
+	case sw == w:
+		return s
+	default:
+		return s + strings.Repeat(" ", w-sw)
+	}
+}
+
+// wrapFit packs parts into as many lines as needed, each at most visual width
+// w, joining the parts on a line with sep. Nothing is ever hidden: a narrow
+// terminal costs extra rows rather than dropped hints. Parts are never split,
+// so styled segments stay intact — a lone part wider than w gets its own line
+// and is clipped by padRight. Always returns at least one line.
+func wrapFit(parts []string, sep string, w int) []string {
+	if len(parts) == 0 || w <= 0 {
+		return []string{""}
+	}
+
+	sepW := lipgloss.Width(sep)
+	var lines []string
+	cur, curW := "", 0
+
+	for _, p := range parts {
+		pw := lipgloss.Width(p)
+		switch {
+		case cur == "":
+			cur, curW = p, pw
+		case curW+sepW+pw <= w:
+			cur += sep + p
+			curW += sepW + pw
+		default:
+			lines = append(lines, cur)
+			cur, curW = p, pw
+		}
+	}
+	return append(lines, cur)
 }
 
 // toLines splits s into exactly h lines, padding/truncating as needed.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -594,14 +594,14 @@ func TestModel_RenderHeader_ContainsVibez(t *testing.T) {
 	}
 }
 
-// --- statusNavContent ---
+// --- statusNavLines ---
 
 func TestModel_RenderFooter_ContainsKeyHints(t *testing.T) {
 	m := newModel(nil)
 	m.width = 100
-	got := m.statusNavContent(m.width - 4)
+	got := strings.Join(m.statusNavLines(m.width-4), "\n")
 	if !strings.Contains(got, "search") {
-		t.Errorf("statusNavContent() should contain key hints, got %q", got)
+		t.Errorf("statusNavLines() should contain key hints, got %q", got)
 	}
 }
 

--- a/internal/tui/statusfit_test.go
+++ b/internal/tui/statusfit_test.go
@@ -1,0 +1,175 @@
+package tui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// --- wrapFit ---
+
+func TestWrapFit_SingleLineWhenAllFit(t *testing.T) {
+	got := wrapFit([]string{"aaa", "bbb", "ccc"}, "-", 20)
+	if len(got) != 1 || got[0] != "aaa-bbb-ccc" {
+		t.Errorf("wrapFit() = %q, want one line %q", got, "aaa-bbb-ccc")
+	}
+}
+
+func TestWrapFit_WrapsInsteadOfDropping(t *testing.T) {
+	got := wrapFit([]string{"aaa", "bbb", "ccc"}, "-", 8)
+	want := []string{"aaa-bbb", "ccc"}
+	if len(got) != len(want) {
+		t.Fatalf("wrapFit() = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestWrapFit_LosesNothing is the core guarantee of the wrap approach: every
+// part survives somewhere, at any width.
+func TestWrapFit_LosesNothing(t *testing.T) {
+	parts := []string{"first", "second", "third", "fourth", "fifth"}
+	for w := 1; w <= 60; w++ {
+		joined := strings.Join(wrapFit(parts, " · ", w), "\n")
+		for _, p := range parts {
+			if !strings.Contains(joined, p) {
+				t.Errorf("w=%d dropped %q (got %q)", w, p, joined)
+			}
+		}
+	}
+}
+
+func TestWrapFit_LinesRespectWidth(t *testing.T) {
+	parts := []string{"first", "second", "third", "fourth", "fifth"}
+	for w := 8; w <= 60; w++ {
+		for i, line := range wrapFit(parts, " · ", w) {
+			// A lone part wider than w cannot be split here; padRight clips it.
+			if lipgloss.Width(line) > w && !isSinglePart(line, parts) {
+				t.Errorf("w=%d line %d is %d wide: %q", w, i, lipgloss.Width(line), line)
+			}
+		}
+	}
+}
+
+func isSinglePart(line string, parts []string) bool {
+	return slices.Contains(parts, line)
+}
+
+func TestWrapFit_PreservesStyledParts(t *testing.T) {
+	styled := lipgloss.NewStyle().Bold(true).Render("bold")
+	got := strings.Join(wrapFit([]string{styled, "plain"}, " ", 6), "\n")
+	if !strings.Contains(got, styled) {
+		t.Errorf("wrapFit() cut the styled part: %q", got)
+	}
+}
+
+func TestWrapFit_EmptyAndZeroWidth(t *testing.T) {
+	if got := wrapFit(nil, "-", 10); len(got) != 1 || got[0] != "" {
+		t.Errorf("wrapFit(nil) = %q, want one empty line", got)
+	}
+	if got := wrapFit([]string{"a"}, "-", 0); len(got) != 1 || got[0] != "" {
+		t.Errorf("wrapFit(w=0) = %q, want one empty line", got)
+	}
+}
+
+// --- padRight ---
+
+func TestPadRight_ClipsOverlongInput(t *testing.T) {
+	got := padRight("abcdefghij", 5)
+	if gw := lipgloss.Width(got); gw != 5 {
+		t.Errorf("padRight() width = %d, want 5 (%q)", gw, got)
+	}
+}
+
+func TestPadRight_ClipDoesNotBreakANSI(t *testing.T) {
+	styled := lipgloss.NewStyle().Bold(true).Render("abcdefghij")
+	got := padRight(styled, 5)
+	if gw := lipgloss.Width(got); gw != 5 {
+		t.Errorf("padRight() visual width = %d, want 5", gw)
+	}
+	// An ANSI-aware clip keeps the reset sequence so styling cannot bleed on.
+	if strings.Contains(styled, "\x1b[") && !strings.Contains(got, "\x1b[m") {
+		t.Errorf("padRight() clipped away the reset sequence: %q", got)
+	}
+}
+
+func TestPadRight_NonPositiveWidth(t *testing.T) {
+	if got := padRight("abc", 0); got != "" {
+		t.Errorf("padRight(w=0) = %q, want empty", got)
+	}
+	if got := padRight("abc", -3); got != "" {
+		t.Errorf("padRight(w=-3) = %q, want empty", got)
+	}
+}
+
+// --- border integrity ---
+
+// TestView_StatusLinesRespectBorder is the regression guard for the status
+// hints ("v vibe", "R radio") spilling past the right border and breaking the
+// vertical rule. Every rendered row must be exactly m.width columns wide.
+func TestView_StatusLinesRespectBorder(t *testing.T) {
+	for _, w := range []int{40, 60, 72, 80, 100, 120, 200} {
+		m := newModel(nil)
+		m.width = w
+		m.height = 30
+		m.introStep = introDone
+
+		for line := range strings.SplitSeq(m.View().Content, "\n") {
+			if line == "" {
+				continue
+			}
+			if lw := lipgloss.Width(line); lw != w {
+				t.Errorf("width=%d: row is %d columns wide, want %d: %q", w, lw, w, line)
+				break
+			}
+		}
+	}
+}
+
+// TestView_HeightMatchesTerminal guards the panelHeight accounting: wrapping
+// hints onto extra rows must come out of the panel area, not out of the frame.
+func TestView_HeightMatchesTerminal(t *testing.T) {
+	for _, w := range []int{60, 80, 100, 140} {
+		m := newModel(nil)
+		m.width = w
+		m.height = 40 // tall enough that panelHeight is not clamped to its floor
+		m.introStep = introDone
+
+		got := len(strings.Split(m.View().Content, "\n"))
+		if got != m.height {
+			t.Errorf("width=%d: View() rendered %d rows, want %d", w, got, m.height)
+		}
+	}
+}
+
+// TestStatusLines_NothingHidden checks that no hint is dropped at any width,
+// including with radio and discovery active (the longest variants).
+func TestStatusLines_NothingHidden(t *testing.T) {
+	for _, w := range []int{40, 60, 80, 100, 120} {
+		m := newModel(nil)
+		m.width = w
+		m.height = 40
+		m.radio.enabled = true
+
+		joined := strings.Join(m.statusLines(w-4), "\n")
+		for _, hint := range []string{"vibe", "radio", "equalizer|eq", "quit", "shuffle"} {
+			if !containsAny(joined, strings.Split(hint, "|")) {
+				t.Errorf("width=%d: hint %q missing from status lines", w, hint)
+			}
+		}
+	}
+}
+
+func containsAny(s string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What's wrong

`padRight` returned over-long content unchanged (`if sw >= w { return s }`), so any
status line wider than the frame ran straight past the closing `│` and broke the
vertical rule. Both status builders also accepted a width argument and ignored it
(`_ int`).

The NORMAL nav line needs **140 columns** to fit on one row, so this fires on any
terminal narrower than that — which is how `v vibe` and `R radio` ended up sitting
outside the border. `go run . --demo` in a window under ~140 columns shows it.

## What changed

- **`padRight` now clips** with an ANSI-aware truncate. It's a global backstop for
  every row rather than the status bar alone, which also covers two pre-existing
  overflows I hit while testing: the `made with ❤️ by simonepelosi` footer (52
  columns in a 40-column box) and the vibe placeholder (70 in 60).
- **`wrapFit`** packs hints onto as many rows as they need, so a narrow terminal
  costs extra rows instead of dropped hints. Nothing is ever hidden.
- `statusNavContent`/`statusPlayContent` become `statusNavLines`/`statusPlayLines`
  returning `[]string`, with a `statusLines` combiner shared by the renderer and the
  height math.
- **`panelHeight`'s hardcoded overhead of 20 becomes `18 + len(statusLines)`.** This
  one isn't cosmetic: once hints wrap, the old constant under-counts and the frame
  overflows the terminal. At width 60 in a 40-row terminal it rendered 44 rows.

`charmbracelet/x/ansi` goes from indirect to direct in `go.mod` — it was already in
the module graph via lipgloss, so this adds nothing to the dependency tree.

## Tests

`TestView_HeightMatchesTerminal` and `TestView_StatusLinesRespectBorder` are the
regression guards. I checked both actually bite by reverting the `panelHeight`
accounting and the `padRight` clip in turn and watching them fail.

Full suite, `go vet`, and golangci-lint v2.11.4 all clean.

## Note on scope

There's a purely cosmetic change I deliberately kept out of this PR: tightening the
separator and shortening three labels takes the NORMAL line from 140 columns to 105,
so both rows stay single-row at ≥109. That's a UI-surface change and you've said you
prefer a minimal UI, so I've put it in #106 for you to accept or reject
separately.

**This fix stands on its own without it** — hints just wrap onto extra rows sooner on
a narrow terminal. The border never breaks either way.
