### PR TITLE
fix(auth): keep the user token when the developer token is rejected

### DIFF
--- a/cmd/cdp_common.go
+++ b/cmd/cdp_common.go
@@ -45,10 +45,16 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 
 		if cfg.AppleUserToken != "" {
 			prog.Send(tui.InitStatusMsg("Checking Apple Music session..."))
-			if !auth.ValidateToken(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
+			switch auth.CheckTokens(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
+			case auth.UserTokenRejected:
 				prog.Send(tui.InitStatusMsg("Session expired - re-authenticating..."))
 				cfg.AppleUserToken = ""
 				_ = cfg.Save("")
+			case auth.DeveloperTokenRejected:
+				// Re-authenticating cannot mint a working developer token, so
+				// keep the user token: it is still good once the build is.
+				prog.Send(tui.InitStatusMsg(auth.DeveloperTokenStatus))
+			case auth.TokensValid:
 			}
 		}
 

--- a/cmd/cdp_common.go
+++ b/cmd/cdp_common.go
@@ -43,6 +43,7 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 			return
 		}
 
+		devTokenRejected := false
 		if cfg.AppleUserToken != "" {
 			prog.Send(tui.InitStatusMsg("Checking Apple Music session..."))
 			switch auth.CheckTokens(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
@@ -53,16 +54,21 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 			case auth.DeveloperTokenRejected:
 				// Re-authenticating cannot mint a working developer token, so
 				// keep the user token: it is still good once the build is.
+				devTokenRejected = true
 				prog.Send(tui.InitStatusMsg(auth.DeveloperTokenStatus))
 			case auth.TokensValid:
 			}
 		}
 
-		status := hooks.initStatus
-		if status == "" {
-			status = "Initializing vibez..."
+		// The generic progress line would replace the warning above before it
+		// could be read, and it carries less information than the warning does.
+		if !devTokenRejected {
+			status := hooks.initStatus
+			if status == "" {
+				status = "Initializing vibez..."
+			}
+			prog.Send(tui.InitStatusMsg(status))
 		}
-		prog.Send(tui.InitStatusMsg(status))
 		if err := cdp.EnsureBrowser(func(msg string) {
 			prog.Send(tui.InitStatusMsg(msg))
 		}); err != nil {

--- a/cmd/root_linux.go
+++ b/cmd/root_linux.go
@@ -49,10 +49,16 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 
 	if cfg.AppleUserToken != "" {
 		fmt.Fprintln(os.Stderr, "Checking Apple Music session...")
-		if !auth.ValidateToken(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
+		switch auth.CheckTokens(cfg.AppleDeveloperToken, cfg.AppleUserToken) {
+		case auth.UserTokenRejected:
 			fmt.Fprintln(os.Stderr, "Session expired - re-authenticating...")
 			cfg.AppleUserToken = ""
 			_ = cfg.Save("")
+		case auth.DeveloperTokenRejected:
+			// Re-authenticating cannot mint a working developer token, so keep
+			// the user token: it is still good once the build is.
+			fmt.Fprintln(os.Stderr, auth.DeveloperTokenHelp)
+		case auth.TokensValid:
 		}
 	}
 	if cfg.AppleUserToken == "" {

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -84,8 +84,9 @@ type probeResult int
 const (
 	probeAccepted probeResult = iota
 	probeRejected
-	// probeInconclusive covers network failures, where assuming the worst
-	// would force an unnecessary re-login.
+	// probeInconclusive covers network failures and any response that is
+	// neither a clear acceptance nor a clear rejection, where assuming the
+	// worst would force an unnecessary re-login.
 	probeInconclusive
 )
 
@@ -113,5 +114,11 @@ func probe(url, devToken, userToken string) probeResult {
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return probeRejected
 	}
-	return probeAccepted
+	// Only a 2xx proves the credentials were accepted. A 429 or a 5xx says
+	// nothing about them, and treating it as acceptance would let a transient
+	// Apple outage attribute the rejection to the user token and wipe it.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return probeAccepted
+	}
+	return probeInconclusive
 }

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -6,40 +6,112 @@ import (
 	"time"
 )
 
-const storefrontURL = "https://api.music.apple.com/v1/me/storefront"
+const (
+	// storefrontURL needs both a developer token and a Music User Token, so a
+	// rejection here does not say which of the two Apple objected to.
+	storefrontURL = "https://api.music.apple.com/v1/me/storefront"
+	// catalogURL needs only a developer token, which makes it the tiebreaker
+	// when storefrontURL rejects a request.
+	catalogURL = "https://api.music.apple.com/v1/storefronts"
+)
 
-// ValidateToken makes a lightweight Apple Music API call to check whether
-// the stored user token is still valid.
+// TokenStatus reports which credential Apple Music rejected.
+type TokenStatus int
+
+const (
+	// TokensValid means both credentials were accepted, or that the check
+	// could not be completed and the caller should carry on as before.
+	TokensValid TokenStatus = iota
+	// UserTokenRejected means the Music User Token is expired, revoked or
+	// absent while the developer token still works. Logging in again fixes it.
+	UserTokenRejected
+	// DeveloperTokenRejected means the developer token is expired, revoked or
+	// absent. Logging in again cannot fix it, because MusicKit needs a valid
+	// developer token before it will ask the user to authorize anything.
+	DeveloperTokenRejected
+)
+
+// DeveloperTokenStatus is a one-line summary for a status bar.
+const DeveloperTokenStatus = "Developer token rejected - update vibez to continue"
+
+// DeveloperTokenHelp is the same failure explained where there is room for it.
 //
-// Returns false when the API responds with 401 or 403 (token expired or
-// revoked). Returns true on network errors so that a temporary connectivity
-// problem does not force an unnecessary re-login.
-func ValidateToken(devToken, userToken string) bool {
-	return probeURL(storefrontURL, devToken, userToken)
+//nolint:gosec // G101: prose naming a config key, not a credential
+const DeveloperTokenHelp = `Apple Music rejected vibez's developer token, which is a problem with this
+build rather than with your account. Your saved session has been kept.
+Updating to a newer release restores access; a source build can instead set
+apple_developer_token in the config.`
+
+// CheckTokens asks Apple Music which of the stored credentials still works.
+//
+// It is deliberately conservative: anything it cannot establish comes back as
+// TokensValid, so a flaky network never costs the user a working session.
+func CheckTokens(devToken, userToken string) TokenStatus {
+	return checkTokens(storefrontURL, catalogURL, devToken, userToken)
 }
 
-// probeURL is the testable core of ValidateToken. It accepts an explicit URL
-// so tests can point it at an httptest server.
-func probeURL(url, devToken, userToken string) bool {
-	if devToken == "" || userToken == "" {
-		return false
+// checkTokens is the testable core of CheckTokens. It takes both URLs
+// explicitly so tests can point them at an httptest server.
+func checkTokens(userURL, devURL, devToken, userToken string) TokenStatus {
+	if devToken == "" {
+		return DeveloperTokenRejected
+	}
+	if userToken == "" {
+		return UserTokenRejected
 	}
 
+	if probe(userURL, devToken, userToken) != probeRejected {
+		return TokensValid
+	}
+
+	// Both credentials travelled together on that request, so the rejection is
+	// still unattributed. A developer-token-only endpoint settles it.
+	switch probe(devURL, devToken, "") {
+	case probeRejected:
+		return DeveloperTokenRejected
+	case probeAccepted:
+		return UserTokenRejected
+	default:
+		// The tiebreaker did not complete, so the cause stays unknown. Keep
+		// the user token rather than discarding it on a guess.
+		return TokensValid
+	}
+}
+
+// probeResult is the outcome of a single credential probe.
+type probeResult int
+
+const (
+	probeAccepted probeResult = iota
+	probeRejected
+	// probeInconclusive covers network failures, where assuming the worst
+	// would force an unnecessary re-login.
+	probeInconclusive
+)
+
+// probe makes one lightweight Apple Music request. An empty userToken sends
+// the developer token alone.
+func probe(url, devToken, userToken string) probeResult {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // URL is a hardcoded constant or test server
 	if err != nil {
-		return true // assume valid
+		return probeInconclusive
 	}
 	req.Header.Set("Authorization", "Bearer "+devToken)
-	req.Header.Set("Music-User-Token", userToken)
+	if userToken != "" {
+		req.Header.Set("Music-User-Token", userToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return true // network error → assume valid, let the engine surface it
+		return probeInconclusive
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	return resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return probeRejected
+	}
+	return probeAccepted
 }

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -6,73 +6,116 @@ import (
 	"testing"
 )
 
-func TestValidateToken_ValidToken(t *testing.T) {
+// statusServer serves a fixed status code and records the request it saw.
+func statusServer(t *testing.T, code int) (*httptest.Server, *http.Header) {
+	t.Helper()
+	var seen http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
+		seen = r.Header.Clone()
+		w.WriteHeader(code)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
+	return srv, &seen
+}
 
-	if !probeURL(srv.URL, "dev", "user") {
-		t.Error("expected true for 200 response, got false")
+// deadURL points at a port that refuses connections.
+const deadURL = "http://127.0.0.1:1"
+
+func TestCheckTokens_BothValid(t *testing.T) {
+	user, _ := statusServer(t, http.StatusOK)
+	dev, _ := statusServer(t, http.StatusOK)
+
+	if got := checkTokens(user.URL, dev.URL, "dev", "user"); got != TokensValid {
+		t.Errorf("checkTokens = %v, want TokensValid", got)
 	}
 }
 
-func TestValidateToken_ExpiredToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
+func TestCheckTokens_UserTokenExpired(t *testing.T) {
+	// The combined request is rejected but the developer token alone works,
+	// which isolates the Music User Token as the expired credential.
+	user, _ := statusServer(t, http.StatusUnauthorized)
+	dev, _ := statusServer(t, http.StatusOK)
 
-	if probeURL(srv.URL, "dev", "user") {
-		t.Error("expected false for 401 response, got true")
+	if got := checkTokens(user.URL, dev.URL, "dev", "user"); got != UserTokenRejected {
+		t.Errorf("checkTokens = %v, want UserTokenRejected", got)
 	}
 }
 
-func TestValidateToken_ForbiddenToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer srv.Close()
+// TestCheckTokens_DeveloperTokenExpired is the regression test for the bug
+// where an expired developer token was reported as an expired session, and the
+// caller then cleared a perfectly good Music User Token.
+func TestCheckTokens_DeveloperTokenExpired(t *testing.T) {
+	user, _ := statusServer(t, http.StatusUnauthorized)
+	dev, _ := statusServer(t, http.StatusUnauthorized)
 
-	if probeURL(srv.URL, "dev", "user") {
-		t.Error("expected false for 403 response, got true")
+	if got := checkTokens(user.URL, dev.URL, "dev", "user"); got != DeveloperTokenRejected {
+		t.Errorf("checkTokens = %v, want DeveloperTokenRejected", got)
 	}
 }
 
-func TestValidateToken_EmptyTokens(t *testing.T) {
-	if ValidateToken("", "user") {
-		t.Error("expected false for empty devToken")
-	}
-	if ValidateToken("dev", "") {
-		t.Error("expected false for empty userToken")
-	}
-	if ValidateToken("", "") {
-		t.Error("expected false for both empty")
+func TestCheckTokens_ForbiddenIsRejection(t *testing.T) {
+	user, _ := statusServer(t, http.StatusForbidden)
+	dev, _ := statusServer(t, http.StatusForbidden)
+
+	if got := checkTokens(user.URL, dev.URL, "dev", "user"); got != DeveloperTokenRejected {
+		t.Errorf("checkTokens = %v, want DeveloperTokenRejected", got)
 	}
 }
 
-func TestValidateToken_NetworkError(t *testing.T) {
-	// Point at a port that refuses connections → should return true (assume valid).
-	if !probeURL("http://127.0.0.1:1", "dev", "user") {
-		t.Error("expected true on network error (assume valid), got false")
+func TestCheckTokens_MissingCredentials(t *testing.T) {
+	if got := CheckTokens("", "user"); got != DeveloperTokenRejected {
+		t.Errorf("empty devToken = %v, want DeveloperTokenRejected", got)
+	}
+	if got := CheckTokens("dev", ""); got != UserTokenRejected {
+		t.Errorf("empty userToken = %v, want UserTokenRejected", got)
+	}
+	if got := CheckTokens("", ""); got != DeveloperTokenRejected {
+		t.Errorf("both empty = %v, want DeveloperTokenRejected", got)
 	}
 }
 
-func TestValidateToken_HeadersSet(t *testing.T) {
-	var gotAuth, gotUserToken string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		gotUserToken = r.Header.Get("Music-User-Token")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+func TestCheckTokens_NetworkErrorKeepsSession(t *testing.T) {
+	dev, _ := statusServer(t, http.StatusOK)
 
-	probeURL(srv.URL, "mydev", "myuser")
-
-	if gotAuth != "Bearer mydev" {
-		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer mydev")
+	if got := checkTokens(deadURL, dev.URL, "dev", "user"); got != TokensValid {
+		t.Errorf("checkTokens = %v, want TokensValid on network error", got)
 	}
-	if gotUserToken != "myuser" {
-		t.Errorf("Music-User-Token = %q, want %q", gotUserToken, "myuser")
+}
+
+// A rejection the tiebreaker cannot attribute must not cost the user a session.
+func TestCheckTokens_InconclusiveTiebreakerKeepsSession(t *testing.T) {
+	user, _ := statusServer(t, http.StatusUnauthorized)
+
+	if got := checkTokens(user.URL, deadURL, "dev", "user"); got != TokensValid {
+		t.Errorf("checkTokens = %v, want TokensValid on inconclusive tiebreaker", got)
+	}
+}
+
+func TestCheckTokens_SendsBothCredentials(t *testing.T) {
+	user, userHeaders := statusServer(t, http.StatusOK)
+	dev, _ := statusServer(t, http.StatusOK)
+
+	checkTokens(user.URL, dev.URL, "mydev", "myuser")
+
+	if got := userHeaders.Get("Authorization"); got != "Bearer mydev" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer mydev")
+	}
+	if got := userHeaders.Get("Music-User-Token"); got != "myuser" {
+		t.Errorf("Music-User-Token = %q, want %q", got, "myuser")
+	}
+}
+
+// The tiebreaker must carry the developer token alone, or it proves nothing.
+func TestCheckTokens_TiebreakerOmitsUserToken(t *testing.T) {
+	user, _ := statusServer(t, http.StatusUnauthorized)
+	dev, devHeaders := statusServer(t, http.StatusOK)
+
+	checkTokens(user.URL, dev.URL, "mydev", "myuser")
+
+	if got := devHeaders.Get("Authorization"); got != "Bearer mydev" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer mydev")
+	}
+	if got := devHeaders.Get("Music-User-Token"); got != "" {
+		t.Errorf("Music-User-Token = %q, want it unset", got)
 	}
 }

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -91,6 +91,25 @@ func TestCheckTokens_InconclusiveTiebreakerKeepsSession(t *testing.T) {
 	}
 }
 
+// A tiebreaker that fails for reasons of Apple's own must not be read as proof
+// the developer token is good, because that attributes the rejection to the
+// user token and clears a session that was never the problem.
+func TestCheckTokens_ServerErrorTiebreakerKeepsSession(t *testing.T) {
+	for _, code := range []int{
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+	} {
+		user, _ := statusServer(t, http.StatusUnauthorized)
+		dev, _ := statusServer(t, code)
+
+		if got := checkTokens(user.URL, dev.URL, "dev", "user"); got != TokensValid {
+			t.Errorf("tiebreaker %d: checkTokens = %v, want TokensValid", code, got)
+		}
+	}
+}
+
 func TestCheckTokens_SendsBothCredentials(t *testing.T) {
 	user, userHeaders := statusServer(t, http.StatusOK)
 	dev, _ := statusServer(t, http.StatusOK)


### PR DESCRIPTION
`ValidateToken` probed `/v1/me/storefront`, which requires both the developer
token and the Music User Token, and collapsed the answer to a bool. A 401 there
cannot say which credential Apple refused, but both callers treated it as an
expired session: `cmd/cdp_common.go` and `cmd/root_linux.go` printed "Session
expired - re-authenticating...", cleared `AppleUserToken` and saved the config.

So an expired developer token deleted a working session, and the re-login that
followed could not succeed either, since MusicKit needs a valid developer token
before it will authorize anyone. This is live right now: the token embedded in
v0.5.0 expired around 9 August, and #113 is someone hitting it.

`CheckTokens` returns a three-state result instead. When the combined request is
rejected, a second probe against `/v1/storefronts` sends the developer token
alone and attributes the failure:

- `UserTokenRejected` clears the token and re-authenticates, as before
- `DeveloperTokenRejected` reports the cause and leaves the session intact
- `TokensValid` proceeds

Anything the probes cannot establish, including a network failure on either
request, returns `TokensValid`. That keeps the old assume-valid behaviour, so a
flaky connection never costs someone a session.

This is only the attribution bug. It does not touch the lifecycle question in
#108, which is your call, and it does not change `ApplyEmbedded`.

Tested on linux/amd64: `go test ./...`, `go vet ./...`, golangci-lint v2.11.4
and gofmt all clean. `GOOS=darwin GOARCH=arm64 go build ./cmd/...` compiles.
`root_darwin.go` has no call site of its own and reaches this through
`cdp_common.go`, but it has not been run on macOS.
