### PR TITLE
chore: ignore additional credential file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,11 @@ release_notes.md
 
 # Config (personal credentials must not be committed)
 .env
+.env.*
+!.env.example
 *.p8
+*.pem
+*.key
 
 # Editor
 .vscode/


### PR DESCRIPTION
`.gitignore` covers `.env` and `*.p8`, but not the neighbouring patterns that show up in a real working tree:

- `.env.*` — `.env` matches only that exact filename, so `.env.local`, `.env.production` and similar were not ignored at all. `!.env.example` negates it for an example file, so one can still be committed if it's ever added (there isn't one today).
- `*.pem`, `*.key` — same category as the existing `*.p8`.

No tracked file matches any of the new patterns, so nothing becomes untracked by this.
