### PR TITLE
build(devtoken): raise the developer token TTL to Apple's ceiling

### DIFF
--- a/scripts/gen-devtoken/main.go
+++ b/scripts/gen-devtoken/main.go
@@ -3,8 +3,7 @@
 // signed token to stdout so CI can capture and inject it at build time.
 //
 // With -write it instead writes the token into apple_developer_token in the
-// vibez config file, which is handy for local (non-embedded) builds where the
-// token expires every 30 days.
+// vibez config file, which is handy for local (non-embedded) builds.
 //
 // Required env vars:
 //
@@ -57,7 +56,17 @@ func main() {
 	fmt.Fprintf(os.Stderr, "wrote developer token to %s\n", path)
 }
 
-// generateToken signs an Apple Music developer JWT valid for 30 days.
+// tokenTTL is how long a generated developer token stays valid.
+//
+// Apple caps MusicKit developer tokens at six months, 15777000 seconds, and
+// rejects anything longer at token-exchange time. Releases embed the token at
+// build time, so a short TTL means a binary stops reaching the catalog long
+// before it stops being the newest release: the ceiling is the useful value
+// here. A rejected token is no longer destructive to the user's session, and
+// vibez tells them the build is stale rather than clearing their login.
+const tokenTTL = 15777000 * time.Second
+
+// generateToken signs an Apple Music developer JWT valid for tokenTTL.
 func generateToken(keyID, teamID, privateKeyPEM string) (string, error) {
 	ecKey, err := parsePrivateKey(privateKeyPEM)
 	if err != nil {
@@ -71,7 +80,7 @@ func generateToken(keyID, teamID, privateKeyPEM string) (string, error) {
 	token.Claims = jwt.MapClaims{
 		"iss": teamID,
 		"iat": now.Unix(),
-		"exp": now.Add(30 * 24 * time.Hour).Unix(),
+		"exp": now.Add(tokenTTL).Unix(),
 	}
 
 	signed, err := token.SignedString(ecKey)

--- a/scripts/gen-devtoken/main_test.go
+++ b/scripts/gen-devtoken/main_test.go
@@ -90,7 +90,7 @@ func TestGeneratedTokenClaims(t *testing.T) {
 	tok.Claims = jwt.MapClaims{
 		"iss": "TEAMID1234",
 		"iat": now.Unix(),
-		"exp": now.Add(30 * 24 * time.Hour).Unix(),
+		"exp": now.Add(tokenTTL).Unix(),
 	}
 
 	signed, err := tok.SignedString(key)
@@ -155,6 +155,50 @@ func TestGenerateToken_InvalidKey(t *testing.T) {
 	}
 }
 
+// generateToken is the only thing that sets the real expiry, and nothing
+// exercised it before: the fixtures above rebuild the claims by hand. Apple
+// rejects a developer token whose lifetime exceeds six months, so a value that
+// drifts past the ceiling fails at token-exchange time rather than at build
+// time, where it would be caught.
+func TestGenerateTokenExpiry(t *testing.T) {
+	const appleMaxTTL = 15777000 * time.Second
+
+	if tokenTTL > appleMaxTTL {
+		t.Fatalf("tokenTTL = %v, exceeds Apple's %v ceiling", tokenTTL, appleMaxTTL)
+	}
+
+	_, pemStr := generateTestKey(t)
+
+	before := time.Now()
+	signed, err := generateToken("TESTKEY123", "TEAMID1234", pemStr)
+	if err != nil {
+		t.Fatalf("generateToken: %v", err)
+	}
+	after := time.Now()
+
+	parsed, _, err := jwt.NewParser().ParseUnverified(signed, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parsing generated token: %v", err)
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("unexpected claims type")
+	}
+
+	expF, ok := claims["exp"].(float64)
+	if !ok {
+		t.Fatalf("exp claim = %T, want a number", claims["exp"])
+	}
+	exp := time.Unix(int64(expF), 0)
+
+	// The token is signed somewhere inside [before, after], so the expiry must
+	// land in that same window shifted by tokenTTL.
+	lo, hi := before.Add(tokenTTL).Add(-time.Second), after.Add(tokenTTL).Add(time.Second)
+	if exp.Before(lo) || exp.After(hi) {
+		t.Errorf("exp = %v, want within [%v, %v]", exp, lo, hi)
+	}
+}
+
 func TestTokenHasCorrectHeader(t *testing.T) {
 	key, _ := generateTestKey(t)
 
@@ -163,7 +207,7 @@ func TestTokenHasCorrectHeader(t *testing.T) {
 	tok.Claims = jwt.MapClaims{
 		"iss": "TEAMTEST",
 		"iat": time.Now().Unix(),
-		"exp": time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"exp": time.Now().Add(tokenTTL).Unix(),
 	}
 
 	signed, err := tok.SignedString(key)


### PR DESCRIPTION
Refs #108. Item 1 of the plan you settled on there: a 180 day developer token, nothing else.

## What changes

`scripts/gen-devtoken` signed tokens for 30 days. This raises that to Apple's ceiling, 15777000 seconds, behind a named `tokenTTL` constant so the value has somewhere to be explained.

Releases embed the token at build time, so the old TTL meant a binary stopped reaching the catalog long before it stopped being the newest release. #113 and #65 are both that, one expiry apart.

Two things this does not do:

- It does not help any binary already published. v0.6.1 carries a 30 day token signed on 20 August, so it lapses around 19 September regardless. A release cut after this lands is what actually puts a six month token in front of users.
- It widens the window in which a leaked token stays usable, which is the cost I flagged in the issue. The trade still favours it: extraction difficulty is unchanged, and the alternative is a guaranteed monthly breakage.

Items 3 and 4 stay separate. 4 is already in via #109. I will send the `DeveloperTokenRejected` update prompt as its own PR.

## Tests

Nothing asserted the production expiry before this. Both existing fixtures rebuild the claims by hand rather than calling `generateToken`, so `exp` was the one claim no test covered, and a drift past Apple's limit would have surfaced at token exchange rather than at build time.

`TestGenerateTokenExpiry` signs a token with the real code path and asserts `exp` lands inside `[before + tokenTTL, after + tokenTTL]`, and fails outright if `tokenTTL` ever exceeds the six month ceiling. The two hand built fixtures now reference `tokenTTL` instead of restating 30 days, so they cannot disagree with the generator again.

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` and `golangci-lint run` (v2.11.4) are all clean on linux/amd64.
