### PR TITLE
fix(apple): fall back to catalog search when amp-api rejects the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Discovery mode returned nothing when amp-api rejected the token**: catalog song search goes through `amp-api.music.apple.com`, an undocumented web-player endpoint that can reject a developer/user token pair the supported endpoints accept. The songs leg then came back empty while the library and album/playlist legs succeeded, leaving discovery with nothing to refill from. That leg now retries against Apple's supported `/catalog/{storefront}/search` endpoint. The fallback response carries no `extendedAssetUrls`, so the stream-availability filter is applied only to amp-api results, and playback stays the final authority on storefront availability. Refs #93.
+
 ## [0.6.0] — 2026-08-20
 
 ### Added

--- a/internal/provider/apple/apple.go
+++ b/internal/provider/apple/apple.go
@@ -367,8 +367,9 @@ func (a *AppleProvider) Search(ctx context.Context, query string) (*provider.Sea
 		err       error
 	}
 	type catSongsOut struct {
-		songs []songResource
-		err   error
+		songs           []songResource
+		verifiedStreams bool
+		err             error
 	}
 	type catCollOut struct {
 		albums    []albumResource
@@ -419,8 +420,25 @@ func (a *AppleProvider) Search(ctx context.Context, query string) (*provider.Sea
 			return
 		}
 		var resp searchResponse
-		if err := a.do(req, &resp); err != nil {
-			catSongsCh <- catSongsOut{err: err}
+		if err := a.do(req, &resp); err == nil {
+			catSongsCh <- catSongsOut{songs: resp.Results.Songs.Data, verifiedStreams: true}
+			return
+		}
+
+		// amp-api is an undocumented web-player endpoint and can reject otherwise
+		// valid developer/user tokens. Fall back to Apple's supported catalog
+		// search. It omits extendedAssetUrls, so playback remains the final
+		// authority for storefront availability.
+		fallbackEP := fmt.Sprintf("/catalog/%s/search?term=%s&types=songs&limit=25",
+			sf, url.QueryEscape(query))
+		fallbackReq, fallbackErr := a.newRequest(ctx, http.MethodGet, fallbackEP)
+		if fallbackErr != nil {
+			catSongsCh <- catSongsOut{err: fallbackErr}
+			return
+		}
+		resp = searchResponse{}
+		if fallbackErr = a.do(fallbackReq, &resp); fallbackErr != nil {
+			catSongsCh <- catSongsOut{err: fallbackErr}
 			return
 		}
 		catSongsCh <- catSongsOut{songs: resp.Results.Songs.Data}
@@ -505,7 +523,7 @@ func (a *AppleProvider) Search(ctx context.Context, query string) (*provider.Sea
 			if s.Attributes.PlayParams.Kind != "song" {
 				continue
 			}
-			if !s.Attributes.ExtendedAssetURLs.hasStream() {
+			if catSongs.verifiedStreams && !s.Attributes.ExtendedAssetURLs.hasStream() {
 				continue
 			}
 			t := toTrack(s)

--- a/internal/provider/apple/apple_test.go
+++ b/internal/provider/apple/apple_test.go
@@ -322,6 +322,92 @@ func TestSearch_NoWarningsWhenAllLegsSucceed(t *testing.T) {
 	}
 }
 
+// The amp-api leg can reject tokens that work everywhere else. When it does,
+// the supported /catalog/{sf}/search endpoint is retried — and because that
+// endpoint never returns extendedAssetUrls, the stream filter must be skipped
+// for its results. Applying it would drop every fallback result for lacking a
+// field the endpoint does not send, which is the empty-songs bug this fixes.
+func TestSearch_CatalogSongsFallBackWhenAmpAPIRejects(t *testing.T) {
+	// Exactly the shape the fallback returns: playable, but no extendedAssetUrls.
+	fallbackSong := songJSONNoStream("777", "Fallback Song", "Artist", "Album", 210000)
+	empty := map[string]any{"results": map[string]any{}}
+
+	var ampCalls, fallbackCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/me/library/search"):
+			writeJSON(t, w, empty)
+		case r.URL.Query().Get("types") != "songs":
+			writeJSON(t, w, empty) // albums/playlists leg
+		case strings.Contains(r.URL.RawQuery, "extend=extendedAssetUrls"):
+			ampCalls.Add(1)
+			w.WriteHeader(http.StatusUnauthorized) // amp-api rejects the token
+		default:
+			fallbackCalls.Add(1)
+			writeJSON(t, w, map[string]any{"results": map[string]any{
+				"songs": map[string]any{"data": []any{fallbackSong}},
+			}})
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	result, err := p.Search(context.Background(), "fallback song")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if got := ampCalls.Load(); got != 1 {
+		t.Errorf("amp-api calls: got %d, want 1", got)
+	}
+	if got := fallbackCalls.Load(); got != 1 {
+		t.Errorf("fallback calls: got %d, want 1 — the retry did not happen", got)
+	}
+	if len(result.Tracks) != 1 || result.Tracks[0].ID != "777" {
+		t.Fatalf("Tracks: got %+v, want the fallback track 777 kept despite having no extendedAssetUrls", result.Tracks)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("Warnings: got %v, want none — the fallback succeeded", result.Warnings)
+	}
+}
+
+// The filter must still apply on the amp-api path, where the field IS returned:
+// the fallback loosens it only for the endpoint that cannot report it.
+func TestSearch_StreamFilterStillAppliesWhenAmpAPISucceeds(t *testing.T) {
+	playable := songJSON("111", "Playable", "Artist", "Album", 200000, "")
+	purchaseOnly := songJSONNoStream("333", "Buy Only", "Artist", "Album", 200000)
+	empty := map[string]any{"results": map[string]any{}}
+
+	var fallbackCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/me/library/search"):
+			writeJSON(t, w, empty)
+		case r.URL.Query().Get("types") != "songs":
+			writeJSON(t, w, empty)
+		case strings.Contains(r.URL.RawQuery, "extend=extendedAssetUrls"):
+			writeJSON(t, w, map[string]any{"results": map[string]any{
+				"songs": map[string]any{"data": []any{playable, purchaseOnly}},
+			}})
+		default:
+			fallbackCalls.Add(1)
+			writeJSON(t, w, empty)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv)
+	result, err := p.Search(context.Background(), "song")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if got := fallbackCalls.Load(); got != 0 {
+		t.Errorf("fallback calls: got %d, want 0 — amp-api succeeded", got)
+	}
+	if len(result.Tracks) != 1 || result.Tracks[0].ID != "111" {
+		t.Fatalf("Tracks: got %+v, want only the streamable track 111", result.Tracks)
+	}
+}
+
 func TestSearch_QueryEncoded(t *testing.T) {
 	var gotURLs []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Refs #93, and the other half of #98. That one made the failure visible; this one makes it recoverable.

## The problem

The catalog-songs leg of `Search` goes through `amp-api.music.apple.com` (apple.go:23, request built at :415), because it is the endpoint that returns `extendedAssetUrls` and therefore the only one that can tell us whether a result is actually streamable.

It is also an undocumented web-player endpoint, and it can reject a developer/user token pair that the supported endpoints accept. That is what #93 turns out to be: 401 on every catalog-song request while the library and album/playlist legs keep working. After #98 that surfaces as a warning instead of silence, but the songs leg still returns nothing, so discovery has nothing to refill from and the user-visible symptom is unchanged.

## What this changes

When the amp-api request fails, the leg retries against Apple's supported `/catalog/{storefront}/search?types=songs` endpoint rather than giving up.

That endpoint does not return `extendedAssetUrls`, so `hasStream()` would discard every result it produces, for lacking a field the endpoint never sends. The filter is therefore gated on `verifiedStreams`, set only when the amp-api response succeeded. Fallback results are returned unfiltered, and playback stays the final authority on storefront availability.

This is the `extendedAssetUrls` decision I flagged in #98 as yours. I have taken the narrow reading: relax the filter only on the path that cannot populate the field, and never on the amp-api path. If you would rather the fallback did not exist, or would rather it return nothing than return unverified results, say so and I will cut it back.

## Tests

- `TestSearch_CatalogSongsFallBackWhenAmpAPIRejects`: amp-api answers 401, the fallback is called exactly once, and a song with no `extendedAssetUrls` survives into the results with no warning raised.
- `TestSearch_StreamFilterStillAppliesWhenAmpAPISucceeds`: amp-api succeeds, the fallback is never called, and a purchase-only result is still dropped.

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` and `golangci-lint run` (v2.11.4) are all clean on linux/amd64.
