### PR TITLE
build: add 'make install' and 'make uninstall'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 GOFLAGS=-tags webkit2gtk_4_1
 PKG_CONFIG_PATH=$(CURDIR)/pkg-config
+PREFIX ?= $(HOME)/.local
+BINDIR ?= $(PREFIX)/bin
 
-.PHONY: build run test lint clean release build-with-token refresh-token
+.PHONY: build run test lint clean release build-with-token refresh-token install uninstall
 
 build:
 	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) go build -o vibez .
@@ -74,6 +76,32 @@ refresh-token:
 	test -n "$$APPLE_PRIVATE_KEY" || { echo "APPLE_PRIVATE_KEY or APPLE_PRIVATE_KEY_FILE is not set (env or .env)"; exit 1; }; \
 	export APPLE_KEY_ID APPLE_TEAM_ID APPLE_PRIVATE_KEY; \
 	GOFLAGS= go run ./scripts/gen-devtoken -write
+
+# install rebuilds with an embedded developer token and copies the binary onto
+# PATH, so the installed copy cannot silently go stale behind a newer ./vibez in
+# the working tree. Credentials come from the environment or a local .env
+# (gitignored), which may point at the key with APPLE_PRIVATE_KEY_FILE instead
+# of inlining its contents as APPLE_PRIVATE_KEY — the same inputs refresh-token
+# accepts.
+#
+# Embedded tokens expire after 30 days, so re-run this when the catalog starts
+# returning 401s. Override the location with: make install PREFIX=/usr/local
+install:
+	@set -e; \
+	if [ -f .env ]; then set -a; . ./.env; set +a; fi; \
+	if [ -z "$$APPLE_PRIVATE_KEY" ] && [ -n "$$APPLE_PRIVATE_KEY_FILE" ]; then \
+		key_file="$$(eval echo $$APPLE_PRIVATE_KEY_FILE)"; \
+		test -f "$$key_file" || { echo "APPLE_PRIVATE_KEY_FILE not found: $$key_file"; exit 1; }; \
+		APPLE_PRIVATE_KEY="$$(cat "$$key_file")"; \
+	fi; \
+	export APPLE_KEY_ID APPLE_TEAM_ID APPLE_PRIVATE_KEY LASTFM_API_KEY LASTFM_API_SECRET; \
+	$(MAKE) --no-print-directory build-with-token; \
+	install -d "$(BINDIR)"; \
+	install -m 755 vibez "$(BINDIR)/vibez"; \
+	echo "Installed vibez to $(BINDIR)/vibez"
+
+uninstall:
+	rm -f "$(BINDIR)/vibez"
 
 run: build
 	./vibez

--- a/README.md
+++ b/README.md
@@ -144,7 +144,13 @@ brew install --cask google-chrome
 git clone https://github.com/simonepelosi/vibez
 cd vibez
 make build-with-token   # requires APPLE_KEY_ID, APPLE_TEAM_ID, APPLE_PRIVATE_KEY
+make install            # same, plus copies the binary to ~/.local/bin
 ```
+
+`make install` reads those credentials from the environment or a gitignored
+`.env`, so the copy on your `PATH` is rebuilt rather than left to go stale.
+Embedded tokens expire after 30 days — re-run it when the catalog starts
+returning 401s. Override the location with `make install PREFIX=/usr/local`.
 
 **Requirements:** Linux x86-64 or arm64, or macOS · Go 1.26+ · WebKit/GStreamer development packages on Linux · Google Chrome on macOS · on Linux arm64, a system Chromium + Widevine CDM for full-track playback (e.g. `pacman -S chromium widevine`) · Apple Developer Account with a MusicKit key
 


### PR DESCRIPTION
## Why

`make build-with-token` leaves the binary in the working tree, so a copy already on
`PATH` can silently go stale behind a newer `./vibez`. Embedded developer tokens also
expire after 30 days, so that stale copy eventually starts failing against the catalog
with no obvious cause — it presents as an Apple problem rather than a build problem. I
lost an afternoon to exactly that.

## What this adds

- **`make install`** rebuilds with a freshly generated embedded token and copies the
  result to `$(BINDIR)`, defaulting to `$(HOME)/.local/bin`. Override with
  `make install PREFIX=/usr/local`, or set `BINDIR` directly.
- **`make uninstall`** removes the installed binary.

Credentials come from the environment or a gitignored `.env`, accepting either
`APPLE_PRIVATE_KEY` with the key contents or `APPLE_PRIVATE_KEY_FILE` with a path to
the `.p8` — the same inputs `refresh-token` already accepts.

README gets a short block under the existing build-from-source instructions.

## One thing worth your call

`install` duplicates about six lines of `.env` / `APPLE_PRIVATE_KEY_FILE` handling
from #91's `refresh-token` rather than factoring out a shared snippet. That was
deliberate — factoring it out means editing your merged target from inside an
unrelated PR. Happy to do it if you'd rather have one shared block; I just didn't want
to assume.

I also dropped my own `refresh-token` equivalent when #91 landed. Yours is better: it
adds `gen-devtoken -write` plus tests.

## Tests

Tested end-to-end with `PREFIX=$(mktemp -d)`: `.env` loaded, `APPLE_PRIVATE_KEY_FILE`
expanded, binary built and installed 755, `uninstall` removed it. Full suite,
`go vet`, and golangci-lint v2.11.4 clean.
