### PR TITLE
fix(config): persist Save("") back to the --config file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,11 @@ import (
 )
 
 type Config struct {
+	// path remembers where this config was loaded from. It is deliberately not
+	// serialized; it only ensures that Save("") persists back to the selected
+	// --config file instead of silently falling back to the default profile.
+	path string
+
 	AppleDeveloperToken string `json:"apple_developer_token"`
 	AppleUserToken      string `json:"apple_user_token"`
 	AppleKeyID          string `json:"apple_key_id"`
@@ -99,6 +104,7 @@ func Load(override string) (*Config, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path comes from user config, not external input
 	if os.IsNotExist(err) {
 		cfg := defaults()
+		cfg.path = path
 		if saveErr := cfg.save(path); saveErr != nil {
 			return nil, fmt.Errorf("creating default config: %w", saveErr)
 		}
@@ -113,6 +119,7 @@ func Load(override string) (*Config, error) {
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
+	cfg.path = path
 	cfg.normalize()
 	return cfg, nil
 }
@@ -132,11 +139,22 @@ func (c *Config) normalize() {
 }
 
 func (c *Config) Save(override string) error {
-	path, err := ConfigPath(override)
-	if err != nil {
+	path := override
+	if path == "" {
+		path = c.path
+	}
+	if path == "" {
+		var err error
+		path, err = ConfigPath("")
+		if err != nil {
+			return err
+		}
+	}
+	if err := c.save(path); err != nil {
 		return err
 	}
-	return c.save(path)
+	c.path = path
+	return nil
 }
 
 func (c *Config) save(path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -301,6 +301,40 @@ func TestSave_WithOverridePath(t *testing.T) {
 	}
 }
 
+func TestSave_UsesLoadedOverrideWhenPathOmitted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	override := writeCfg(t, map[string]any{
+		"storefront": "us",
+		"auth_port":  7777,
+		"provider":   "apple",
+	})
+
+	cfg, err := config.Load(override)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cfg.StoreFront = "gb"
+	if err := cfg.Save(""); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(override) //nolint:gosec // test fixture
+	if err != nil {
+		t.Fatalf("reading override: %v", err)
+	}
+	if !strings.Contains(string(data), `"storefront": "gb"`) {
+		t.Fatalf("override was not updated: %s", data)
+	}
+
+	defaultPath, err := config.ConfigPath("")
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		t.Fatalf("Save created default config %q; stat error = %v", defaultPath, err)
+	}
+}
+
 func TestAudioQualityDefaultsHigh(t *testing.T) {
 	path := writeCfg(t, map[string]any{"storefront": "us"})
 	cfg, err := config.Load(path)


### PR DESCRIPTION
## Why

`vibez --config dev.json` doesn't fully honour the flag. `cfg.Save("")` resolves the
default config path rather than the file the config was loaded from, so part of a
session's state lands in `~/.config/vibez/config.json` while the rest is read back
from `dev.json`. The symptom is a setting that appears to revert: you change it, it's
written to one file, and the next read returns the old value from the other.

## What this changes

`Config` remembers the path it was loaded from in an unexported `path` field that is
deliberately not serialized. `Save("")` writes back to that path, falling back to the
default profile only when the config wasn't loaded from an explicit path.
`Save(override)` behaviour is unchanged, and a successful save updates the remembered
path.

The on-disk format is untouched — no new key, and an unexported field can't leak into
the JSON.

## Tests

New `TestSave_UsesLoadedOverrideWhenPathOmitted` loads from an override, mutates a
field, calls `Save("")`, then asserts the override received the write **and** that no
default config was created. That second assertion is what actually pins the bug —
without it the test would pass even if `Save` wrote to both files.

Full suite, `go vet`, and golangci-lint v2.11.4 clean.
