### PR TITLE
build(release): build darwin on a macOS runner with CGo enabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,64 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Darwin is built here rather than in the release job below because its
+  # native backends are CGO: a macOS runner is the only place clang and the
+  # macOS SDK are available. The archives are handed to the release job, which
+  # attaches them to the same release via extra_files.
+  darwin:
+    name: build-darwin
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      # Signed here as well as in the release job: a masked value cannot be
+      # handed between jobs, and two tokens signed from the same key are
+      # equivalent. garble installs via the goreleaser before-hook.
+      - name: Generate Apple Developer Token
+        id: devtoken
+        env:
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_PRIVATE_KEY: ${{ secrets.APPLE_PRIVATE_KEY }}
+        run: |
+          TOKEN=$(go run ./scripts/gen-devtoken)
+          # Mask the token so it never appears in logs
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Build darwin archives
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean --skip=publish
+        env:
+          APPLE_DEV_TOKEN: ${{ steps.devtoken.outputs.token }}
+          VIBEZ_SKIP_LINUX: '1'
+          # Prevent Go from downloading a different toolchain into GOMODCACHE,
+          # which garble cannot patch (overlay restrictions on GOMODCACHE).
+          GOTOOLCHAIN: local
+
+      - name: Upload darwin archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-archives
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          # Consumed by the next job; the same bytes ship on the release.
+          retention-days: 1
+
   release:
+    name: release
+    needs: darwin
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,6 +101,23 @@ jobs:
           echo "::add-mask::$TOKEN"
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
+      - name: Download darwin archives
+        uses: actions/download-artifact@v4
+        with:
+          name: darwin-archives
+          path: dist-darwin
+
+      - name: Check darwin archives
+        run: |
+          # extra_files globs quietly when nothing matches, so without this the
+          # release would publish with no macOS binaries and no error anywhere.
+          for arch in amd64 arm64; do
+            f="dist-darwin/vibez_darwin_${arch}.tar.gz"
+            [ -s "$f" ] || { echo "missing $f"; exit 1; }
+            tar tzf "$f" | grep -qx vibez || { echo "$f contains no vibez binary"; exit 1; }
+          done
+          ls -l dist-darwin
+
       - name: Extract CHANGELOG entry
         id: changelog
         run: |
@@ -64,6 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_DEV_TOKEN: ${{ steps.devtoken.outputs.token }}
           PROJECT_DIR: ${{ github.workspace }}
+          VIBEZ_SKIP_DARWIN: '1'
           # Prevent Go from downloading a different toolchain into GOMODCACHE,
           # which garble cannot patch (overlay restrictions on GOMODCACHE).
           GOTOOLCHAIN: local

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage.html
 
 # Release
 release_notes.md
+dist-darwin/
 
 # Config (personal credentials must not be committed)
 .env

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ builds:
   - id: vibez-linux
     binary: vibez
     gobinary: ./scripts/garble-go
+    # Set to 1 by the darwin release job, which runs this same config on a
+    # macOS runner and cannot build the webkit/gstreamer CGO target.
+    skip: '{{ eq (index .Env "VIBEZ_SKIP_LINUX") "1" }}'
     ldflags:
       - -s -w
       - -X 'github.com/simone-vibes/vibez/internal/version.Version={{ .Version }}'
@@ -30,18 +33,32 @@ builds:
   - id: vibez-darwin
     binary: vibez
     gobinary: ./scripts/garble-go
+    # Set to 1 by the linux release job. Darwin is built on a macOS runner so
+    # that CGO_ENABLED=1 below has a working clang and the macOS SDK; the two
+    # jobs each skip the other's target.
+    skip: '{{ eq (index .Env "VIBEZ_SKIP_DARWIN") "1" }}'
     ldflags:
       - -s -w
       - -X 'github.com/simone-vibes/vibez/internal/version.Version={{ .Version }}'
       - -X 'github.com/simone-vibes/vibez/internal/auth.devToken={{ .Env.APPLE_DEV_TOKEN }}'
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - GOTOOLCHAIN=local
     goos:
       - darwin
     goarch:
       - amd64
       - arm64
+    overrides:
+      # macos-latest is arm64, so darwin/amd64 is a cgo cross-compile and clang
+      # has to be told which architecture to emit. Only the compiler vars belong
+      # here: this env is merged into the build's rather than replacing it, so
+      # CGO_ENABLED=1 above still reaches the amd64 target.
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=clang -arch x86_64
+          - CXX=clang++ -arch x86_64
 
 archives:
   - id: vibez
@@ -59,6 +76,10 @@ archives:
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256
+  # Darwin archives are built on the macOS job and handed to this one as
+  # ./dist-darwin, outside the dist/ that --clean wipes.
+  extra_files:
+    - glob: ./dist-darwin/*.tar.gz
 
 changelog:
   sort: asc
@@ -78,3 +99,5 @@ release:
   draft: false
   prerelease: auto
   replace_existing_artifacts: true
+  extra_files:
+    - glob: ./dist-darwin/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **macOS release binaries are now built on a macOS runner with CGo enabled** — `.goreleaser.yml` built the darwin artefacts with `CGO_ENABLED=0` on the Linux release runner, so a native macOS backend would compile in CI and work for anyone running `make build`, then silently fall back to its no-cgo stub in every published binary. Darwin now builds on `macos-latest` with `CGO_ENABLED=1`, and those archives are attached to the same release as the Linux ones. Nothing changes for the current feature set — every cgo package in the tree is `//go:build linux` — but the macOS local-tracks player in #62 cannot ship without it. Refs #117.
+
 ## [0.6.1] — 2026-08-21
 
 ### Fixed


### PR DESCRIPTION
Refs #117. Option 1, the one you picked: darwin builds on `macos-latest` with `CGO_ENABLED=1`.

## What changes

`.goreleaser.yml` flips the darwin build to `CGO_ENABLED=1`, and `release.yml` grows a
`build-darwin` job on `macos-latest` that produces the two darwin archives and hands them to
the existing ubuntu job, which attaches them to the same release through
`release.extra_files` and covers them in `checksums.txt` through `checksum.extra_files`. One
release, one checksum file, same artefact names as today.

Both builds carry a templated `skip`, so a single config serves both runners: the mac job
sets `VIBEZ_SKIP_LINUX`, the linux job sets `VIBEZ_SKIP_DARWIN`, and with neither set the
config behaves exactly as it does now.

**A correction to my own issue text:** I offered `goreleaser release --split` plus
`continue --merge` as the mechanism. That is Pro-only, as is the `prebuilt` builder, which
would have been the other clean way to pass binaries between runners. Hence the artefact
handoff.

Three details worth knowing:

- `macos-latest` is arm64, so darwin/amd64 is a cgo cross-compile and needs
  `CC=clang -arch x86_64`. That `overrides` env merges into the build env rather than
  replacing it, so `CGO_ENABLED=1` still reaches the amd64 target — measured, not assumed.
- The developer token is signed once per job. A masked value cannot be handed between jobs,
  and two tokens signed from the same key are equivalent.
- `extra_files` globs quietly when nothing matches. A lost artefact would publish a release
  with no mac binaries and no error anywhere, so the ubuntu job checks both archives exist
  and contain a `vibez` binary before goreleaser runs.

## Reproduced on Apple Silicon

go1.26.1 darwin/arm64, no local edits beyond the config in this PR.

Against `main` the flip is inert, which is worth stating plainly: every cgo package in the
tree is `//go:build linux`, so nothing about today's feature set changes. To make cgo
observable I ran the same config against #62's head `a34eae3`:

| check | result |
|---|---|
| `garble -literals -tiny` over the AudioToolbox package | builds, both slices |
| `otool -L` on darwin/arm64 | links `/System/Library/Frameworks/AudioToolbox` |
| `otool -L` on darwin/amd64 (cross-compiled) | links `/System/Library/Frameworks/AudioToolbox` |
| same tree at `CGO_ENABLED=0` | no AudioToolbox — the stub path this removes from releases |
| binaries run | arm64 natively, amd64 under Rosetta, both report the injected version |
| garble applied | 0 readable module-path strings, matching the published v0.6.1 binary |
| archive shape | `CHANGELOG.md`, `LICENSE`, `README.md`, `vibez` — same as published |
| `checksum.extra_files` digests | match `shasum -a 256` |

The stub is the concrete failure this prevents: `player_darwin_nocgo.go`'s `New()` returns
`local playback requires CGo on macOS — build with CGO_ENABLED=1`, and that is what every
published mac binary would have done with #62 merged and the release job unchanged.

## Dry run of the whole flow

The two steps this machine cannot exercise are the cross-job artefact handoff and the
`release.extra_files` upload, so I ran the whole flow on a throwaway tag in my fork, on a
branch with #62 merged in so the outcome was observable end to end
([run](https://github.com/ianswope/vibez/actions/runs/32539261397)):

- `build-darwin` on `macos-latest`: linux skipped, `darwin_arm64_v8.0` and `darwin_amd64_v1`
  built and archived, 2m20s.
- The merged env for `darwin_amd64_v1` came out as
  `[CC=clang -arch x86_64 CXX=clang++ -arch x86_64 CGO_ENABLED=1 GOTOOLCHAIN=local]`.
- `release` on `ubuntu-latest`: both archives arrived in `dist-darwin`, darwin skipped,
  `linux_amd64_v1` built, four assets published — `vibez_linux_amd64.tar.gz`,
  `vibez_darwin_amd64.tar.gz`, `vibez_darwin_arm64.tar.gz`, `checksums.txt`.
- `checksums.txt` covers all three tarballs, and the darwin arm64 digest matches
  `shasum -a 256` run against the asset downloaded from the release.
- That published `vibez_darwin_arm64.tar.gz`, unpacked and run on this Mac: Mach-O arm64,
  links `AudioToolbox`, garbled, ad-hoc linker-signed, prints its version.

The scaffolding for that run was a stubbed token step, since my fork has no `APPLE_*`
secrets, and `release.github.owner` pointed at the fork with `draft: true`. None of it is in
this PR, and the tag and draft release are deleted.

## Two things I did not touch

`goreleaser check` fails on `main` today: `builds.gobinary` is deprecated in favour of
`builds.tool`, on both builds. Pre-existing and unrelated to this, so I left it alone. It can
go out as its own change if you want it cleared.

Signing and notarization are out of scope here. The arm64 slice comes out ad-hoc
linker-signed exactly as the current release does, and the amd64 slice is unsigned exactly
as the current release is, so nothing regresses; a Developer ID identity would be a
different conversation.

Linux is untouched, including the arm64 gap in the comment there.
