### PR TITLE
fix(auth): act on a rejected developer token instead of only reporting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **A rejected developer token now acts on the update instead of only naming it** — the startup update check looks at most once every 24 hours, so a build whose embedded token had just expired could print `Developer token rejected - update vibez to continue` on the same run that skipped the check which would have fixed it. That path now asks GitHub immediately, installs and restarts when a newer release exists, and otherwise says which case it is: nothing newer published yet, `--no-update` in force, or an install that cannot replace itself. The WebKit fallback path, which ran no update check at all, gets the same handling. Refs #108, #113.
+
 ## [0.6.1] — 2026-08-21
 
 ### Fixed

--- a/cmd/cdp_common.go
+++ b/cmd/cdp_common.go
@@ -55,7 +55,23 @@ func runCDPFlow(cfg *config.Config, opts tui.Options, onUserToken, onStorefront 
 				// Re-authenticating cannot mint a working developer token, so
 				// keep the user token: it is still good once the build is.
 				devTokenRejected = true
-				prog.Send(tui.InitStatusMsg(auth.DeveloperTokenStatus))
+				// The update check above may have been inside its once-a-day
+				// window and returned without asking, which is exactly what
+				// would leave the user reading "update vibez" on a build that
+				// could have updated itself. Ask again, and say what came back.
+				res := updater.UpdateNow(version.Version, noUpdate, func(msg string) {
+					prog.Send(tui.InitStatusMsg(msg))
+				})
+				if res.Outcome == updater.OutcomeInstalled {
+					restartExe <- res.Exe
+					prog.Send(tui.RestartMsg{})
+					return
+				}
+				status := auth.DeveloperTokenStatus
+				if advice := res.Advice(); advice != "" {
+					status = auth.DeveloperTokenPrefix + " - " + advice
+				}
+				prog.Send(tui.InitStatusMsg(status))
 			case auth.TokensValid:
 			}
 		}

--- a/cmd/root_linux.go
+++ b/cmd/root_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -16,6 +17,8 @@ import (
 	"github.com/simone-vibes/vibez/internal/player/webkit"
 	"github.com/simone-vibes/vibez/internal/provider/apple"
 	"github.com/simone-vibes/vibez/internal/tui"
+	"github.com/simone-vibes/vibez/internal/updater"
+	"github.com/simone-vibes/vibez/internal/version"
 )
 
 func runPlatform(cfg *config.Config, iconPath string, opts tui.Options, onUserToken, onStorefront func(string), audioBitrateKbps int) error {
@@ -56,8 +59,21 @@ func runWebKitFlow(cfg *config.Config, iconPath string, opts tui.Options, onUser
 			_ = cfg.Save("")
 		case auth.DeveloperTokenRejected:
 			// Re-authenticating cannot mint a working developer token, so keep
-			// the user token: it is still good once the build is.
+			// the user token: it is still good once the build is. This path
+			// runs no update check of its own, so without asking here a stale
+			// build has no way to fix itself.
+			res := updater.UpdateNow(version.Version, noUpdate, func(msg string) {
+				fmt.Fprintln(os.Stderr, msg)
+			})
+			if res.Outcome == updater.OutcomeInstalled {
+				// Nothing owns the terminal or the main thread yet on this
+				// path, so the new binary can take over directly.
+				return syscall.Exec(res.Exe, os.Args, os.Environ()) //nolint:gosec // exe is the binary we just verified and installed
+			}
 			fmt.Fprintln(os.Stderr, auth.DeveloperTokenHelp)
+			if advice := res.Advice(); advice != "" {
+				fmt.Fprintln(os.Stderr, advice)
+			}
 		case auth.TokensValid:
 		}
 	}

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -31,8 +31,13 @@ const (
 	DeveloperTokenRejected
 )
 
-// DeveloperTokenStatus is a one-line summary for a status bar.
-const DeveloperTokenStatus = "Developer token rejected - update vibez to continue"
+// DeveloperTokenPrefix names the failure without prescribing a fix, for
+// callers that can say something more specific about getting a working build.
+const DeveloperTokenPrefix = "Developer token rejected"
+
+// DeveloperTokenStatus is a one-line summary for a status bar, used when
+// nothing more specific about the fix is known.
+const DeveloperTokenStatus = DeveloperTokenPrefix + " - update vibez to continue"
 
 // DeveloperTokenHelp is the same failure explained where there is room for it.
 //

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -37,6 +37,58 @@ type ghAsset struct {
 	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
+// Outcome says what an update attempt did.
+type Outcome int
+
+const (
+	// OutcomeFailed means the check itself did not complete, so nothing is
+	// known about whether a newer release exists.
+	OutcomeFailed Outcome = iota
+	// OutcomeCurrent means this build is already the newest release.
+	OutcomeCurrent
+	// OutcomeInstalled means a newer release was installed and the caller
+	// should re-exec Exe.
+	OutcomeInstalled
+	// OutcomeDisabled means a newer release exists and was left alone because
+	// updates were turned off.
+	OutcomeDisabled
+	// OutcomeManual means a newer release exists but this process did not
+	// install it: no asset for the platform, a binary it cannot replace, or a
+	// download that failed. Either way the user has to update it themselves.
+	OutcomeManual
+)
+
+// Result reports what an update attempt did, so a caller that knows the build
+// is broken can explain the situation rather than repeating "update vibez".
+type Result struct {
+	Outcome Outcome
+	// Tag is the newer release, when the check got far enough to learn it.
+	Tag string
+	// Exe is the binary to re-exec, set only for OutcomeInstalled.
+	Exe string
+}
+
+// Advice is a one-clause summary of what can be done about the update state.
+// It is empty when the check failed, since nothing is known to advise on.
+func (r Result) Advice() string {
+	switch r.Outcome {
+	case OutcomeCurrent:
+		return "this is already the newest release, so a newer build has to be published first"
+	case OutcomeInstalled:
+		return fmt.Sprintf("updated to %s", r.Tag)
+	case OutcomeDisabled:
+		return fmt.Sprintf("%s is available; restart without --no-update to install it", r.Tag)
+	case OutcomeManual:
+		return fmt.Sprintf("%s is available, but this install cannot replace itself; reinstall to update", r.Tag)
+	default:
+		return ""
+	}
+}
+
+// executable is indirected so tests can point the self-replace at a temp file
+// instead of the test binary.
+var executable = os.Executable
+
 // CheckAndUpdate checks GitHub for a newer release. If one is found it
 // downloads, verifies the SHA-256 checksum, and installs it in-place.
 // It returns the path of the updated binary when a restart is needed, or ""
@@ -45,6 +97,9 @@ type ghAsset struct {
 // The caller is responsible for re-execing after cleaning up (e.g. after the
 // TUI exits). All errors are handled internally — the function never blocks
 // startup fatally.
+//
+// It looks at most once every 24 hours. UpdateNow is for callers that cannot
+// wait for the next window.
 func CheckAndUpdate(current string, noUpdate bool, log func(string)) string {
 	if noUpdate {
 		return ""
@@ -52,19 +107,39 @@ func CheckAndUpdate(current string, noUpdate bool, log func(string)) string {
 	if !shouldCheck() {
 		return ""
 	}
+	return update(apiURL, current, true, log).Exe
+}
 
+// UpdateNow asks GitHub straight away, ignoring the once-a-day window, and
+// reports what it found. It is for callers that already know this build cannot
+// work: a rejected developer token is not something the user can wait out, and
+// the throttle would otherwise leave them on a broken build for another day.
+//
+// With noUpdate set it still reports whether a newer release exists, and
+// installs nothing.
+func UpdateNow(current string, noUpdate bool, log func(string)) Result {
+	return update(apiURL, current, !noUpdate, log)
+}
+
+// update is the testable core. api is the releases endpoint, and install says
+// whether a newer release may replace this binary.
+func update(api, current string, install bool, log func(string)) Result {
 	log("Checking for updates…")
 
-	rel, err := fetchLatestRelease()
+	rel, err := fetchLatestRelease(api)
 	if err != nil {
-		return ""
+		return Result{Outcome: OutcomeFailed}
 	}
 
 	markChecked()
 
 	if !isNewer(rel.TagName, current) {
-		return ""
+		return Result{Outcome: OutcomeCurrent, Tag: rel.TagName}
 	}
+
+	// Anything past here has a newer release to report, and reaching the end
+	// is the only way to come back with something better than OutcomeManual.
+	res := Result{Outcome: OutcomeManual, Tag: rel.TagName}
 
 	assetName := fmt.Sprintf("vibez_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
 	var downloadURL, checksumURL string
@@ -76,41 +151,48 @@ func CheckAndUpdate(current string, noUpdate bool, log func(string)) string {
 			checksumURL = a.BrowserDownloadURL
 		}
 	}
+	// Checked before install, so a platform with no published asset - today,
+	// linux/arm64 - is never told to drop --no-update for a build that is not
+	// there.
 	if downloadURL == "" {
-		return "" // no asset for this platform
+		return res
+	}
+	if !install {
+		res.Outcome = OutcomeDisabled
+		return res
 	}
 
 	// Only attempt self-update for writable, self-managed installs.
-	exe, err := os.Executable()
+	exe, err := executable()
 	if err != nil {
-		return ""
+		return res
 	}
 	exe, err = filepath.EvalSymlinks(exe)
 	if err != nil {
-		return ""
+		return res
 	}
 	if !isWritable(exe) {
-		return ""
+		return res
 	}
 
 	log(fmt.Sprintf("Downloading update %s…", rel.TagName))
 
 	tmpDir, err := os.MkdirTemp("", "vibez-update-*")
 	if err != nil {
-		return ""
+		return res
 	}
 
 	tarPath := filepath.Join(tmpDir, assetName)
 	if err := downloadFile(downloadURL, tarPath); err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return ""
+		return res
 	}
 
 	if checksumURL != "" {
 		if err := verifyChecksum(tarPath, assetName, checksumURL); err != nil {
 			log("Update aborted: checksum verification failed")
 			_ = os.RemoveAll(tmpDir)
-			return ""
+			return res
 		}
 	}
 
@@ -119,11 +201,11 @@ func CheckAndUpdate(current string, noUpdate bool, log func(string)) string {
 	newBin := filepath.Join(tmpDir, "vibez")
 	if err := extractBinary(tarPath, "vibez", newBin); err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return ""
+		return res
 	}
 	if err := os.Chmod(newBin, 0o755); err != nil { //nolint:gosec // executables require 0755
 		_ = os.RemoveAll(tmpDir)
-		return ""
+		return res
 	}
 
 	// Atomic replace: write to exe.new, rename over exe.
@@ -131,26 +213,26 @@ func CheckAndUpdate(current string, noUpdate bool, log func(string)) string {
 	data, err := os.ReadFile(newBin) //nolint:gosec // path comes from our own tmpDir
 	if err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return ""
+		return res
 	}
 	if err := os.WriteFile(tmpBin, data, 0o755); err != nil { //nolint:gosec // executable permissions required
 		_ = os.RemoveAll(tmpDir)
-		return ""
+		return res
 	}
 	if err := os.Rename(tmpBin, exe); err != nil {
 		_ = os.Remove(tmpBin)
 		_ = os.RemoveAll(tmpDir)
-		return ""
+		return res
 	}
 
 	log(fmt.Sprintf("Updated to %s — restarting…", rel.TagName))
 	_ = os.RemoveAll(tmpDir)
-	return exe
+	return Result{Outcome: OutcomeInstalled, Tag: rel.TagName, Exe: exe}
 }
 
-func fetchLatestRelease() (*ghRelease, error) {
+func fetchLatestRelease(api string) (*ghRelease, error) {
 	client := &http.Client{Timeout: apiTimeout}
-	resp, err := client.Get(apiURL) //nolint:gosec // URL is a hardcoded constant
+	resp, err := client.Get(api) //nolint:gosec // URL is a hardcoded constant or test server
 	if err != nil {
 		return nil, err
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -2,13 +2,18 @@ package updater
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -174,5 +179,281 @@ func TestShouldCheck_RecentStamp(t *testing.T) {
 
 	if shouldCheck() {
 		t.Error("shouldCheck should return false when stamp was just written")
+	}
+}
+
+// ── update ────────────────────────────────────────────────────────────────────
+
+// tarGz builds a gzipped tar holding one regular file.
+func tarGz(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(content)),
+		Mode:     0o755,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// fakeReleases serves a releases endpoint for tag, plus the archive and
+// checksums it advertises. withAsset says whether an archive for this platform
+// is published at all, which is how a release that skips a platform is
+// modelled.
+func fakeReleases(t *testing.T, tag string, withAsset bool, binary []byte) *httptest.Server {
+	t.Helper()
+	assetName := fmt.Sprintf("vibez_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	archive := tarGz(t, "vibez", binary)
+	sum := sha256.Sum256(archive)
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		switch r.URL.Path {
+		case "/checksums.txt":
+			_, _ = w.Write([]byte(hex.EncodeToString(sum[:]) + "  " + assetName + "\n"))
+		case "/asset":
+			_, _ = w.Write(archive)
+		default:
+			assets := []ghAsset{{Name: "checksums.txt", BrowserDownloadURL: base + "/checksums.txt"}}
+			if withAsset {
+				assets = append(assets, ghAsset{Name: assetName, BrowserDownloadURL: base + "/asset"})
+			}
+			_ = json.NewEncoder(w).Encode(ghRelease{TagName: tag, Assets: assets})
+		}
+	}))
+}
+
+// isolateCache points the update-check stamp at a temp HOME so a test never
+// reads or writes the real one.
+func isolateCache(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", "")
+}
+
+// fakeExe writes a stand-in binary and points executable() at it, so a test
+// never overwrites the test binary itself.
+func fakeExe(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "vibez")
+	if err := os.WriteFile(path, []byte("old binary"), mode); err != nil {
+		t.Fatal(err)
+	}
+	orig := executable
+	executable = func() (string, error) { return path, nil }
+	t.Cleanup(func() { executable = orig })
+	return path
+}
+
+func discard(string) {}
+
+func TestUpdate_CurrentVersionNeedsNothing(t *testing.T) {
+	isolateCache(t)
+	srv := fakeReleases(t, "v1.2.3", true, []byte("new binary"))
+	defer srv.Close()
+
+	got := update(srv.URL, "v1.2.3", true, discard)
+	if got.Outcome != OutcomeCurrent {
+		t.Errorf("Outcome = %v, want OutcomeCurrent", got.Outcome)
+	}
+	if got.Exe != "" {
+		t.Errorf("Exe = %q, want empty", got.Exe)
+	}
+}
+
+func TestUpdate_CheckFailureKnowsNothing(t *testing.T) {
+	isolateCache(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	got := update(srv.URL, "v1.0.0", true, discard)
+	if got.Outcome != OutcomeFailed {
+		t.Errorf("Outcome = %v, want OutcomeFailed", got.Outcome)
+	}
+	if got.Tag != "" {
+		t.Errorf("Tag = %q, want empty: a failed check learns no version", got.Tag)
+	}
+	if got.Advice() != "" {
+		t.Errorf("Advice = %q, want empty", got.Advice())
+	}
+}
+
+func TestUpdate_DisabledStillReportsTheRelease(t *testing.T) {
+	isolateCache(t)
+	srv := fakeReleases(t, "v2.0.0", true, []byte("new binary"))
+	defer srv.Close()
+
+	got := update(srv.URL, "v1.0.0", false, discard)
+	if got.Outcome != OutcomeDisabled {
+		t.Errorf("Outcome = %v, want OutcomeDisabled", got.Outcome)
+	}
+	if got.Tag != "v2.0.0" {
+		t.Errorf("Tag = %q, want v2.0.0", got.Tag)
+	}
+	if !strings.Contains(got.Advice(), "--no-update") {
+		t.Errorf("Advice = %q, should say how to install it", got.Advice())
+	}
+}
+
+// A platform with no published archive - linux/arm64 at the time of writing -
+// must not be told to drop --no-update for a build that is not there.
+func TestUpdate_MissingPlatformAssetIsManual(t *testing.T) {
+	isolateCache(t)
+	srv := fakeReleases(t, "v2.0.0", false, nil)
+	defer srv.Close()
+
+	for _, install := range []bool{true, false} {
+		got := update(srv.URL, "v1.0.0", install, discard)
+		if got.Outcome != OutcomeManual {
+			t.Errorf("install=%v: Outcome = %v, want OutcomeManual", install, got.Outcome)
+		}
+		if got.Tag != "v2.0.0" {
+			t.Errorf("install=%v: Tag = %q, want v2.0.0", install, got.Tag)
+		}
+	}
+}
+
+func TestUpdate_UnwritableBinaryIsManual(t *testing.T) {
+	isolateCache(t)
+	fakeExe(t, 0o400)
+	srv := fakeReleases(t, "v2.0.0", true, []byte("new binary"))
+	defer srv.Close()
+
+	got := update(srv.URL, "v1.0.0", true, discard)
+	if got.Outcome != OutcomeManual {
+		t.Errorf("Outcome = %v, want OutcomeManual", got.Outcome)
+	}
+	if !strings.Contains(got.Advice(), "reinstall") {
+		t.Errorf("Advice = %q, should point at reinstalling", got.Advice())
+	}
+}
+
+func TestUpdate_InstallsOverTheRunningBinary(t *testing.T) {
+	isolateCache(t)
+	exe := fakeExe(t, 0o755)
+	srv := fakeReleases(t, "v2.0.0", true, []byte("new binary"))
+	defer srv.Close()
+
+	got := update(srv.URL, "v1.0.0", true, discard)
+	if got.Outcome != OutcomeInstalled {
+		t.Fatalf("Outcome = %v, want OutcomeInstalled", got.Outcome)
+	}
+
+	// The path comes back symlink-resolved, which on macOS means /private/var
+	// rather than the /var the test handed in.
+	want, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Exe != want {
+		t.Errorf("Exe = %q, want %q", got.Exe, want)
+	}
+	content, err := os.ReadFile(exe) //nolint:gosec // exe is a path inside t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "new binary" {
+		t.Errorf("installed content = %q, want %q", content, "new binary")
+	}
+	if left, err := os.Stat(exe + ".new"); err == nil {
+		t.Errorf("left a staging file behind: %s", left.Name())
+	}
+}
+
+func TestUpdate_ChecksumMismatchInstallsNothing(t *testing.T) {
+	isolateCache(t)
+	exe := fakeExe(t, 0o755)
+	assetName := fmt.Sprintf("vibez_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		switch r.URL.Path {
+		case "/checksums.txt":
+			_, _ = w.Write([]byte(strings.Repeat("0", 64) + "  " + assetName + "\n"))
+		case "/asset":
+			_, _ = w.Write(tarGz(t, "vibez", []byte("new binary")))
+		default:
+			_ = json.NewEncoder(w).Encode(ghRelease{TagName: "v2.0.0", Assets: []ghAsset{
+				{Name: "checksums.txt", BrowserDownloadURL: base + "/checksums.txt"},
+				{Name: assetName, BrowserDownloadURL: base + "/asset"},
+			}})
+		}
+	}))
+	defer srv.Close()
+
+	got := update(srv.URL, "v1.0.0", true, discard)
+	if got.Outcome != OutcomeManual {
+		t.Errorf("Outcome = %v, want OutcomeManual", got.Outcome)
+	}
+	content, err := os.ReadFile(exe) //nolint:gosec // exe is a path inside t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "old binary" {
+		t.Errorf("binary was replaced despite a bad checksum: %q", content)
+	}
+}
+
+// UpdateNow must ask even when CheckAndUpdate would have skipped the day's
+// check, since the caller already knows this build cannot work.
+func TestUpdateNow_IgnoresTheDailyWindow(t *testing.T) {
+	isolateCache(t)
+	dir := cacheDir()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "last_update_check"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if shouldCheck() {
+		t.Fatal("stamp was just written, so the daily window should be closed")
+	}
+
+	asked := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		asked = true
+		_ = json.NewEncoder(w).Encode(ghRelease{TagName: "v1.0.0"})
+	}))
+	defer srv.Close()
+
+	if got := update(srv.URL, "v1.0.0", false, discard); got.Outcome != OutcomeCurrent {
+		t.Errorf("Outcome = %v, want OutcomeCurrent", got.Outcome)
+	}
+	if !asked {
+		t.Error("update did not reach the server")
+	}
+}
+
+func TestAdvice(t *testing.T) {
+	cases := []struct {
+		name string
+		r    Result
+		want string
+	}{
+		{"failed", Result{Outcome: OutcomeFailed}, ""},
+		{"current", Result{Outcome: OutcomeCurrent, Tag: "v1.0.0"}, "this is already the newest release, so a newer build has to be published first"},
+		{"installed", Result{Outcome: OutcomeInstalled, Tag: "v2.0.0"}, "updated to v2.0.0"},
+		{"disabled", Result{Outcome: OutcomeDisabled, Tag: "v2.0.0"}, "v2.0.0 is available; restart without --no-update to install it"},
+		{"manual", Result{Outcome: OutcomeManual, Tag: "v2.0.0"}, "v2.0.0 is available, but this install cannot replace itself; reinstall to update"},
+	}
+	for _, tc := range cases {
+		if got := tc.r.Advice(); got != tc.want {
+			t.Errorf("%s: Advice = %q, want %q", tc.name, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
Refs #108, item 3 of the plan there, and the piece #113 actually needs.

## The problem

#114 made a rejected developer token survivable: the session is kept and the status bar reads
`Developer token rejected - update vibez to continue`. The advice is correct, and on a lot of
runs the user cannot act on it.

`CheckAndUpdate` looks at most once every 24 hours, gated by a stamp in the cache dir. Anyone
who started vibez yesterday, and whose embedded token expires today, is told to update by the
same run that skipped the check that would have updated them. The WebKit fallback path is
worse: it runs no update check at all, so there the message has never had anything behind it.

And when a token expires *before* a newer release exists — #113 exactly — "update vibez to
continue" is a dead end no matter what the throttle does.

## What changes

`updater.UpdateNow` asks GitHub straight away, ignoring the daily window, and reports what came
back as an outcome rather than just a path. The rejection branch calls it, installs and re-execs
when it can — reusing the restart plumbing already there for the startup check — and otherwise
names the actual situation:

| situation | what the user gets |
|---|---|
| newer release, updates allowed | installs it and restarts |
| already the newest release | `… - this is already the newest release, so a newer build has to be published first` |
| `--no-update` in force | `… - v0.6.1 is available; restart without --no-update to install it` |
| install cannot replace itself | `… - v0.6.1 is available, but this install cannot replace itself; reinstall to update` |
| the check itself failed | unchanged: `… - update vibez to continue` |

The second row is the #113 case. A failed check learns nothing, so it keeps the existing
wording rather than guessing.

`--no-update` is honoured: it reports the release and installs nothing. The asset lookup runs
*before* that gate on purpose, so a platform with no published archive — linux/arm64 today —
is never told to drop `--no-update` for a build that is not there. There is a test pinning
that ordering.

`CheckAndUpdate` keeps its signature and its throttle. Both it and `UpdateNow` now go through
one core that takes the endpoint, which is what makes the outcomes testable, and
`os.Executable` is indirected for the same reason, so the install test replaces a temp file
instead of the test binary.

## Verified

On Apple Silicon against the live Apple and GitHub endpoints, with `HOME` pointed at a temp dir
so the real update stamp stayed untouched:

| case | result |
|---|---|
| garbage credentials | `DeveloperTokenRejected` |
| `current=99.0.0` | newest-release message, no download |
| `current=0.1.0` + `--no-update` | names v0.6.1, no download |
| `current=0.1.0`, updates allowed | downloads v0.6.1, verifies the checksum, installs, returns the path to re-exec |

Nine unit tests cover the outcomes against an `httptest` release endpoint, including the
ordering rule above and a checksum mismatch leaving the binary in place. `go vet`,
`go test ./...`, `gofmt` and `golangci-lint` are clean here on darwin/arm64.

One gap worth stating: `cmd/root_linux.go` is the only file I cannot compile on this machine,
since cross-compiling the webkit/gstreamer cgo target needs a Linux toolchain — that is
pre-existing, `GOOS=linux go build ./...` fails the same way on `main`. `build-vet-test-linux`
is its compile check and I will confirm it green before asking you to look.

## Notes

Items 1 and 4 of #108 are already out as #119 and #109, so this leaves only item 2, the one we
agreed against.

The CHANGELOG entry lands in the same `## [Unreleased]` block as #120's, so whichever of the
two merges second may want a one-line merge.
