### PR TITLE
feat(player): let MusicKit advance the queue instead of rebuilding it per track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Track transitions no longer rebuild MusicKit's queue**: vibez called `setQueue({songs:[one id]})` at every track boundary, so each transition paid a round trip that landed exactly where the gap is audible. The queue is now built once with `setQueue({items:[...]})` and MusicKit advances it, with `next`/`prev` delegating to `skipToNextItem`/`skipToPreviousItem` and insertions going through `playNext`/`playLater`. `items:` takes resolved descriptors of either kind, so a library song no longer forces the whole queue back to per-track rebuilds. Measured over a two-item queue the boundary gap went from a 700 ms median to 23.7 ms, though the figure moves with queue length and the shipped shape has not been swept yet. Refs #96.
+
 ## [0.7.0] — 2026-08-29
 
 ### Changed

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -219,13 +219,15 @@
         //
         // There are two modes, and exactly one of them owns advancement:
         //
-        //   native   — one setQueue({songs:[...]}) builds the whole queue and
-        //              MusicKit advances, repeats and shuffles it by itself.
-        //              Navigation is skipToNextItem / skipToPreviousItem; new
-        //              songs go through playLater().
-        //   one-item — setQueue({...}) per track, vibez advances on `completed`.
-        //              The only mode that can play library items and run the
-        //              CONTENT_UNAVAILABLE → library-copy fallback.
+        //   native:   one setQueue({items:[...]}) builds the whole queue, mixing
+        //             catalog and library items freely, and MusicKit advances,
+        //             repeats and shuffles it by itself. Navigation is
+        //             skipToNextItem / skipToPreviousItem; new songs go through
+        //             playLater().
+        //   one-item: setQueue({...}) per track, vibez advances on `completed`.
+        //             This is the recovery mode. It is the only mode that sees a
+        //             per-item failure, so it is the only one that can run the
+        //             CONTENT_UNAVAILABLE to library-copy fallback.
         //
         // Two separate facts, deliberately not one flag:
         //
@@ -239,18 +241,30 @@
         //                    authority stays with MusicKit, which is why the two
         //                    cannot be the same flag.
         //
-        // Why native mode exists, measured on MusicKit 3.2526.0-prerelease.x with
-        // the #96 probe (media-element currentTime, 50 ms poll, DSOTM 50th
-        // tracks 3-5):
+        // Why native mode exists. Measured with the #96 probe on MusicKit
+        // 3.2526.0-prerelease.x, from the media element's own currentTime at a
+        // 50 ms poll. Every arm is two items over the same track pair, with the
+        // order rotated each pass so queue length and position cannot pose as a
+        // difference between designs:
         //
-        //   one-item rebuild per track   850.0 ms gap, media src changes at the
-        //                                boundary (2 distinct srcs)
-        //   native multi-item queue       20.3 ms gap, media src never changes
-        //                                (1 src), MusicKit auto-advances
+        //   arm                         n   median     range       single src
+        //   rebuild (one item/track)   11   700.0 ms   451-1000      0/11
+        //   items: catalog + library   11    23.7 ms   15-37        11/11
+        //   items: 2 catalog            6   350.0 ms   11-450        1/6
         //
-        // The src swap is the cost: a rebuild cannot start decoding the next
-        // track until the current one releases the element. A native queue never
-        // swaps, so there is nothing to wait for.
+        // The media-element src count is the invariant here, not any of those
+        // medians: one src is always under 40 ms, two are always over 300. A
+        // rebuild cannot start decoding the next track until the current one
+        // releases the element, so it always pays for a swap. A native queue
+        // never swaps, so there is nothing to wait for.
+        //
+        // Two caveats outlived the measurement, and both belong to #96 rather
+        // than to this code. An all-catalog items: queue was the worst native
+        // arm, and nothing explains why a library item in second position is the
+        // most consistent thing measured. Queue length also moves the figure on
+        // its own: the songs: form gave 26.5 ms at two items and 350.2 ms at
+        // three. So the shipped queue shape needs its own measurement before any
+        // of these numbers is quoted as this player's behaviour.
 
         let _q       = [];    // resolved items from the Apple Music API
         let _qi      = -1;    // index of the currently playing item (-1 = nothing)
@@ -272,10 +286,36 @@
         // supported replacement exists.
         let _removedIds = new Set();
 
-        // Native mode can only be used when every item is a catalog song:
-        // library items have to reach setQueue as resolved objects, which the
-        // songs:[ids] form cannot express.
-        const _allCatalog = (items) => items.every(item => !item.id.startsWith('i.'));
+        // The user's library copies of the queue's catalog songs, keyed by
+        // library ID. _libMap records which library ID belongs to which catalog
+        // song while resolving; this holds the resolved objects for them.
+        //
+        // Native mode is why they are fetched ahead of being needed. MusicKit
+        // advances by itself there, so a failing item has no call site to throw
+        // at the way _doPlayAt has one, and the recovery is to hand the index
+        // back to one-item mode. That is only cheap if the substitute is already
+        // in hand.
+        let _libItems = {};
+
+        // Warm _libItems for everything currently in _q. Deliberately not
+        // awaited: it must not add latency to the first play, and the earliest
+        // boundary that could want it is a whole track away.
+        function _warmLibItems() {
+          const wanted = [...new Set(_q.map(item => _libMap[item.id])
+                                       .filter(id => id && !_libItems[id]))];
+          if (wanted.length === 0) return;
+          const batchSize = 100;
+          for (let i = 0; i < wanted.length; i += batchSize) {
+            const batch = wanted.slice(i, i + batchSize);
+            _m().api.music('/v1/me/library/songs', { ids: batch })
+              .then(r => {
+                for (const song of r?.data?.data ?? []) _libItems[song.id] = song;
+                _log(`[js:libwarm] cached ${batch.length} library copy(s)`);
+              })
+              // Not an error path: _libraryFallback still fetches on demand.
+              .catch(e => _log(`[js:libwarm] skipped (${errName(e)})`));
+          }
+        }
 
         function _syncQueueIndex() {
           if (!_nativeQueue) return;
@@ -295,6 +335,31 @@
           }
         }
         music.addEventListener('nowPlayingItemDidChange', _syncQueueIndex);
+
+        // Native mode's blind spot. MusicKit advances on its own there, so an
+        // item that turns out to be unavailable mid-queue never reaches a
+        // try/catch: _doPlayAt's per-item handling only sees the item it was
+        // asked to play. Hand the index back to one-item mode, which does have
+        // the CONTENT_UNAVAILABLE to library-copy path, and let it recover.
+        //
+        // Written from the event surface, not measured: the #96 probes never
+        // provoked a failure inside a live native queue, so whether MusicKit
+        // reports one this way is still open. It costs nothing if the event
+        // never fires, and without it a bad item would strand the queue where
+        // one-item mode would have skipped past it.
+        music.addEventListener('mediaPlaybackError', (e) => {
+          if (!_nativeQueue) return;
+          const idx = _qi >= 0 ? _qi : 0;
+          _log(`[js:native] playback error (${errName(e?.detail ?? e)}) at #${idx}, recovering in one-item mode`);
+          _nativeQueue   = false;
+          _nativeMirrors = false;
+          // stop() rather than leaving it to _playAt's setQueue: if a build is
+          // already in flight, _playAt only records _wantIdx and returns, and
+          // MusicKit would keep advancing an abandoned queue in the meantime.
+          // That is the two-advancer state the flags above exist to prevent.
+          _m().stop().catch(() => {});
+          _playAt(idx);
+        });
 
         // Does MusicKit have somewhere to go on its own when the current item
         // completes?  Asked of MusicKit's queue rather than _qi so the answer
@@ -331,7 +396,11 @@
           _removedIds = new Set(); // the queue about to be built is authoritative
           try {
             await _stopAndWait(m);
-            await m.setQueue({ songs: _q.map(item => item.id) });
+            // items: rather than songs: so one descriptor covers both kinds and
+            // a pre-resolved library copy can be dropped straight in. Copied,
+            // because _q keeps being mutated underneath a live queue.
+            await m.setQueue({ items: _q.slice() });
+            _warmLibItems();
             if (startIdx > 0) await m.changeToMediaAtIndex(startIdx);
             _qi = startIdx;
             _nativeQueue   = true;
@@ -479,11 +548,18 @@
           const libId = _libMap[item.id];
           _log(`[js:doPlay] fallback libId=${libId||'none'}`);
           if (libId) {
+            if (_libItems[libId]) {
+              _log(`[js:doPlay] library swap OK (warmed) → retry #${idx}`);
+              _q[idx]  = _libItems[libId];
+              _wantIdx = idx; // retry via finally
+              return;
+            }
             try {
               const r = await _m().api.music('/v1/me/library/songs', { ids: [libId] });
               const lib = r?.data?.data ?? [];
               if (lib.length > 0) {
                 _log(`[js:doPlay] library swap OK → retry #${idx}`);
+                _libItems[libId] = lib[0];
                 _q[idx]  = lib[0];
                 _wantIdx = idx; // retry via finally
                 return;
@@ -796,7 +872,7 @@
             _q  = items;
             _qi = -1;
             _qUnshuffled = []; // clear any prior shuffle snapshot
-            if (items.length > 1 && _allCatalog(items)) _playNativeAt(0);
+            if (items.length > 1) _playNativeAt(0);
             else _playAt(0);
           } catch(e) { goError('setQueue failed: '+errName(e)).catch(()=>{}); }
         };
@@ -820,7 +896,7 @@
             _qi = -1;
             _qUnshuffled = []; // clear any prior shuffle snapshot
             const idx = Math.max(0, Math.min(startIdx || 0, items.length - 1));
-            if (items.length > 1 && _allCatalog(items)) _playNativeAt(idx);
+            if (items.length > 1) _playNativeAt(idx);
             else _playAt(idx);
           } catch(e) { goError('setPlaylist failed: '+errName(e)).catch(()=>{}); }
         };
@@ -834,8 +910,12 @@
             _q = _q.concat(items);
             _log(`[js:append] +${items.length} → _q.length=${_q.length} _qi=${_qi}`);
             if (_qi < 0) _playAt(0); // nothing was playing — start now
-            else if (_nativeQueue && _allCatalog(items)) {
-              try { await _m().playLater({ songs: items.map(item => item.id) }); }
+            else if (_nativeQueue) {
+              // playLater and playNext both call deferPlayback() before mutating
+              // the queue (#96 probe, phase F), which is the sanctioned way to
+              // extend one that is already playing. queue.append throws
+              // TypeError. items: again, so a library append is expressible.
+              try { await _m().playLater({ items: items.slice() }); _warmLibItems(); }
               catch(e) {
                 // Keep _nativeQueue set: MusicKit still owns the items it does
                 // have, and clearing it would double up on the next boundary.

--- a/internal/player/web/musickit.html
+++ b/internal/player/web/musickit.html
@@ -217,20 +217,150 @@
         // _q[]  = source of truth for all queued songs
         // _qi   = index of the currently playing item in _q
         //
-        // MusicKit's native queue is built ONCE (on first play / explicit rebuild)
-        // with ALL songs via setQueue({songs:[...]}).  Navigation uses
-        // skipToNextItem / skipToPreviousItem exclusively — no setQueue re-calls.
-        // New songs appended while playing go through m.queue.append().
+        // There are two modes, and exactly one of them owns advancement:
         //
-        // Why: setQueue() mid-session is silently ignored by MusicKit (it returns
-        // CONTENT_EQUIVALENT) and leaves the native queue unchanged, creating a
-        // hard desync between _q and what MusicKit is actually playing.
+        //   native   — one setQueue({songs:[...]}) builds the whole queue and
+        //              MusicKit advances, repeats and shuffles it by itself.
+        //              Navigation is skipToNextItem / skipToPreviousItem; new
+        //              songs go through playLater().
+        //   one-item — setQueue({...}) per track, vibez advances on `completed`.
+        //              The only mode that can play library items and run the
+        //              CONTENT_UNAVAILABLE → library-copy fallback.
+        //
+        // Two separate facts, deliberately not one flag:
+        //
+        //   _nativeQueue   — MusicKit holds a multi-item queue and is the sole
+        //                    advance authority. Only setQueue or stop() can take
+        //                    that back, so clearing this flag without one of them
+        //                    does not stop MusicKit advancing: it just adds a
+        //                    second advancer and both fire at the next boundary.
+        //   _nativeMirrors — _q[i] is still MusicKit's queue item i for every i
+        //                    it holds. Shuffle and reorder break this while
+        //                    authority stays with MusicKit, which is why the two
+        //                    cannot be the same flag.
+        //
+        // Why native mode exists, measured on MusicKit 3.2526.0-prerelease.x with
+        // the #96 probe (media-element currentTime, 50 ms poll, DSOTM 50th
+        // tracks 3-5):
+        //
+        //   one-item rebuild per track   850.0 ms gap, media src changes at the
+        //                                boundary (2 distinct srcs)
+        //   native multi-item queue       20.3 ms gap, media src never changes
+        //                                (1 src), MusicKit auto-advances
+        //
+        // The src swap is the cost: a rebuild cannot start decoding the next
+        // track until the current one releases the element. A native queue never
+        // swaps, so there is nothing to wait for.
 
         let _q       = [];    // resolved items from the Apple Music API
         let _qi      = -1;    // index of the currently playing item (-1 = nothing)
         let _busy    = false; // guard: only one _buildAndPlay running at a time
         let _wantIdx = -1;    // pending explicit-jump target; -1 = none
+        let _wantNative = false; // pending jump should rebuild the native queue
         let _libMap  = {};    // catalog ID → library song ID, for CONTENT_UNAVAILABLE fallback
+        let _nativeQueue   = false; // MusicKit owns advancement (see above)
+        let _nativeMirrors = false; // ...and _q still mirrors its queue order
+
+        // Items dropped from _q while MusicKit still holds them in its native
+        // queue. The removal is honoured by skipping the item the moment it
+        // starts, which needs no MusicKit queue-mutation API at all.
+        //
+        // The #96 probe found queue.remove does work on a live queue (and
+        // queue.append throws TypeError, which is why appends go through the
+        // instance-level playLater). Using it would be more direct, but MusicKit
+        // logs it as deprecated, so skip-on-arrival is the safer bet until a
+        // supported replacement exists.
+        let _removedIds = new Set();
+
+        // Native mode can only be used when every item is a catalog song:
+        // library items have to reach setQueue as resolved objects, which the
+        // songs:[ids] form cannot express.
+        const _allCatalog = (items) => items.every(item => !item.id.startsWith('i.'));
+
+        function _syncQueueIndex() {
+          if (!_nativeQueue) return;
+          const id = _m().nowPlayingItem?.id;
+          if (!id) return;
+          const idx = _q.findIndex(item => item.id === id);
+          if (idx >= 0) { _qi = idx; return; }
+          // Playing something that is no longer in _q — it was removed while
+          // MusicKit still had it queued. Honour the removal now.
+          if (_removedIds.has(id)) {
+            _log(`[js:sync] removed item ${id} started — skipping it`);
+            const m = _m();
+            if (_nativeHasNext(m)) m.skipToNextItem().catch(() => {});
+            // Nothing to skip to: it was the last item MusicKit held, so end the
+            // queue rather than let a removed track play it out.
+            else { _nativeQueue = false; m.stop().catch(() => {}); }
+          }
+        }
+        music.addEventListener('nowPlayingItemDidChange', _syncQueueIndex);
+
+        // Does MusicKit have somewhere to go on its own when the current item
+        // completes?  Asked of MusicKit's queue rather than _qi so the answer
+        // cannot depend on whether nowPlayingItemDidChange or the completed
+        // event fires first.  Unknown queue shape → false, so vibez takes over.
+        function _nativeHasNext(m) {
+          if (m.repeatMode === 1 || m.repeatMode === 2) return true; // repeats itself
+          const q = m.queue;
+          if (!q || typeof q.length !== 'number' || typeof q.position !== 'number') return false;
+          return q.position < q.length - 1;
+        }
+
+        // Run a jump that arrived while a build was in flight. The native flag
+        // travels with the index so a deferred setQueue does not silently
+        // downgrade itself to one-item mode.
+        function _runPending() {
+          if (_wantIdx < 0 || _wantIdx >= _q.length) return;
+          const next   = _wantIdx;
+          const native = _wantNative;
+          _wantIdx    = -1;
+          _wantNative = false;
+          if (native) _doPlayNativeAt(next);
+          else        _doPlayAt(next);
+        }
+
+        // Build the whole native queue once, so MusicKit advances without a
+        // setQueue/play round trip — and without a media-element src swap — at
+        // every boundary. See the measurements above the flag declarations.
+        async function _doPlayNativeAt(startIdx) {
+          const m = _m();
+          _busy = true;
+          _wantIdx = -1;
+          _wantNative = false;
+          _removedIds = new Set(); // the queue about to be built is authoritative
+          try {
+            await _stopAndWait(m);
+            await m.setQueue({ songs: _q.map(item => item.id) });
+            if (startIdx > 0) await m.changeToMediaAtIndex(startIdx);
+            _qi = startIdx;
+            _nativeQueue   = true;
+            _nativeMirrors = true;
+            await m.play();
+            _log(`[js:native] playing ${_q.length} item(s) from #${startIdx}`);
+          } catch(e) {
+            _nativeQueue   = false;
+            _nativeMirrors = false;
+            _log(`[js:native] unavailable (${errName(e)}) → one-item fallback`);
+            _wantIdx = startIdx;
+          } finally {
+            _busy = false;
+            _runPending();
+          }
+        }
+
+        // Same _busy discipline as _playAt: a build already in flight would
+        // otherwise have its setQueue interleaved with ours, which is exactly
+        // what desyncs _q from MusicKit's queue.
+        function _playNativeAt(idx) {
+          if (_busy) {
+            _log(`[js:native] busy → queue #${idx}`);
+            _wantIdx    = idx;
+            _wantNative = true;
+            return;
+          }
+          _doPlayNativeAt(idx);
+        }
 
         // Resolve a mixed array of catalog + library IDs → MediaItem objects.
         // Catalog songs are fetched with include=library so we can cache the
@@ -373,7 +503,13 @@
         async function _doPlayAt(idx) {
           _busy    = true;
           _wantIdx = -1;
+          _wantNative = false;
           _qi      = idx;
+          // The setQueue below replaces MusicKit's queue with this one item, so
+          // it really does take advance authority back.
+          _nativeQueue   = false;
+          _nativeMirrors = false;
+          _removedIds    = new Set();
 
           const m    = _m();
           const item = _q[idx];
@@ -440,11 +576,7 @@
           } finally {
             _log(`[js:doPlay] done #${idx}, wantIdx=${_wantIdx}`);
             _busy = false;
-            if (_wantIdx >= 0 && _wantIdx < _q.length) {
-              const next = _wantIdx;
-              _wantIdx   = -1;
-              _doPlayAt(next);
-            }
+            _runPending();
           }
         }
 
@@ -472,6 +604,20 @@
           const m = _m();
           _log(`[js:state] ${_stateN[m.playbackState]||m.playbackState}`);
           if (m.playbackState !== _completedState) return;
+          // In native mode MusicKit advances its own queue and applies its own
+          // repeatMode — advancing here as well would advance twice. Only step
+          // in once MusicKit has run out of queue (items appended past the end
+          // of the native queue, or repeat off at the last track).
+          if (_nativeQueue && _nativeHasNext(m)) return;
+          // Native queue exhausted. Resuming at _qi+1 only means anything while
+          // _q still mirrors that queue — after a shuffle or reorder _qi+1 is an
+          // arbitrary track MusicKit may already have played. Stop cleanly
+          // instead. Safe to drop authority here: MusicKit has nowhere to go.
+          if (_nativeQueue && !_nativeMirrors) {
+            _log('[js:auto] native queue done, order diverged — stopping');
+            _nativeQueue = false;
+            return;
+          }
           _log(`[js:auto] completed _qi=${_qi} next=${_qi+1} len=${_q.length} busy=${_busy}`);
           if (_busy || _qi < 0 || _q.length === 0) return;
           if (m.repeatMode === 1 /* repeat-one */) { _playAt(_qi); return; }
@@ -507,12 +653,29 @@
           try { await _m().pause(); _log('[js:pause] paused ✓'); }
           catch(e) { _log(`[js:pause] error: ${errName(e)}`); goError('pause: '+errName(e)).catch(()=>{}); }
         };
+        // While MusicKit owns the queue, let it do the moving and let
+        // _syncQueueIndex resettle _qi afterwards: once its order has diverged
+        // from _q (shuffle, reorder) _qi ± 1 is not the neighbouring item, so
+        // the bounds have to come from MusicKit's queue rather than from _q.
         window.vibezNext  = () => {
-          _log(`[js:next] _qi=${_qi} len=${_q.length} busy=${_busy}`);
+          const m = _m();
+          _log(`[js:next] _qi=${_qi} len=${_q.length} busy=${_busy} native=${_nativeQueue}`);
+          if (_nativeQueue && _nativeHasNext(m)) {
+            m.skipToNextItem().catch(e => goError('next: '+errName(e)).catch(()=>{}));
+            return;
+          }
           if (_qi < _q.length - 1) _playAt(_qi + 1);
           else _log(`[js:next] already at end of queue`);
         };
-        window.vibezPrev  = () => { _log(`[js:prev] _qi=${_qi}`); _playAt(_qi > 0 ? _qi - 1 : 0); };
+        window.vibezPrev  = () => {
+          const m = _m();
+          _log(`[js:prev] _qi=${_qi} native=${_nativeQueue}`);
+          if (_nativeQueue && (m.queue?.position ?? 0) > 0) {
+            m.skipToPreviousItem().catch(e => goError('previous: '+errName(e)).catch(()=>{}));
+            return;
+          }
+          _playAt(_qi > 0 ? _qi - 1 : 0);
+        };
         const _repeatName = ['off', 'one', 'all'];
         window.vibezSeek      = (t) => { _log(`[js:seek] → ${t.toFixed(1)}s`); _m().seekToTime(t); };
         window.vibezSetVolume = (v) => { _log(`[js:volume] → ${Math.round(v*100)}%`); _m().volume = v; };
@@ -567,7 +730,25 @@
         window.vibezSetRepeat  = (mode) => { _log(`[js:repeat] → ${_repeatName[mode]||mode}`); _m().repeatMode  = mode; };
         window.vibezSetShuffle = (on) => {
           _log(`[js:shuffle] → ${on ? 'on' : 'off'}`);
-          // Keep MusicKit's own flag in sync so the state poll reflects the toggle.
+          // _nativeQueue is deliberately left alone: in native mode the
+          // shuffleMode below is what actually reorders playback and MusicKit
+          // stays the advance authority. Clearing it would only add a second
+          // advancer while its queue kept running. The local _q shuffle still
+          // drives the queue *view*, so the listed order and MusicKit's order
+          // diverge — _syncQueueIndex keeps now-playing correct meanwhile.
+          //
+          // Pushing the new order into the live queue instead was tried and
+          // measured (#96 probe, phase H). A mid-session setQueue does replace
+          // the queue's contents without an error, but it also STOPS playback:
+          // queue.position goes to -1, nowPlayingItem becomes undefined, and
+          // playbackState lands on stopped(4). So there is no way to reorder a
+          // live queue in place — any push costs a restart plus a seek back to
+          // the old position, which is worse than a stale listing.
+          //
+          // Phase C's earlier "playbackInterrupted: false" for the same case is
+          // a false negative: it compares nowPlayingItem before and after, and
+          // playback had already stopped, so both sides were undefined.
+          _nativeMirrors = false;
           _m().shuffleMode = on ? 1 : 0;
           if (on) {
             // Shuffle all tracks after the current one in-place; keep current
@@ -615,7 +796,8 @@
             _q  = items;
             _qi = -1;
             _qUnshuffled = []; // clear any prior shuffle snapshot
-            _playAt(0);
+            if (items.length > 1 && _allCatalog(items)) _playNativeAt(0);
+            else _playAt(0);
           } catch(e) { goError('setQueue failed: '+errName(e)).catch(()=>{}); }
         };
 
@@ -637,7 +819,9 @@
             _q  = items;
             _qi = -1;
             _qUnshuffled = []; // clear any prior shuffle snapshot
-            _playAt(startIdx || 0);
+            const idx = Math.max(0, Math.min(startIdx || 0, items.length - 1));
+            if (items.length > 1 && _allCatalog(items)) _playNativeAt(idx);
+            else _playAt(idx);
           } catch(e) { goError('setPlaylist failed: '+errName(e)).catch(()=>{}); }
         };
 
@@ -650,7 +834,16 @@
             _q = _q.concat(items);
             _log(`[js:append] +${items.length} → _q.length=${_q.length} _qi=${_qi}`);
             if (_qi < 0) _playAt(0); // nothing was playing — start now
-            // else: items enqueued; auto-advance (or next/prev) will pick them up
+            else if (_nativeQueue && _allCatalog(items)) {
+              try { await _m().playLater({ songs: items.map(item => item.id) }); }
+              catch(e) {
+                // Keep _nativeQueue set: MusicKit still owns the items it does
+                // have, and clearing it would double up on the next boundary.
+                // _nativeHasNext then reports exhausted at the end of its queue
+                // and the completed handler picks the appended items up.
+                _log(`[js:append] native mutation failed: ${errName(e)} — tail plays one-item`);
+              }
+            }
           } catch(e) { goError('appendQueue failed: '+errName(e)).catch(()=>{}); }
         };
 
@@ -660,13 +853,30 @@
           const name = _q[idx]?.attributes?.name || '?';
           _log(`[js:remove] #${idx} "${name}" (len=${_q.length} _qi=${_qi})`);
           if (idx === _qi) {
+            // _playAt below rebuilds as a one-item queue, which is what takes
+            // advance authority back from MusicKit.
             _q.splice(idx, 1);
-            if (_q.length === 0) { _qi = -1; _m().stop().catch(()=>{}); return; }
+            if (_q.length === 0) {
+              _qi = -1;
+              _nativeQueue   = false; // the stop() below takes authority back
+              _nativeMirrors = false;
+              _removedIds    = new Set();
+              _m().stop().catch(()=>{});
+              return;
+            }
             if (_qi >= _q.length) _qi = _q.length - 1;
             _playAt(_qi);
           } else {
+            const removed = _q[idx];
             _q.splice(idx, 1);
             if (idx < _qi) _qi--;
+            // MusicKit is still holding this item in its live queue and has no
+            // public way to drop it. Remember the id so _syncQueueIndex can skip
+            // past it if playback reaches it before the next rebuild.
+            if (_nativeQueue && removed && !_q.some(item => item.id === removed.id)) {
+              _removedIds.add(removed.id);
+            }
+            _nativeMirrors = false;
           }
         };
 
@@ -674,6 +884,10 @@
           const from = parseInt(fromStr);
           const to   = parseInt(toStr);
           if (from < 0 || from >= _q.length || to < 0 || to >= _q.length || from === to) return;
+          // _nativeQueue is deliberately left alone, and in native mode this
+          // reorders the view only — see vibezSetShuffle for the measurement
+          // showing a live queue cannot be reordered without stopping playback.
+          _nativeMirrors = false;
           const name = _q[from]?.attributes?.name || '?';
           _log(`[js:move] #${from} → #${to} "${name}"`);
           const item = _q.splice(from, 1)[0];
@@ -687,6 +901,9 @@
           _log(`[js:clear] queue (${_q.length} item(s))`);
           _q  = [];
           _qi = -1;
+          _nativeQueue   = false; // the stop() below takes authority back
+          _nativeMirrors = false;
+          _removedIds    = new Set();
           _m().stop().catch(()=>{});
         };
 

--- a/internal/player/web/musickit_test.mjs
+++ b/internal/player/web/musickit_test.mjs
@@ -416,6 +416,323 @@ test('lossless/unsupported values are rejected with web max', () => {
   }
 });
 
+// ─── Native queue mode (#96) ──────────────────────────────────────────────────
+// _allCatalog and _nativeHasNext are copied verbatim from musickit.html.
+// The rest simulate the decision each call site makes, in the same style as the
+// _busy/playbackStateDidChange tests above.
+
+const _allCatalog = (items) => items.every(item => !item.id.startsWith('i.'));
+
+function _nativeHasNext(m) {
+  if (m.repeatMode === 1 || m.repeatMode === 2) return true; // repeats itself
+  const q = m.queue;
+  if (!q || typeof q.length !== 'number' || typeof q.position !== 'number') return false;
+  return q.position < q.length - 1;
+}
+
+console.log('\n_allCatalog()');
+test('all catalog ids → true', () =>
+  eq(_allCatalog([{ id: '1' }, { id: '2' }]), true));
+test('any library id → false', () =>
+  eq(_allCatalog([{ id: '1' }, { id: 'i.abc' }]), false));
+test('all library ids → false', () =>
+  eq(_allCatalog([{ id: 'i.a' }, { id: 'i.b' }]), false));
+
+console.log('\n_nativeHasNext()');
+test('repeat-one always has a next', () =>
+  eq(_nativeHasNext({ repeatMode: 1, queue: { position: 4, length: 5 } }), true));
+test('repeat-all always has a next, including the last item', () =>
+  eq(_nativeHasNext({ repeatMode: 2, queue: { position: 4, length: 5 } }), true));
+test('mid-queue with repeat off → true', () =>
+  eq(_nativeHasNext({ repeatMode: 0, queue: { position: 0, length: 3 } }), true));
+test('last item with repeat off → false', () =>
+  eq(_nativeHasNext({ repeatMode: 0, queue: { position: 2, length: 3 } }), false));
+test('missing queue → false (vibez takes over)', () =>
+  eq(_nativeHasNext({ repeatMode: 0 }), false));
+test('non-numeric queue shape → false (vibez takes over)', () => {
+  eq(_nativeHasNext({ repeatMode: 0, queue: { position: '1', length: 3 } }), false);
+  eq(_nativeHasNext({ repeatMode: 0, queue: { position: 1, length: null } }), false);
+});
+test('single-item native queue with repeat off → false', () =>
+  eq(_nativeHasNext({ repeatMode: 0, queue: { position: 0, length: 1 } }), false));
+
+console.log('\nNative mode entry condition');
+const wantsNative = (items) => items.length > 1 && _allCatalog(items);
+test('multi-item all-catalog → native', () =>
+  eq(wantsNative([{ id: '1' }, { id: '2' }]), true));
+test('single catalog item → one-item mode', () =>
+  eq(wantsNative([{ id: '1' }]), false));
+test('multi-item with a library id → one-item mode', () =>
+  eq(wantsNative([{ id: '1' }, { id: 'i.x' }]), false));
+test('empty → one-item mode', () => eq(wantsNative([]), false));
+
+console.log('\ncompleted handler: who advances');
+// Mirrors musickit.html playbackStateDidChange: native short-circuit, diverged
+// stop, then the pre-existing one-item logic.
+const onCompleted = (s) => {
+  const out = { playAt: null, clearedNative: false, advanced: false };
+  if (s.nativeQueue && _nativeHasNext(s.m)) return out;      // MusicKit advances
+  if (s.nativeQueue && !s.nativeMirrors) { out.clearedNative = true; return out; }
+  if (s.busy || s.qi < 0 || s.q.length === 0) return out;
+  if (s.m.repeatMode === 1) { out.playAt = s.qi; out.advanced = true; return out; }
+  const next = s.qi + 1;
+  if (next < s.q.length)     { out.playAt = next; out.advanced = true; return out; }
+  if (s.m.repeatMode === 2)  { out.playAt = 0;    out.advanced = true; }
+  return out;
+};
+const base = { nativeQueue: false, nativeMirrors: false, busy: false, qi: 0, q: ['a', 'b', 'c'] };
+
+test('native with a next: vibez does not advance (no double advance)', () => {
+  const r = onCompleted({ ...base, nativeQueue: true, nativeMirrors: true,
+                          m: { repeatMode: 0, queue: { position: 0, length: 3 } } });
+  eq(r.advanced, false);
+  eq(r.clearedNative, false, 'authority must stay with MusicKit while it has a next');
+});
+test('native repeat-all at the last item: MusicKit laps, vibez stays out', () => {
+  const r = onCompleted({ ...base, nativeQueue: true, nativeMirrors: true, qi: 2,
+                          m: { repeatMode: 2, queue: { position: 2, length: 3 } } });
+  eq(r.advanced, false);
+});
+test('native exhausted while mirroring: vibez resumes at _qi+1', () => {
+  const r = onCompleted({ ...base, nativeQueue: true, nativeMirrors: true, qi: 1,
+                          m: { repeatMode: 0, queue: { position: 2, length: 2 } } });
+  eq(r.playAt, 2, 'should pick up the appended tail');
+});
+test('native exhausted with order diverged: stops instead of playing an arbitrary index', () => {
+  const r = onCompleted({ ...base, nativeQueue: true, nativeMirrors: false, qi: 1,
+                          m: { repeatMode: 0, queue: { position: 2, length: 2 } } });
+  eq(r.advanced, false, 'must not resume at _qi+1 after a shuffle');
+  eq(r.clearedNative, true, 'safe to drop authority: MusicKit has nowhere to go');
+});
+test('one-item mode is unchanged: advance, repeat-one, repeat-all', () => {
+  eq(onCompleted({ ...base, m: { repeatMode: 0 } }).playAt, 1);
+  eq(onCompleted({ ...base, qi: 1, m: { repeatMode: 1 } }).playAt, 1);
+  eq(onCompleted({ ...base, qi: 2, m: { repeatMode: 2 } }).playAt, 0);
+  eq(onCompleted({ ...base, qi: 2, m: { repeatMode: 0 } }).playAt, null);
+});
+test('_busy suppresses the one-item path but not the native short-circuit', () => {
+  eq(onCompleted({ ...base, busy: true, m: { repeatMode: 0 } }).playAt, null);
+  const r = onCompleted({ ...base, nativeQueue: true, nativeMirrors: true, busy: true,
+                          m: { repeatMode: 0, queue: { position: 0, length: 3 } } });
+  eq(r.advanced, false);
+});
+
+console.log('\nPending jump keeps its native intent');
+// _playNativeAt + _runPending: the native flag travels with the index so a
+// deferred build cannot silently downgrade to one-item mode.
+const makePending = () => {
+  const s = { busy: false, wantIdx: -1, wantNative: false, q: ['a', 'b', 'c'], calls: [] };
+  s.playNativeAt = (idx) => {
+    if (s.busy) { s.wantIdx = idx; s.wantNative = true; return; }
+    s.calls.push(['native', idx]);
+  };
+  s.playAt = (idx) => {
+    if (s.busy) { s.wantIdx = idx; s.wantNative = false; return; }
+    s.calls.push(['one', idx]);
+  };
+  s.runPending = () => {
+    if (s.wantIdx < 0 || s.wantIdx >= s.q.length) return;
+    const next = s.wantIdx, native = s.wantNative;
+    s.wantIdx = -1; s.wantNative = false;
+    if (native) s.calls.push(['native', next]);
+    else        s.calls.push(['one', next]);
+  };
+  return s;
+};
+
+test('_playNativeAt while busy defers instead of building', () => {
+  const s = makePending();
+  s.busy = true;
+  s.playNativeAt(1);
+  eq(s.calls, [], 'must not build while another build is in flight');
+  eq([s.wantIdx, s.wantNative], [1, true]);
+});
+test('deferred native jump runs as native, not one-item', () => {
+  const s = makePending();
+  s.busy = true; s.playNativeAt(2);
+  s.busy = false; s.runPending();
+  eq(s.calls, [['native', 2]], 'a deferred native build must not downgrade');
+});
+test('deferred one-item jump stays one-item', () => {
+  const s = makePending();
+  s.busy = true; s.playAt(1);
+  s.busy = false; s.runPending();
+  eq(s.calls, [['one', 1]]);
+});
+test('_runPending clears both fields before dispatching', () => {
+  const s = makePending();
+  s.busy = true; s.playNativeAt(1);
+  s.busy = false; s.runPending();
+  eq([s.wantIdx, s.wantNative], [-1, false]);
+  s.runPending();
+  eq(s.calls.length, 1, 'a consumed pending jump must not run twice');
+});
+test('_runPending ignores an out-of-range pending index', () => {
+  const s = makePending();
+  s.wantIdx = 9; s.wantNative = true;
+  s.runPending();
+  eq(s.calls, []);
+});
+
+console.log('\nQueue edits and advance authority');
+// Authority may only be dropped alongside a stop()/setQueue that actually takes
+// it back — clearing the flag on its own leaves two advancers running.
+const makeQueueState = () => ({
+  q: [{ id: '1' }, { id: '2' }, { id: '3' }],
+  qi: 1, nativeQueue: true, nativeMirrors: true,
+  removedIds: new Set(), stopped: false, rebuiltAt: null,
+});
+const removeAt = (s, idx) => {
+  if (idx < 0 || idx >= s.q.length) return s;
+  if (idx === s.qi) {
+    s.q.splice(idx, 1);
+    if (s.q.length === 0) {
+      s.qi = -1; s.nativeQueue = false; s.nativeMirrors = false;
+      s.removedIds = new Set(); s.stopped = true; return s;
+    }
+    if (s.qi >= s.q.length) s.qi = s.q.length - 1;
+    s.rebuiltAt = s.qi; // _playAt rebuilds one-item, which takes authority back
+    return s;
+  }
+  const removed = s.q[idx];
+  s.q.splice(idx, 1);
+  if (idx < s.qi) s.qi--;
+  if (s.nativeQueue && removed && !s.q.some(i => i.id === removed.id)) s.removedIds.add(removed.id);
+  s.nativeMirrors = false;
+  return s;
+};
+
+test('removing a non-current item keeps authority but marks order diverged', () => {
+  const s = removeAt(makeQueueState(), 2);
+  eq(s.nativeQueue, true, 'MusicKit still holds the item — authority must not be dropped');
+  eq(s.nativeMirrors, false);
+  eq([...s.removedIds], ['3'], 'id remembered so it can be skipped on arrival');
+});
+test('removing before the current item shifts _qi', () => {
+  const s = removeAt(makeQueueState(), 0);
+  eq(s.qi, 0);
+});
+test('removing the current item rebuilds, which takes authority back', () => {
+  const s = removeAt(makeQueueState(), 1);
+  eq(s.rebuiltAt, 1);
+});
+test('removing the last remaining item drops authority together with a stop', () => {
+  const s = makeQueueState();
+  s.q = [{ id: '1' }]; s.qi = 0;
+  removeAt(s, 0);
+  eq(s.nativeQueue, false);
+  eq(s.stopped, true, 'authority may only be cleared alongside a stop');
+});
+test('clearing the queue drops authority together with a stop', () => {
+  const s = makeQueueState();
+  s.q = []; s.qi = -1; s.nativeQueue = false; s.nativeMirrors = false; s.stopped = true;
+  eq([s.nativeQueue, s.stopped], [false, true]);
+});
+test('reorder is view-only: authority kept, mirroring broken', () => {
+  const s = makeQueueState();
+  s.nativeMirrors = false; // vibezQueueMove leaves _nativeQueue alone
+  eq([s.nativeQueue, s.nativeMirrors], [true, false]);
+});
+
+console.log('\nSkip-on-arrival for removed items');
+const onNowPlayingChange = (s, playingId) => {
+  const out = { qi: s.qi, skipped: false, stopped: false, clearedNative: false };
+  if (!s.nativeQueue) return out;
+  if (!playingId) return out;
+  const idx = s.q.findIndex(i => i.id === playingId);
+  if (idx >= 0) { out.qi = idx; return out; }
+  if (s.removedIds.has(playingId)) {
+    if (_nativeHasNext(s.m)) { out.skipped = true; return out; }
+    out.clearedNative = true; out.stopped = true;
+  }
+  return out;
+};
+
+test('playing an item still in _q resettles _qi', () => {
+  const s = { ...makeQueueState(), m: { repeatMode: 0, queue: { position: 2, length: 3 } } };
+  eq(onNowPlayingChange(s, '3').qi, 2);
+});
+test('a removed item that starts is skipped when MusicKit has a next', () => {
+  const s = { ...makeQueueState(), removedIds: new Set(['9']),
+              m: { repeatMode: 0, queue: { position: 1, length: 3 } } };
+  eq(onNowPlayingChange(s, '9').skipped, true);
+});
+test('a removed last item ends the queue rather than playing out', () => {
+  const s = { ...makeQueueState(), removedIds: new Set(['9']),
+              m: { repeatMode: 0, queue: { position: 2, length: 3 } } };
+  const r = onNowPlayingChange(s, '9');
+  eq([r.skipped, r.stopped, r.clearedNative], [false, true, true]);
+});
+test('an unknown item that was never removed is left alone', () => {
+  const s = { ...makeQueueState(), m: { repeatMode: 0, queue: { position: 1, length: 3 } } };
+  const r = onNowPlayingChange(s, 'surprise');
+  eq([r.skipped, r.stopped], [false, false]);
+});
+test('nothing happens in one-item mode', () => {
+  const s = { ...makeQueueState(), nativeQueue: false, removedIds: new Set(['9']),
+              m: { repeatMode: 0, queue: { position: 0, length: 3 } } };
+  eq(onNowPlayingChange(s, '9').skipped, false);
+});
+
+console.log('\nnext/prev delegate while MusicKit owns the queue');
+const onNext = (s) => (s.nativeQueue && _nativeHasNext(s.m))
+  ? { skipToNext: true, playAt: null }
+  : { skipToNext: false, playAt: s.qi < s.q.length - 1 ? s.qi + 1 : null };
+const onPrev = (s) => (s.nativeQueue && (s.m.queue?.position ?? 0) > 0)
+  ? { skipToPrev: true, playAt: null }
+  : { skipToPrev: false, playAt: s.qi > 0 ? s.qi - 1 : 0 };
+
+test('next delegates to skipToNextItem in native mode', () => {
+  const s = { ...makeQueueState(), m: { repeatMode: 0, queue: { position: 1, length: 3 } } };
+  eq(onNext(s).skipToNext, true);
+});
+test('next falls back to _playAt once the native queue is exhausted', () => {
+  const s = { ...makeQueueState(), m: { repeatMode: 0, queue: { position: 2, length: 3 } } };
+  eq(onNext(s), { skipToNext: false, playAt: 2 });
+});
+test('prev delegates to skipToPreviousItem when MusicKit is past the start', () => {
+  const s = { ...makeQueueState(), m: { repeatMode: 0, queue: { position: 1, length: 3 } } };
+  eq(onPrev(s).skipToPrev, true);
+});
+test('prev at the native queue start uses _playAt', () => {
+  const s = { ...makeQueueState(), m: { repeatMode: 0, queue: { position: 0, length: 3 } } };
+  eq(onPrev(s), { skipToPrev: false, playAt: 0 });
+});
+
+console.log('\nAppend against a live native queue');
+// playLater failure must not clear _nativeQueue: MusicKit still owns what it
+// has, and the completed handler picks the tail up once it runs out.
+const onAppend = (s, items, playLaterThrows) => {
+  s.q = s.q.concat(items);
+  if (s.qi < 0) { s.rebuiltAt = 0; return s; }
+  if (s.nativeQueue && _allCatalog(items)) {
+    if (playLaterThrows) return s; // flag deliberately left set
+    s.playLater = items.map(i => i.id);
+  }
+  return s;
+};
+
+test('appending catalog items to a native queue uses playLater', () => {
+  const s = onAppend(makeQueueState(), [{ id: '4' }], false);
+  eq(s.playLater, ['4']);
+  eq(s.nativeQueue, true);
+});
+test('playLater failure keeps authority so the boundary does not double up', () => {
+  const s = onAppend(makeQueueState(), [{ id: '4' }], true);
+  eq(s.nativeQueue, true, 'clearing here would add a second advancer');
+  eq(s.q.length, 4, 'the item is still in _q for the completed handler to reach');
+});
+test('appending a library item to a native queue does not use playLater', () => {
+  const s = onAppend(makeQueueState(), [{ id: 'i.x' }], false);
+  eq(s.playLater, undefined);
+});
+test('appending while nothing plays starts playback', () => {
+  const s = makeQueueState();
+  s.qi = -1;
+  onAppend(s, [{ id: '4' }], false);
+  eq(s.rebuiltAt, 0);
+});
+
 
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/internal/player/web/musickit_test.mjs
+++ b/internal/player/web/musickit_test.mjs
@@ -417,11 +417,9 @@ test('lossless/unsupported values are rejected with web max', () => {
 });
 
 // ─── Native queue mode (#96) ──────────────────────────────────────────────────
-// _allCatalog and _nativeHasNext are copied verbatim from musickit.html.
+// _nativeHasNext is copied verbatim from musickit.html.
 // The rest simulate the decision each call site makes, in the same style as the
 // _busy/playbackStateDidChange tests above.
-
-const _allCatalog = (items) => items.every(item => !item.id.startsWith('i.'));
 
 function _nativeHasNext(m) {
   if (m.repeatMode === 1 || m.repeatMode === 2) return true; // repeats itself
@@ -429,14 +427,6 @@ function _nativeHasNext(m) {
   if (!q || typeof q.length !== 'number' || typeof q.position !== 'number') return false;
   return q.position < q.length - 1;
 }
-
-console.log('\n_allCatalog()');
-test('all catalog ids → true', () =>
-  eq(_allCatalog([{ id: '1' }, { id: '2' }]), true));
-test('any library id → false', () =>
-  eq(_allCatalog([{ id: '1' }, { id: 'i.abc' }]), false));
-test('all library ids → false', () =>
-  eq(_allCatalog([{ id: 'i.a' }, { id: 'i.b' }]), false));
 
 console.log('\n_nativeHasNext()');
 test('repeat-one always has a next', () =>
@@ -457,13 +447,18 @@ test('single-item native queue with repeat off → false', () =>
   eq(_nativeHasNext({ repeatMode: 0, queue: { position: 0, length: 1 } }), false));
 
 console.log('\nNative mode entry condition');
-const wantsNative = (items) => items.length > 1 && _allCatalog(items);
+// Queue length is the whole condition now. The items: descriptor carries
+// catalog and library objects alike, so item kind no longer decides the mode
+// (#96: a mixed queue was the fastest arm measured, not a disqualifying one).
+const wantsNative = (items) => items.length > 1;
 test('multi-item all-catalog → native', () =>
   eq(wantsNative([{ id: '1' }, { id: '2' }]), true));
 test('single catalog item → one-item mode', () =>
   eq(wantsNative([{ id: '1' }]), false));
-test('multi-item with a library id → one-item mode', () =>
-  eq(wantsNative([{ id: '1' }, { id: 'i.x' }]), false));
+test('multi-item mixed catalog and library → native', () =>
+  eq(wantsNative([{ id: '1' }, { id: 'i.x' }]), true));
+test('multi-item library only → native', () =>
+  eq(wantsNative([{ id: 'i.a' }, { id: 'i.b' }]), true));
 test('empty → one-item mode', () => eq(wantsNative([]), false));
 
 console.log('\ncompleted handler: who advances');
@@ -705,7 +700,7 @@ console.log('\nAppend against a live native queue');
 const onAppend = (s, items, playLaterThrows) => {
   s.q = s.q.concat(items);
   if (s.qi < 0) { s.rebuiltAt = 0; return s; }
-  if (s.nativeQueue && _allCatalog(items)) {
+  if (s.nativeQueue) {
     if (playLaterThrows) return s; // flag deliberately left set
     s.playLater = items.map(i => i.id);
   }
@@ -722,15 +717,82 @@ test('playLater failure keeps authority so the boundary does not double up', () 
   eq(s.nativeQueue, true, 'clearing here would add a second advancer');
   eq(s.q.length, 4, 'the item is still in _q for the completed handler to reach');
 });
-test('appending a library item to a native queue does not use playLater', () => {
+test('appending a library item to a native queue also uses playLater', () => {
   const s = onAppend(makeQueueState(), [{ id: 'i.x' }], false);
-  eq(s.playLater, undefined);
+  eq(s.playLater, ['i.x'], 'items: can express a library append');
 });
 test('appending while nothing plays starts playback', () => {
   const s = makeQueueState();
   s.qi = -1;
   onAppend(s, [{ id: '4' }], false);
   eq(s.rebuiltAt, 0);
+});
+
+
+console.log('\nPre-resolved library copies');
+// Mirrors _warmLibItems' id selection: every library copy the current queue
+// could need, minus the ones already held, deduped.
+const wantedLibIds = (q, libMap, libItems) =>
+  [...new Set(q.map(item => libMap[item.id]).filter(id => id && !libItems[id]))];
+
+test('collects the library copy of each catalog item', () =>
+  eq(wantedLibIds([{ id: '1' }, { id: '2' }], { 1: 'i.a', 2: 'i.b' }, {}), ['i.a', 'i.b']));
+test('items with no library copy contribute nothing', () =>
+  eq(wantedLibIds([{ id: '1' }, { id: '2' }], { 1: 'i.a' }, {}), ['i.a']));
+test('already-warmed copies are not refetched', () =>
+  eq(wantedLibIds([{ id: '1' }, { id: '2' }], { 1: 'i.a', 2: 'i.b' }, { 'i.a': {} }), ['i.b']));
+test('the same copy behind two catalog items is fetched once', () =>
+  eq(wantedLibIds([{ id: '1' }, { id: '2' }], { 1: 'i.a', 2: 'i.a' }, {}), ['i.a']));
+test('nothing to fetch → no request', () =>
+  eq(wantedLibIds([{ id: '1' }], {}, {}), []));
+
+console.log('\nLibrary fallback prefers a warmed copy');
+// Mirrors _libraryFallback: a warmed copy is a local swap, an unwarmed one
+// costs a round trip inside the audible gap, no copy at all skips the track.
+const fallbackPlan = (item, libMap, libItems) => {
+  if (item.id.startsWith('i.')) return { action: 'skip', why: 'already library' };
+  const libId = libMap[item.id];
+  if (!libId) return { action: 'skip', why: 'no library copy' };
+  return { action: 'swap', via: libItems[libId] ? 'warmed' : 'fetch', libId };
+};
+
+test('warmed copy swaps without a fetch', () =>
+  eq(fallbackPlan({ id: '1' }, { 1: 'i.a' }, { 'i.a': {} }), { action: 'swap', via: 'warmed', libId: 'i.a' }));
+test('unwarmed copy still falls back, by fetching', () =>
+  eq(fallbackPlan({ id: '1' }, { 1: 'i.a' }, {}), { action: 'swap', via: 'fetch', libId: 'i.a' }));
+test('no library copy → skip', () =>
+  eq(fallbackPlan({ id: '1' }, {}, {}).action, 'skip'));
+test('a failing library item has nothing left to try', () =>
+  eq(fallbackPlan({ id: 'i.a' }, {}, {}).why, 'already library'));
+
+console.log('\nNative mode has no per-item catch');
+// Mirrors the mediaPlaybackError listener. MusicKit advances by itself in
+// native mode, so a failing item never reaches _doPlayAt's try/catch: the
+// index goes back to one-item mode, which can run the fallback.
+const onPlaybackError = (s) => {
+  if (!s.nativeQueue) return s;
+  s.recoverAt     = s.qi >= 0 ? s.qi : 0;
+  s.nativeQueue   = false;
+  s.nativeMirrors = false;
+  s.stopped       = true;
+  return s;
+};
+
+test('recovers at the item that failed', () => {
+  const s = onPlaybackError({ ...makeQueueState(), qi: 2 });
+  eq(s.recoverAt, 2);
+});
+test('recovery drops authority, and stops to take it back', () => {
+  const s = onPlaybackError({ ...makeQueueState(), qi: 1 });
+  eq([s.nativeQueue, s.nativeMirrors, s.stopped], [false, false, true]);
+});
+test('nothing playing recovers at the head', () => {
+  const s = onPlaybackError({ ...makeQueueState(), qi: -1 });
+  eq(s.recoverAt, 0);
+});
+test('one-item mode is left alone: _doPlayAt already caught it', () => {
+  const s = onPlaybackError({ ...makeQueueState(), nativeQueue: false, qi: 1 });
+  eq(s.recoverAt, undefined, 'recovering twice would restart the track');
 });
 
 


### PR DESCRIPTION
Phase 1 of the plan in #96.

vibez rebuilt MusicKit's queue with `setQueue({songs:[one id]})` at every track boundary, so each transition paid a round trip that landed exactly where the gap is audible. This builds the queue once with `setQueue({items:[...]})` and lets MusicKit advance it. `items:` takes resolved descriptors of either kind, so a library song no longer forces the whole queue back to per-track rebuilds.

### What changed

- `musickit.html` builds the queue up front and hands advancement to MusicKit. `next`/`prev` delegate to `skipToNextItem`/`skipToPreviousItem` while it holds authority, and fall back to `_playAt` once the native queue is exhausted.
- Insertions go through `playNext`/`playLater`, which call `deferPlayback()` internally. That is the sanctioned way to extend a live queue without restarting playback.
- Library copies are warmed into `_libItems` when the queue is built and when `playLater` extends it, so the `CONTENT_UNAVAILABLE` fallback can swap from memory rather than paying a round trip inside the audible gap. The fetch is not awaited, batches at 100 ids, and its failure is not an error path: `_libraryFallback` still fetches on demand.
- Native mode has no per-item call site to throw at, so an unavailable item mid-queue would strand the queue where one-item mode would have skipped past it. A `mediaPlaybackError` listener drops authority, stops to take it back, and hands the index to `_playAt`. That one is written from the event surface rather than measured: the probes never provoked a failure inside a live native queue. It costs nothing if the event never fires.

### Measurements

Two items over the same track pair, order rotated each pass so queue length and position cannot pose as a difference between designs. MusicKit 3.2526.0-prerelease.x, media-element `currentTime`, 50 ms poll.

| arm | n | median | range | single src |
|---|---|---|---|---|
| rebuild (one item per track) | 11 | 700.0 ms | 451-1000 | 0/11 |
| `items:` catalog + library | 11 | 23.7 ms | 15-37 | 11/11 |
| `items:` 2 catalog | 6 | 350.0 ms | 11-450 | 1/6 |

The invariant that held in every sample is the media-element `src` count rather than any of these medians: one src is always under 40 ms, two are always over 300.

### What is not measured yet

I said on #96 that Phase 1 should fix the segment length it ships and re-measure that shape. This branch does not fix one. It sends the whole queue in a single `setQueue({items:[...]})` (`musickit.html:402`), so the open question is a length sweep rather than a single re-run.

That matters, because length moved the figure on its own in the earlier data: `songs:` gave 26.5 ms at two items and 350.2 ms at three. An all-catalog `items:` queue was also the worst native arm, and I still cannot explain why a library item in second position is the consistent one.

So none of the numbers above should be quoted as this player's behaviour yet. I can run the sweep, the probe is on `proto/96-gapless-probe` and I have a session. I am flagging it here rather than holding the code back, because the sweep may well argue for segmenting the queue, and that is a design question worth settling in review rather than after it.

### Tests

`musickit_test.mjs` covers the native-queue invariants: authority handover, `next`/`prev` delegation and their fallbacks, append against a live native queue, the pre-resolved library copies, and the `mediaPlaybackError` recovery path. 104 assertions, run by pre-commit.

Worth a reviewer's attention: that harness copies logic out of `musickit.html` by hand rather than importing it, so it can stay green while the HTML drifts. `isLibraryID`, `isCatalogID` and `partitionIDs` exist only in the test, inlined from `vibezSetQueue`/`vibezAppendQueue`.

`go test ./...` and `go vet ./...` are clean on linux/amd64.
